### PR TITLE
streamed requests return a proper response

### DIFF
--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -927,7 +927,8 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
                     status = kCBLStatusBadRequest;
             }
             _response.internalStatus = status;
-            [self finished];
+            [self sendResponseHeaders];
+            [self sendResponseBodyAndFinish: YES];
         }];
 
         if (CBLStatusIsError(status))


### PR DESCRIPTION
This is in relation to this bug in PouchDB: https://github.com/pouchdb/pouchdb/issues/2660

When an AJAX request accesses the `xhr.upload` property, the request turns into a stream, giving the request a `HTTPBodyStream` member, instead of a `HTTPBody` member.

When this happens the request is parsed asynchronously, and the response isn't sent back correctly, resulting in a 0 status on the XHR.

Sounds weird, but because of this issue, PouchDB cannot talk to Couchbase Lite on iOS.

This patch returns a proper response when the request is a stream.
