### PR TITLE
wrong lastDbError causes [CBLView removeIndex] fails

### DIFF
--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -463,7 +463,7 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
 
 - (CBLStatus) lastDbError {
     CBLStatus status = self.lastDbStatus;
-    return (status == kCBLStatusOK) ? kCBLStatusDBError : status;
+    return (status != kCBLStatusOK) ? kCBLStatusDBError : status;
 }
 
 


### PR DESCRIPTION
In [CBLView removeIndex], _db.lastDbError is returned to the transaction. 

<pre>
    [_db _inTransaction: ^CBLStatus {
        if ([_db.fmdb executeUpdate: @"DELETE FROM maps WHERE view_id=?",
                                     @(_viewID)]) {
            [_db.fmdb executeUpdate: @"UPDATE views SET lastsequence=0 WHERE view_id=?",
                                     @(_viewID)];
        }
        return _db.lastDbError;
    }];
</pre>


While _db.lastDbError does not return correct status, the transaction always fails.
