### PR TITLE
Stop attachment bodyURL crashing

### DIFF
--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -231,8 +231,8 @@
         *outStatus = kCBLStatusOK;
         if (outType)
             *outType = [r stringForColumnIndex: 1];
-        
-        *outEncoding = [r intForColumnIndex: 2];
+        if (outEncoding)
+            *outEncoding = [r intForColumnIndex: 2];
     } @finally {
         [r close];
     }


### PR DESCRIPTION
Calling bodyURL resulted in EXE BAD ACCESS error due to NULL being assign a nil
