### PR TITLE
CGI escape _id fields properly

### DIFF
--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -134,7 +134,7 @@ NSString* CBLEscapeID( NSString* docOrRevID ) {
 #else
     CFStringRef escaped = CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                   (CFStringRef)docOrRevID,
-                                                                  NULL, (CFStringRef)@"?&/",
+                                                                  NULL, NULL,
                                                                   kCFStringEncodingUTF8);
     #ifdef __OBJC_GC__
     return NSMakeCollectable(escaped);


### PR DESCRIPTION
We ran into problems with `+` in our `_id`s and so I jumped into the source and noticed that the only characters you were escaping were `?&/` but many more characters can appear in `_id`s that need escaping.  I thought this was better to just do the full CGI escape (which can never hurt) by escaping according to [RFC3986](http://tools.ietf.org/html/rfc3986#section-2.3)

Honestly, I haven't read your CONTRIBUTING guide, I'm not an ObjC coder, I didn't look at tests, I know for sure that the `GNUSTEP` code isn't improved (although that was already missing `?`) and there's probably better ways of creating a string of all the alphanums - so let's consider this a conversation starter :)
