### PR TITLE
Fixes #163 REST total_rows should return number of rows in the view

### DIFF
--- a/Source/API/CBLView.m
+++ b/Source/API/CBLView.m
@@ -58,6 +58,20 @@
 }
 
 
+- (NSUInteger) totalDocs {
+    CBLDatabase* db = _weakDB;
+    NSInteger totalDocs = [db.fmdb intForQuery: @"SELECT total_docs FROM views WHERE name=?", _name];
+    if (totalDocs == -1) { // mean unknown
+        totalDocs = [db.fmdb intForQuery: @"SELECT COUNT(view_id) FROM maps WHERE view_id=?",
+                     @(self.viewID)];
+        [db.fmdb executeUpdate: @"UPDATE views SET total_docs=? WHERE view_id=?",
+            @(totalDocs), @(self.viewID)];
+    }
+    assert(totalDocs >= 0);
+    return totalDocs;
+}
+
+
 - (SequenceNumber) lastSequenceIndexed {
     return [_weakDB.fmdb longLongForQuery: @"SELECT lastSequence FROM views WHERE name=?", _name];
 }
@@ -67,6 +81,7 @@
     CBLDatabase* db = _weakDB;
     return [db.shared valueForType: @"map" name: _name inDatabaseNamed: db.name];
 }
+
 
 - (CBLReduceBlock) reduceBlock {
     CBLDatabase* db = _weakDB;
@@ -94,12 +109,13 @@
     // Update the version column in the db. This is a little weird looking because we want to
     // avoid modifying the db if the version didn't change, and because the row might not exist yet.
     CBL_FMDatabase* fmdb = db.fmdb;
-    if (![fmdb executeUpdate: @"INSERT OR IGNORE INTO views (name, version) VALUES (?, ?)", 
-                              _name, version])
+    if (![fmdb executeUpdate: @"INSERT OR IGNORE INTO views (name, version, total_docs) "
+                               "VALUES (?, ?, ?)",
+                              _name, version, @(0)])
         return NO;
     if (fmdb.changes)
         return YES;     // created new view
-    if (![fmdb executeUpdate: @"UPDATE views SET version=?, lastSequence=0 "
+    if (![fmdb executeUpdate: @"UPDATE views SET version=?, lastSequence=0, total_docs=0 "
                                "WHERE name=? AND version!=?", 
                               version, _name, version])
         return NO;
@@ -124,7 +140,7 @@
     CBLStatus status = [db _inTransaction: ^CBLStatus {
         if ([db.fmdb executeUpdate: @"DELETE FROM maps WHERE view_id=?",
                                      @(_viewID)]) {
-            [db.fmdb executeUpdate: @"UPDATE views SET lastsequence=0 WHERE view_id=?",
+            [db.fmdb executeUpdate: @"UPDATE views SET lastsequence=0, total_docs=0 WHERE view_id=?",
                                      @(_viewID)];
         }
         return db.lastDbStatus;

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -422,6 +422,15 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
             return NO;
         dbVersion = 12;
     }
+    
+    if (dbVersion < 13) {
+        // Version 13: Add rows to track number of rows in the views
+        NSString* sql = @"ALTER TABLE views ADD COLUMN total_docs INTEGER DEFAULT -1; \
+                          PRAGMA user_version = 13";
+        if (![self initialize: sql error: outError])
+            return NO;
+        dbVersion = 13;
+    }
 
     if (isNew && ![self initialize: @"END TRANSACTION" error: outError])
         return NO;

--- a/Source/CBLRouter_Tests.m
+++ b/Source/CBLRouter_Tests.m
@@ -355,7 +355,7 @@ TestCase(CBL_Router_Views) {
     Send(server, @"GET", @"/db/_design/design/_view/view?key=%22bonjour%22", kCBLStatusOK,
          $dict({@"offset", @0},
                {@"rows", $array($dict({@"id", @"doc3"}, {@"key", @"bonjour"}) )},
-               {@"total_rows", @1}));
+               {@"total_rows", @4}));
 
     // Query the view with "?keys="
     Send(server, @"GET", @"/db/_design/design/_view/view?keys=%5B%22bonjour%22,%22hello%22%5D",
@@ -363,7 +363,7 @@ TestCase(CBL_Router_Views) {
          $dict({@"offset", @0},
                {@"rows", $array($dict({@"id", @"doc3"}, {@"key", @"bonjour"}),
                                 $dict({@"id", @"doc1"}, {@"key", @"hello"}) )},
-               {@"total_rows", @2}));
+               {@"total_rows", @4}));
     
     [server close];
 }

--- a/Source/CBLView+Internal.h
+++ b/Source/CBLView+Internal.h
@@ -67,6 +67,8 @@ BOOL CBLValueIsEntireDoc(NSData* valueData);
 - (void) databaseClosing;
 
 @property (readonly) int viewID;
+@property (readonly) NSUInteger totalDocs;
+
 @end
 
 

--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -1085,7 +1085,7 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
     }];
     id updateSeq = options->updateSeq ? @(view.lastSequenceIndexed) : nil;
     _response.bodyObject = $dict({@"rows", rows},
-                                 {@"total_rows", @(rows.count)},
+                                 {@"total_rows", @(view.totalDocs)},
                                  {@"offset", @(options->skip)},
                                  {@"update_seq", updateSeq});
     return kCBLStatusOK;

--- a/Source/CBL_View_Tests.m
+++ b/Source/CBL_View_Tests.m
@@ -1035,6 +1035,65 @@ TestCase(CBL_View_FullTextQuery) {
     CAssert([db close]);
 }
 
+
+TestCase(CBL_View_TotalDocs) {
+    CBLDatabase *db = createDB();
+    
+    // Create some docs
+    NSArray* docs = putDocs(db);
+    NSUInteger totalDocs = [docs count];
+    
+    // Create a view
+    CBLView* view = createView(db);
+    CAssertEq(view.totalDocs, 0u);
+    CAssertEq([view updateIndex], kCBLStatusOK);
+    CAssertEq(view.totalDocs, totalDocs);
+    
+    // Create a conflict, won by the new revision:
+    NSDictionary* props;
+    CBLStatus status;
+    CBL_Revision* rev;
+    props = $dict({@"_id", @"44444"},
+                  {@"_rev", @"1-~~~~~"},  // higher revID, will win conflict
+                  {@"key", @"40ur"});
+    rev = [[CBL_Revision alloc] initWithProperties: props];
+    status = [db forceInsert: rev revisionHistory: @[] source: nil];
+    CAssert(status < 300);
+    CAssertEq([view updateIndex], kCBLStatusOK);
+    CAssertEq(view.totalDocs, totalDocs);
+    
+    // Create a conflict, won by the old revision:
+    props = $dict({@"_id", @"44444"},
+                  {@"_rev", @"1-...."},  // lower revID, will lose conflict
+                  {@"key", @"40ur"});
+    rev = [[CBL_Revision alloc] initWithProperties: props];
+    status = [db forceInsert: rev revisionHistory: @[] source: nil];
+    CAssert(status < 300);
+    CAssertEq([view updateIndex], kCBLStatusOK);
+    CAssertEq(view.totalDocs, totalDocs);
+    
+    // Update a doc
+    CBL_MutableRevision* nuRev = [[CBL_MutableRevision alloc] initWithDocID: rev.docID
+                                                                      revID: nil deleted:NO];
+    nuRev.properties = $dict({@"key", @"F0uR"});
+    rev = [db putRevision: nuRev prevRevisionID: rev.revID allowConflict: NO status: &status];
+    CAssert(status < 300);
+    CAssertEq([view updateIndex], kCBLStatusOK);
+    CAssertEq(view.totalDocs, totalDocs);
+    
+    // Delete a doc
+    CBL_Revision* del = [[CBL_Revision alloc] initWithDocID: rev.docID revID: rev.revID deleted: YES];
+    [db putRevision: del prevRevisionID: rev.revID allowConflict: NO status: &status];
+    CAssertEq(status, kCBLStatusOK);
+    CAssertEq([view updateIndex], kCBLStatusOK);
+    CAssertEq(view.totalDocs, totalDocs - 1);
+    
+    // Delete the index
+    [view deleteIndex];
+    CAssertEq(view.totalDocs, 0u);
+}
+
+
 TestCase(CBLView) {
     RequireTestCase(CBL_View_Create);
     RequireTestCase(CBL_View_Index);


### PR DESCRIPTION
- Add total_docs column to views table and set its default value to -1 (means 'unknown' for the old version of the api that do not have this fix)
- Add totalDocs property to CBLView() category. The totalDocs property will first try to get the value from views.total_docs columns and if the value is '-1', it will count the number of docs from the maps table, update the value to views.total_docs and return.
- Update the views.total_rows every time when the view's index is updated.
- Update CBL_Router's handler to return view.totalDocs for the total_rows attribute in query responses.
- Add CBL_View_TotalDocs test case and fix CBL_Router_Views accordingly.
