### PR TITLE
Fixed omission of comma in string array

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -674,7 +674,7 @@ TestCase(CBLManager) {
     NSMutableString* longName = [@"long" mutableCopy];
     while (longName.length < 240)
         [longName appendString: @"!"];
-    for (NSString* name in @[@"", @"0", @"123foo", @"Foo", @"/etc/passwd", @"foo " @"_foo", longName])
+    for (NSString* name in @[@"", @"0", @"123foo", @"Foo", @"/etc/passwd", @"foo ", @"_foo", longName])
         CAssert(![CBLManager isValidDatabaseName: name], @"Db name '%@' should not be valid", name);
 
     CBLManager* dbm = [CBLManager createEmptyAtTemporaryPath: @"CBLManagerTest"];


### PR DESCRIPTION
Fixing compile error building target "CBL iOS Library" (Xcode 5.1):

/Users/alex/dev/couchbase-lite-ios/Source/API/CBLManager.m:677:76: error: concatenated NSString literal for an NSArray expression - possibly missing a comma [-Werror,-Wobjc-string-concatenation]
    for (NSString\* name in @[@"", @"0", @"123foo", @"Foo", @"/etc/passwd", @"foo " @"_foo", longName])
