### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,19 @@ For full details see the [wiki page][7]. The basic steps are:
 Please refer to the files [BUILDING.txt][14] and [SETUP.txt][15] in the `GNUstep` directory.
 
 [1]: http://couchdb.apache.org
-[2]: https://github.com/couchbaselabs/CouchbaseLite-iOS/wiki
+[2]: https://github.com/couchbase/CouchbaseLite-iOS/wiki
 [3]: http://couchbase.com
 [5]: https://github.com/couchbaselabs/fmdb
 [6]: https://bitbucket.org/snej/myutilities/overview
-[7]: https://github.com/couchbaselabs/CouchbaseLite-iOS/wiki/Building-CouchbaseLite
+[7]: https://github.com/couchbase/CouchbaseLite-iOS/wiki/Building-CouchbaseLite
 [8]: https://github.com/ccgus/
 [9]: https://github.com/robbiehanson/CocoaHTTPServer
 [10]: http://code.google.com/p/google-toolbox-for-mac/
-[11]: https://github.com/couchbaselabs/CouchbaseLite-Android
+[11]: https://github.com/couchbase/CouchbaseLite-Android
 [12]: http://www.gnustep.org/
 [13]: http://wiki.gnustep.org/index.php/Platform_compatibility
-[14]: https://github.com/couchbaselabs/CouchbaseLite-iOS/blob/master/GNUstep/BUILDING.txt
-[15]: https://github.com/couchbaselabs/CouchbaseLite-iOS/blob/master/GNUstep/SETUP.txt
+[14]: https://github.com/couchbase/CouchbaseLite-iOS/blob/master/GNUstep/BUILDING.txt
+[15]: https://github.com/couchbase/CouchbaseLite-iOS/blob/master/GNUstep/SETUP.txt
 [17]: https://groups.google.com/forum/?fromgroups#!forum/mobile-couchbase
 [18]: https://github.com/couchbaselabs/iOS-Couchbase-Demo
 [19]: http://files.couchbase.com/developer-previews/mobile/ios/touchdb/


### PR DESCRIPTION
Some links result in a 404 error page. The reason seem to be a reference to "couchbaselabs" in URL. A change to "couchbase" in URL seem to fix the error.
