### PR TITLE
Fixes #417 Not fetch each individual rev when _all_docs returns an error

### DIFF
--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -560,17 +560,17 @@ static NSString* joinQuotedEscaped(NSArray* strings);
                               }
                           }
                       }
+                      
+                      // Any leftover revisions that didn't get matched will be fetched individually:
+                      if (remainingRevs.count) {
+                          LogTo(Sync, @"%@ bulk-fetch didn't work for %u of %u revs; getting individually",
+                                self, (unsigned)remainingRevs.count, (unsigned)bulkRevs.count);
+                          for (CBL_Revision* rev in remainingRevs)
+                              [self queueRemoteRevision: rev];
+                          [self pullRemoteRevisions];
+                      }
                   }
                   
-                  // Any leftover revisions that didn't get matched will be fetched individually:
-                  if (remainingRevs.count) {
-                      LogTo(Sync, @"%@ bulk-fetch didn't work for %u of %u revs; getting individually",
-                            self, (unsigned)remainingRevs.count, (unsigned)bulkRevs.count);
-                      for (CBL_Revision* rev in remainingRevs)
-                          [self queueRemoteRevision: rev];
-                      [self pullRemoteRevisions];
-                  }
-
                   // Note that we've finished this task:
                   [self asyncTasksFinished: 1];
                   --_httpConnectionCount;


### PR DESCRIPTION
- In CBL_Puller's pullBulkWithAllDocs: method, when _all_docs request fails, all the docs are not treated as leftover docs and will not be fetched individually as the retry process will kick in.
- With this fix, the completed change count issue describing in #417 will be resolved as well.
