### PR TITLE
Post DatabaseChange notifications on main queue

### DIFF
--- a/Source/API/CBLDatabase.m
+++ b/Source/API/CBLDatabase.m
@@ -111,14 +111,17 @@ static id<CBLFilterCompiler> sFilterCompiler;
     // Post the public kCBLDatabaseChangeNotification:
     NSDictionary* userInfo = @{@"changes": changes,
                                @"external": @(external)};
-    NSNotification* n = [NSNotification notificationWithName: kCBLDatabaseChangeNotification
-                                                      object: self
-                                                    userInfo: userInfo];
-    NSNotificationQueue* queue = [NSNotificationQueue defaultQueue];
-    [queue enqueueNotification: n
-                  postingStyle: NSPostASAP 
-                  coalesceMask: NSNotificationNoCoalescing
-                      forModes: @[NSRunLoopCommonModes]];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        NSNotification* n = [NSNotification notificationWithName: kCBLDatabaseChangeNotification
+                                                          object: self
+                                                        userInfo: userInfo];
+        
+        NSNotificationQueue* queue = [NSNotificationQueue defaultQueue];
+        [queue enqueueNotification: n
+                      postingStyle: NSPostASAP
+                      coalesceMask: NSNotificationNoCoalescing
+                          forModes: @[NSRunLoopCommonModes]];
+    });
 }
 
 


### PR DESCRIPTION
I noticed that database change notifications weren't being received by CBLQuery when the change came remotely (via replication).  This only started happening when I started using a dispatchQueue.

I noticed that the DatabaseChangeNotification wasn't happening in the main thread, so I wrapped it in a   dispatch_sync(dispatch_get_main_queue(), ^{ }

This fixed the issue for me.
