### PR TITLE
Fixes #337: assertion failure in -[CBLChangeTracker endParsingData]()

### DIFF
--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -269,7 +269,11 @@ typedef void (^CBLChangeMatcherClient)(id sequence, NSString* docID, NSArray* re
 }
 
 - (NSInteger) endParsingData {
-    Assert(_parser);
+    if (!_parser) {
+        Warn(@"Connection closed before first byte");
+        return - 1;
+    }
+    
     BOOL ok = [_parser finish];
     _parser = nil;
     if (!ok) {


### PR DESCRIPTION
Instead of asserting that there is a parser, just check if one was set. Connection can be closed before first byte is written, and therefore be no parser. (We don't want to crash here). Fixes issue #337
