### PR TITLE
Update the characters to be escaped in URL params

### DIFF
--- a/Source/CBLMisc.h
+++ b/Source/CBLMisc.h
@@ -28,10 +28,6 @@ NSString* CBLHexFromBytes( const void* bytes, size_t length) __attribute__((nonn
 
 NSComparisonResult CBLSequenceCompare( SequenceNumber a, SequenceNumber b);
 
-/** Escapes a document or revision ID for use in a URL.
-    This does the usual %-escaping, but makes sure that '/' is escaped in case the ID appears in the path portion of the URL, and that '&' is escaped in case the ID appears in a query value. */
-NSString* CBLEscapeID( NSString* param ) __attribute__((nonnull));
-
 /** Escapes a string to be used as the value of a query parameter in a URL.
     This does the usual %-escaping, but makes sure that '&' is also escaped. */
 NSString* CBLEscapeURLParam( NSString* param ) __attribute__((nonnull));

--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -125,37 +125,32 @@ NSComparisonResult CBLSequenceCompare( SequenceNumber a, SequenceNumber b) {
 }
 
 
-NSString* CBLEscapeID( NSString* docOrRevID ) {
-#ifdef GNUSTEP
-    docOrRevID = [docOrRevID stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
-    docOrRevID = [docOrRevID stringByReplacingOccurrencesOfString: @"&" withString: @"%26"];
-    docOrRevID = [docOrRevID stringByReplacingOccurrencesOfString: @"/" withString: @"%2F"];
-    return docOrRevID;
-#else
-    CFStringRef escaped = CFURLCreateStringByAddingPercentEscapes(NULL,
-                                                                  (CFStringRef)docOrRevID,
-                                                                  NULL, (CFStringRef)@"?&/",
-                                                                  kCFStringEncodingUTF8);
-    #ifdef __OBJC_GC__
-    return NSMakeCollectable(escaped);
-    #else
-    return (__bridge_transfer NSString *)escaped;
-    #endif
-
-#endif
-}
-
-
 NSString* CBLEscapeURLParam( NSString* param ) {
+    // Escape all of the reserved characters according to section 2.2 in rfc3986
+    // http://tools.ietf.org/html/rfc3986#section-2.2
 #ifdef GNUSTEP
     param = [param stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+    param = [param stringByReplacingOccurrencesOfString: @":" withString: @"%3A"];
+    param = [param stringByReplacingOccurrencesOfString: @"/" withString: @"%2F"];
+    param = [param stringByReplacingOccurrencesOfString: @"?" withString: @"%3F"];
+    param = [param stringByReplacingOccurrencesOfString: @"@" withString: @"%40"];
+    param = [param stringByReplacingOccurrencesOfString: @"!" withString: @"%21"];
+    param = [param stringByReplacingOccurrencesOfString: @"$" withString: @"%24"];
     param = [param stringByReplacingOccurrencesOfString: @"&" withString: @"%26"];
+    param = [param stringByReplacingOccurrencesOfString: @"'" withString: @"%27"];
+    param = [param stringByReplacingOccurrencesOfString: @"(" withString: @"%28"];
+    param = [param stringByReplacingOccurrencesOfString: @")" withString: @"%29"];
+    param = [param stringByReplacingOccurrencesOfString: @"*" withString: @"%2A"];
     param = [param stringByReplacingOccurrencesOfString: @"+" withString: @"%2B"];
+    param = [param stringByReplacingOccurrencesOfString: @"," withString: @"%2C"];
+    param = [param stringByReplacingOccurrencesOfString: @";" withString: @"%3B"];
+    param = [param stringByReplacingOccurrencesOfString: @"=" withString: @"%3D"];
     return param;
 #else
     CFStringRef escaped = CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                   (CFStringRef)param,
-                                                                  NULL, (CFStringRef)@"&+",
+                                                                  NULL,
+                                                                  (CFStringRef)@":/?@!$&'()*+,;=",
                                                                   kCFStringEncodingUTF8);
     #ifdef __OBJC_GC__
     return NSMakeCollectable(escaped);
@@ -365,10 +360,13 @@ TestCase(CBLQuoteString) {
     CAssertEqual(CBLUnquoteString(@"\"foo\\\""), nil);
 }
 
-TestCase(TDEscapeID) {
-    CAssertEqual(CBLEscapeID(@"foobar"), @"foobar");
-    CAssertEqual(CBLEscapeID(@"<script>alert('ARE YOU MY DADDY?')</script>"),
-                            @"%3Cscript%3Ealert('ARE%20YOU%20MY%20DADDY%3F')%3C%2Fscript%3E");
-    CAssertEqual(CBLEscapeID(@"foo/bar"), @"foo%2Fbar");
-    CAssertEqual(CBLEscapeID(@"foo&bar"), @"foo%26bar");
+
+TestCase(CBLEscapeURLParam) {
+    CAssertEqual(CBLEscapeURLParam(@"foobar"), @"foobar");
+    CAssertEqual(CBLEscapeURLParam(@"<script>alert('ARE YOU MY DADDY?')</script>"),
+                 @"%3Cscript%3Ealert%28%27ARE%20YOU%20MY%20DADDY%3F%27%29%3C%2Fscript%3E");
+    CAssertEqual(CBLEscapeURLParam(@"foo/bar"), @"foo%2Fbar");
+    CAssertEqual(CBLEscapeURLParam(@"foo&bar"), @"foo%26bar");
+    CAssertEqual(CBLEscapeURLParam(@":/?#[]@!$&'()*+,;="),
+                 @"%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D");
 }

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -385,7 +385,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     // See: http://wiki.apache.org/couchdb/HTTP_Document_API#GET
     // See: http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Attachments_With_a_Document
     NSString* path = $sprintf(@"%@?rev=%@&revs=true&attachments=true",
-                              CBLEscapeID(rev.docID), CBLEscapeID(rev.revID));
+                              CBLEscapeURLParam(rev.docID), CBLEscapeURLParam(rev.revID));
     // If the document has attachments, add an 'atts_since' param with a list of
     // already-known revisions, so the server can skip sending the bodies of any
     // attachments we already have locally:

--- a/Source/CBL_Pusher.m
+++ b/Source/CBL_Pusher.m
@@ -425,7 +425,7 @@ CBLStatus CBLStatusFromBulkDocsResponseItem(NSDictionary* item) {
     self.changesTotal++;
     [self asyncTaskStarted];
 
-    NSString* path = $sprintf(@"%@?new_edits=false", CBLEscapeID(rev.docID));
+    NSString* path = $sprintf(@"%@?new_edits=false", CBLEscapeURLParam(rev.docID));
     __block CBLMultipartUploader* uploader = [[CBLMultipartUploader alloc]
                                   initWithURL: CBLAppendToURL(_remote, path)
                                      streamer: bodyStream
@@ -477,7 +477,7 @@ CBLStatus CBLStatusFromBulkDocsResponseItem(NSDictionary* item) {
     }
 
     [self asyncTaskStarted];
-    NSString* path = $sprintf(@"%@?new_edits=false", CBLEscapeID(rev.docID));
+    NSString* path = $sprintf(@"%@?new_edits=false", CBLEscapeURLParam(rev.docID));
     [self sendAsyncRequest: @"PUT"
                       path: path
                       body: rev.properties


### PR DESCRIPTION
- Add all of the reserved characters according to section 2.2 in rfc3986 that haven't get escaped automatically by the Apple library
- Consolidate CBLEscapeID and CBLEscapeURLParam into just CBLEscapeURLParam
- Update test case and others accordingly
