### PR TITLE
Fixed Couchbase for Android URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For full details see the [wiki page][7]. The basic steps are:
 [8]: https://github.com/ccgus/
 [9]: https://github.com/robbiehanson/CocoaHTTPServer
 [10]: http://code.google.com/p/google-toolbox-for-mac/
-[11]: https://github.com/couchbase/CouchbaseLite-Android
+[11]: https://github.com/couchbase/Android-Couchbase
 [12]: http://www.gnustep.org/
 [13]: http://wiki.gnustep.org/index.php/Platform_compatibility
 [14]: https://github.com/couchbase/CouchbaseLite-iOS/blob/master/GNUstep/BUILDING.txt


### PR DESCRIPTION
The link to the Android version was broken.
