### PR TITLE
Amend the limit property for CBLQuery, default value is -1

### DIFF
--- a/Source/API/CBLQuery.h
+++ b/Source/API/CBLQuery.h
@@ -34,7 +34,7 @@ typedef enum {
 /** The database that contains this view. */
 @property (readonly) CBLDatabase* database;
 
-/** The maximum number of rows to return. Default value is 0, meaning 'unlimited'. */
+/** The maximum number of rows to return. Default value is -1, meaning 'unlimited'. */
 @property NSUInteger limit;
 
 /** The number of initial rows to skip. Default value is 0.


### PR DESCRIPTION
The limit default value is not 0, and setting limit to zero returns no results. I updated the comment to reflect the true default value.
