### PR TITLE
fix 349

### DIFF
--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -280,6 +280,9 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
 - (CBLSavedRevision*) update: (BOOL(^)(CBLUnsavedRevision*))block error: (NSError**)outError {
     NSError* error;
     do {
+        // if there is a conflict error, get the latest revision from db instead of cache
+        if (error)
+            [self forgetCurrentRevision];
         CBLUnsavedRevision* newRev = self.newRevision;
         if (!block(newRev)) {
             error = nil;


### PR DESCRIPTION
- if there is a conflict while updating, get latest revision from db instead of cache
