### PR TITLE
Added support to return HTTP headers

### DIFF
--- a/Source/API/CBLManager.h
+++ b/Source/API/CBLManager.h
@@ -125,6 +125,7 @@ typedef struct CBLManagerOptions {
     other criteria to enable logging. */
 + (void) enableLogging: (NSString*)type;
 
+@property (readonly, nonatomic) NSMutableDictionary* customHTTPHeaders;
 
 #ifdef CBL_DEPRECATED
 - (CBLDatabase*) createDatabaseNamed: (NSString*)name

--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -42,6 +42,11 @@
 
 static const CBLManagerOptions kCBLManagerDefaultOptions;
 
+@interface CBLManager ()
+
+@property (nonatomic) NSMutableDictionary* customHTTPHeaders;
+
+@end
 
 @implementation CBLManager
 {
@@ -59,7 +64,7 @@ static const CBLManagerOptions kCBLManagerDefaultOptions;
 
 
 @synthesize dispatchQueue=_dispatchQueue;
-
+@synthesize customHTTPHeaders = _customHTTPHeaders;
 
 // http://wiki.apache.org/couchdb/HTTP_database_API#Naming_and_Addressing
 #define kLegalChars @"abcdefghijklmnopqrstuvwxyz0123456789_$()+-/"
@@ -110,6 +115,9 @@ static CBLManager* sInstance;
                              error: &error];
     if (!self)
         Warn(@"Failed to create CBLManager: %@", error);
+    
+    _customHTTPHeaders = [NSMutableDictionary dictionary];
+    
     return self;
 }
 
@@ -194,9 +202,13 @@ static CBLManager* sInstance;
 
 
 - (id) copyWithZone: (NSZone*)zone {
-    return [[[self class] alloc] initWithDirectory: self.directory
+    CBLManager *managerCopy = [[[self class] alloc] initWithDirectory: self.directory
                                            options: &_options
-                                            shared: _shared];
+                                                               shared: _shared];
+    
+    managerCopy.customHTTPHeaders = [self.customHTTPHeaders copy];
+    
+    return managerCopy;
 }
 
 - (instancetype) copy {

--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -640,6 +640,9 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
                                                          error: NULL]);
 }
 
+- (CBLStatus)do_OPTIONS: (CBLDatabase *)db docID:(NSString *)docID {
+    return kCBLStatusOK;
+}
 
 - (CBLStatus) do_GET: (CBLDatabase*)db docID: (NSString*)docID {
     // http://wiki.apache.org/couchdb/HTTP_Document_API#GET

--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -584,6 +584,11 @@ static NSArray* splitPath( NSURL* url ) {
             _response[@"Cache-Control"] = @"must-revalidate";
     }
 
+    for (NSString *key in [_server.customHTTPHeaders allKeys])
+    {
+        _response[key] = _server.customHTTPHeaders[key];
+    }
+
     if (_onResponseReady)
         _onResponseReady(_response);
 }

--- a/Source/CBL_Server.h
+++ b/Source/CBL_Server.h
@@ -23,6 +23,7 @@
 - (instancetype) initWithManager: (CBLManager*)newManager;
 
 @property (readonly) NSString* directory;
+@property (readonly) NSDictionary *customHTTPHeaders;
 
 - (void) queue: (void(^)())block;
 - (void) tellDatabaseManager: (void (^)(CBLManager*))block;

--- a/Source/CBL_Server.m
+++ b/Source/CBL_Server.m
@@ -26,6 +26,7 @@
 
 @implementation CBL_Server
 
+@dynamic customHTTPHeaders;
 
 #if DEBUG
 + (instancetype) createEmptyAtPath: (NSString*)path {
@@ -43,6 +44,9 @@
 }
 #endif
 
+- (NSDictionary*) customHTTPHeaders {
+    return _manager.customHTTPHeaders;
+}
 
 - (instancetype) initWithManager: (CBLManager*)newManager {
     self = [super init];


### PR DESCRIPTION
For example, to support CORS.

```
    [[CBLManager sharedInstance].customHTTPHeaders setObject:@"*" forKey:@"Access-Control-Allow-Origin"];
```

Thanks! :)
