### PR TITLE
CGI escape _id fields properly

### DIFF
--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -134,7 +134,7 @@ NSString* CBLEscapeID( NSString* docOrRevID ) {
 #else
     CFStringRef escaped = CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                   (CFStringRef)docOrRevID,
-                                                                  NULL, (CFStringRef)@"?&/",
+                                                                  NULL, (CFStringRef)@":/?#[]@!$&'()*+,;=",
                                                                   kCFStringEncodingUTF8);
     #ifdef __OBJC_GC__
     return NSMakeCollectable(escaped);


### PR DESCRIPTION
Ok, this time for sure (sorry about the bum steer, this has been a long day hunting down this bug).

So, as you seem to already know, `CFURLCreateStringByAddingPercentEscapes` escapes all valid URL characters, but we need more than that for a proper CGI param escape.  So you had already added `?&/` to the list, I've added the rest of the characters in [Section 2.2 of the RFC](http://tools.ietf.org/html/rfc3986#section-2.2) - all of which are valid CouchDB `_id` characters, none of which were being escaped by `CBLEscapeID`
