### PR TITLE
Fixes a crash in CBLMultipartDocumentReader.m caused by the stream outliving the CBLMultipartDocumentReader that is its delegate

### DIFF
--- a/Source/CBLMultipartDocumentReader.m
+++ b/Source/CBLMultipartDocumentReader.m
@@ -172,7 +172,15 @@
 {
     if ([self setHeaders: headers]) {
         LogTo(SyncVerbose, @"%@: Reading from input stream...", self);
-          // balanced by release in -finishAsync:
+        // balanced by release in -finishAsync:
+        
+        __block id slf = self;
+        _completionBlock = ^(CBLMultipartDocumentReader *reader)
+        {
+            completionBlock(reader);
+            slf = nil;
+        };
+        
         _completionBlock = [completionBlock copy];
         [stream open];
         stream.delegate = self;


### PR DESCRIPTION
Fixes a crash in CBLMultipartDocumentReader.m caused by the stream outliving the CBLMultipartDocumentReader that is its delegate. Solved by adding a strong reference to the reader in its completion handler and breaking the retain loop in the end of the completion handler block.
