### PR TITLE
Adds 'properties' as a @property in CBLModel_Internal

### DIFF
--- a/Source/API/CBLModel.h
+++ b/Source/API/CBLModel.h
@@ -65,7 +65,7 @@
 
 /** The document's current properties (including unsaved changes) in externalized JSON format.
     This is what will be written to the CBLDocument when the model is saved. */
-- (NSDictionary*) propertiesToSave;
+@property (readonly, copy) NSDictionary* propertiesToSave;
 
 /** Removes any changes made to properties and attachments since the last save. */
 - (void) revertChanges;

--- a/Source/API/CBLModel.m
+++ b/Source/API/CBLModel.m
@@ -358,6 +358,9 @@
 
 #pragma mark - PROPERTIES:
 
+- (NSMutableDictionary*) properties {
+    return _properties;
+}
 
 - (NSDictionary*) currentProperties {
     NSMutableDictionary* properties = [_document.properties mutableCopy];
@@ -365,7 +368,7 @@
         properties = [[NSMutableDictionary alloc] init];
     for (NSString* key in _changedNames)
         [properties setValue: _properties[key] forKey: key];
-    return properties;
+    return [properties copy];
 }
 
 
@@ -396,7 +399,6 @@
     return value;
 }
 
-
 - (NSDictionary*) propertiesToSave {
     NSMutableDictionary* properties = [_document.properties mutableCopy];
     if (!properties)
@@ -413,6 +415,7 @@
 - (void) cacheValue: (id)value ofProperty: (NSString*)property changed: (BOOL)changed {
     if (!_properties)
         _properties = [[NSMutableDictionary alloc] init];
+    
     [_properties setValue: value forKey: property];
     if (changed) {
         if (!_changedNames)

--- a/Source/API/CBLModel_Internal.h
+++ b/Source/API/CBLModel_Internal.h
@@ -17,13 +17,19 @@
     bool _needsSave :1;
     bool _saving    :1;
 
-    NSMutableDictionary* _properties;   // Cached property values, including changed values
+    NSMutableDictionary *_properties;
     NSMutableSet* _changedNames;        // Names of properties that have been changed but not saved
     NSMutableDictionary* _changedAttachments;
 }
 @property (readwrite, retain) CBLDocument* document;
 @property (readwrite) bool needsSave;
-@property (readonly) NSDictionary* currentProperties;
+
+/** Cached property values, including changed values */
+@property (readonly, nonatomic) NSMutableDictionary *properties;
+
+/** Copy of the currently cached property values, including changed values */
+@property (readonly) NSDictionary *currentProperties;
+
 - (void) cacheValue: (id)value ofProperty: (NSString*)property changed: (BOOL)changed;
 - (void) willSave: (NSSet*)changedProperties;   // overridable
 - (CBLModel*) modelWithDocID: (NSString*)docID


### PR DESCRIPTION
This set of changes adds a readonly @property declaration for 'properties' in the CBLModel_Internal header and implements it in CBLModel.m. 

The concrete use case I have is a CBLModel subclass which can contain nested JSON encodable objects I call 'embedded model objects' (which themselves are similar to a CBLModel uniquely identified, MYDynamicObject subclasses). The properties dictionary is used to cache the non-externalized embedded model object (this kind of CBLModel subclass is also one of the reasons I requested earlier for the property type introspection functions to be made public APIs, they were also required for supporting this kind of CBLModel subclass). 

The embedded object support is not included in this change set, only used to describe a use for exposing the properties dictionary to CBLModel subclasses. Another option might be exposing instead a -getCachedValueOfProperty: in CBLModel to return a value directly from the _properties dictionary.

Also, I happened to notice off-chance that -currentProperties was returning a mutable array when it is intended as an immutable copy. This is fixed in this changeset too. The API documentation entry I added for currentProperties is probably incorrect -- I did not know how to correctly describe its  is probably not documented correctly here. What would be a better way to describe it?
