### PR TITLE
remove CBLDocument from database document cache when purged

### DIFF
--- a/Source/API/APITests.m
+++ b/Source/API/APITests.m
@@ -249,6 +249,19 @@ TestCase(API_DeleteDocument) {
 }
 
 
+TestCase(API_PurgeDocument) {
+    CBLDatabase* db = createEmptyDB();
+    NSDictionary* properties = @{@"testName": @"testPurgeDocument"};
+    CBLDocument* doc = createDocumentWithProperties(db, properties);
+    CAssert(doc);
+    
+    NSError* error;
+    CAssert([doc purgeDocument: &error]);
+    
+    CBLDocument* redoc = [db cachedDocumentWithID:doc.documentID];
+    CAssert(!redoc);
+}
+
 TestCase(API_AllDocuments) {
     CBLDatabase* db = createEmptyDB();
     static const NSUInteger kNDocs = 5;
@@ -613,6 +626,7 @@ TestCase(API) {
     RequireTestCase(API_SaveMultipleUnsavedDocuments);
     RequireTestCase(API_DeleteMultipleDocuments);
     RequireTestCase(API_DeleteDocument);
+    RequireTestCase(API_PurgeDocument);
     RequireTestCase(API_AllDocuments);
     RequireTestCase(API_RowsIfChanged);
     RequireTestCase(API_History);

--- a/Source/API/CBLDatabase.m
+++ b/Source/API/CBLDatabase.m
@@ -187,6 +187,9 @@ static id<CBLFilterCompiler> sFilterCompiler;
     [_docCache forgetAllResources];
 }
 
+- (void) removeDocumentFromCache: (CBLDocument*)document {
+    [_docCache forgetResource: document];
+}
 
 - (CBLQuery*) queryAllDocuments {
     return [[CBLQuery alloc] initWithDatabase: self view: nil];

--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -81,12 +81,15 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
 
 
 - (BOOL) purgeDocument: (NSError**)outError {
-    CBLStatus status = [_database.tddb purgeRevisions: @{self.documentID : @"*"} result: nil];
+    CBLStatus status = [_database.tddb purgeRevisions: @{self.documentID : [NSArray arrayWithObject:@"*"]} result: nil];
     if (CBLStatusIsError(status)) {
         if (outError) {
             *outError = CBLStatusToNSError(status, nil);
             return NO;
         }
+    }
+    else {
+        [self.database removeDocumentFromCache: self];
     }
     return YES;
 }

--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -30,6 +30,7 @@
                     CBL_Database: (CBL_Database*)tddb               __attribute__((nonnull));
 @property (readonly, nonatomic) CBL_Database* tddb;
 @property (readonly, nonatomic) NSMutableSet* unsavedModelsMutable;
+- (void) removeDocumentFromCache: (CBLDocument*)document;
 @end
 
 


### PR DESCRIPTION
This is the fix to remove a purged document from the database cache that I submitted to the TouchDB-iOS project, including the fixes that you suggested in the old pull request.
