### PR TITLE
Add heartbeat parameter to _changes REST API

### DIFF
--- a/Source/CBLRouter_Tests.m
+++ b/Source/CBLRouter_Tests.m
@@ -452,6 +452,57 @@ TestCase(CBL_Router_LongPollChanges) {
 }
 
 
+TestCase(CBL_Router_LongPollChanges_Heartbeat) {
+    RequireTestCase(CBL_Router_ContinuousChanges);
+    CBLManager* server = createDBManager();
+    Send(server, @"PUT", @"/db", kCBLStatusCreated, nil);
+    
+    __block CBLResponse* response = nil;
+    NSMutableData* body = [NSMutableData data];
+    __block BOOL finished = NO;
+    
+    __block NSInteger heartbeat = 0;
+    NSURL* url = [NSURL URLWithString: @"cbl:///db/_changes?feed=longpoll&heartbeat=5000"];
+    NSURLRequest* request = [NSURLRequest requestWithURL: url];
+    CBL_Router* router = [[CBL_Router alloc] initWithDatabaseManager: server request: request];
+    router.onResponseReady = ^(CBLResponse* routerResponse) {
+        CAssert(!response);
+        response = routerResponse;
+    };
+    router.onDataAvailable = ^(NSData* content, BOOL finished) {
+        NSString* str = [[NSString alloc] initWithData: content encoding: NSUTF8StringEncoding];
+        if ([str isEqualToString: @"\r\n"])
+            heartbeat++;
+        [body appendData: content];
+    };
+    router.onFinished = ^{
+        CAssert(!finished);
+        finished = YES;
+    };
+    
+    // Start:
+    [router start];
+    CAssert(!finished);
+    
+    NSDate* timeout = [NSDate dateWithTimeIntervalSinceNow: 10.5];
+    while ([[NSDate date] compare: timeout] == NSOrderedAscending
+           && [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode beforeDate: timeout])
+        ;
+    
+    // Should now have received additional output from the router:
+    CAssert(body.length > 0);
+    CAssert(heartbeat == 2);
+    CAssert(!finished);
+    
+    // Now make a change to the database:
+    SendBody(server, @"PUT", @"/db/doc1", $dict({@"message", @"hej"}), kCBLStatusCreated, nil);
+    CAssert(finished);
+    
+    [router stop];
+    [server close];
+}
+
+
 TestCase(CBL_Router_ContinuousChanges) {
     RequireTestCase(CBL_Router_Changes);
     CBLManager* server = createDBManager();
@@ -496,6 +547,71 @@ TestCase(CBL_Router_ContinuousChanges) {
     CAssert(!finished);
     
     [router stop];
+    [server close];
+}
+
+
+TestCase(CBL_Router_ContinuousChanges_Heartbeat) {
+    RequireTestCase(CBL_Router_ContinuousChanges);
+    CBLManager* server = createDBManager();
+    Send(server, @"PUT", @"/db", kCBLStatusCreated, nil);
+    
+    __block CBLResponse* response = nil;
+    NSMutableData* body = [NSMutableData data];
+    __block BOOL finished = NO;
+    
+    __block NSInteger heartbeat = 0;
+    NSURL* url = [NSURL URLWithString: @"cbl:///db/_changes?feed=continuous&heartbeat=5000"];
+    NSURLRequest* request = [NSURLRequest requestWithURL: url];
+    CBL_Router* router = [[CBL_Router alloc] initWithDatabaseManager: server request: request];
+    router.onResponseReady = ^(CBLResponse* routerResponse) {
+        CAssert(!response);
+        response = routerResponse;
+    };
+    router.onDataAvailable = ^(NSData* content, BOOL finished) {
+        NSString *str = [[NSString alloc] initWithData: content encoding: NSUTF8StringEncoding];
+        if ([str isEqualToString: @"\r\n"])
+            heartbeat++;
+        [body appendData: content];
+    };
+    router.onFinished = ^{
+        CAssert(!finished);
+        finished = YES;
+    };
+    
+    // Start:
+    [router start];
+    
+    // Should initially have a response and one line of output:
+    CAssert(response != nil);
+    CAssertEq(response.status, kCBLStatusOK);
+    CAssert(body.length == 0);
+    CAssert(!finished);
+
+    NSDate* timeout = [NSDate dateWithTimeIntervalSinceNow: 10.5];
+    while ([[NSDate date] compare: timeout] == NSOrderedAscending
+           && [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode beforeDate: timeout])
+        ;
+    
+    // Should now have received additional output from the router:
+    CAssert(body.length > 0);
+    CAssert(heartbeat == 2);
+    CAssert(!finished);
+    
+    [router stop];
+    [server close];
+}
+
+
+TestCase(CBL_Router_Changes_BadHeartbeatParams) {
+    CBLManager* server = createDBManager();
+    Send(server, @"PUT", @"/db", kCBLStatusCreated, nil);
+    Send(server, @"GET", @"/db/_changes?feed=continuous&heartbeat=foo", kCBLStatusBadRequest, nil);
+    Send(server, @"GET", @"/db/_changes?feed=continuous&heartbeat=-1", kCBLStatusBadRequest, nil);
+    Send(server, @"GET", @"/db/_changes?feed=continuous&heartbeat=-0", kCBLStatusBadRequest, nil);
+    Send(server, @"GET", @"/db/_changes?feed=longpoll&heartbeat=foo", kCBLStatusBadRequest, nil);
+    Send(server, @"GET", @"/db/_changes?feed=longpoll&heartbeat=-1", kCBLStatusBadRequest, nil);
+    Send(server, @"GET", @"/db/_changes?feed=longpoll&heartbeat=-0", kCBLStatusBadRequest, nil);
     [server close];
 }
 
@@ -868,7 +984,9 @@ TestCase(CBL_Router) {
     RequireTestCase(CBL_Router_Docs);
     RequireTestCase(CBL_Router_AllDocs);
     RequireTestCase(CBL_Router_LongPollChanges);
+    RequireTestCase(CBL_Router_LongPollChanges_Heartbeat);
     RequireTestCase(CBL_Router_ContinuousChanges);
+    RequireTestCase(CBL_Router_ContinuousChanges_Heartbeat);
     RequireTestCase(CBL_Router_GetAttachment);
     RequireTestCase(CBL_Router_GetJSONAttachment);
     RequireTestCase(CBL_Router_RevsDiff);

--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -37,6 +37,7 @@
 #import "CollectionUtils.h"
 #import "Test.h"
 
+#define kMinHeartbeat 5.0
 
 @implementation CBL_Router (Handlers)
 
@@ -618,6 +619,17 @@
                                                  selector: @selector(dbChanged:)
                                                      name: CBL_DatabaseChangesNotification
                                                    object: db];
+
+        NSString* heartbeatParam = [self query:@"heartbeat"];
+        if (heartbeatParam) {
+            NSTimeInterval heartbeat = [heartbeatParam doubleValue] / 1000.0;
+            if (heartbeat <= 0)
+                return kCBLStatusBadRequest;
+            else if (heartbeat < kMinHeartbeat)
+                heartbeat = kMinHeartbeat;
+            [self startHeartbeat: heartbeat];
+        }
+        
         // Don't close connection; more data to come
         return 0;
     } else {

--- a/Source/CBL_Router.h
+++ b/Source/CBL_Router.h
@@ -42,6 +42,7 @@ typedef void (^OnFinishedBlock)();
     NSDictionary* _changesFilterParams;
     BOOL _changesIncludeDocs;
     BOOL _changesIncludeConflicts;
+    NSTimer *_heartbeatTimer;
 }
 
 - (instancetype) initWithServer: (CBL_Server*)server
@@ -80,6 +81,8 @@ typedef void (^OnFinishedBlock)();
 - (void) sendResponseHeaders;
 - (void) sendResponseBodyAndFinish: (BOOL)finished;
 - (void) finished;
+- (void) startHeartbeat: (NSTimeInterval)interval;
+- (void) stopHeartbeat;
 @end
 
 

--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -611,6 +611,7 @@ static NSArray* splitPath( NSURL* url ) {
 
 - (void) stopNow {
     _running = NO;
+    [self stopHeartbeat];
     self.onResponseReady = nil;
     self.onDataAvailable = nil;
     self.onFinished = nil;
@@ -651,6 +652,33 @@ static NSArray* splitPath( NSURL* url ) {
         [self sendResponseHeaders];
     }
     [self finished];
+}
+
+#pragma mark - Heartbeat
+
+- (void) sendHeartbeatResponse {
+    if (_onDataAvailable) {
+        _onDataAvailable([@"\r\n" dataUsingEncoding:NSUTF8StringEncoding], NO);
+    }
+}
+
+
+- (void) startHeartbeat: (NSTimeInterval)interval {
+    if (interval <= 0)
+        return;
+    
+    [_heartbeatTimer invalidate];
+    _heartbeatTimer = [NSTimer scheduledTimerWithTimeInterval: interval
+                                                       target: self
+                                                     selector: @selector(sendHeartbeatResponse)
+                                                     userInfo: nil
+                                                      repeats: YES];
+}
+
+
+- (void) stopHeartbeat {
+    [_heartbeatTimer invalidate];
+    _heartbeatTimer = nil;
 }
 
 


### PR DESCRIPTION
Add heartbeat (CRLF ping) to _changes REST API in continuous and longpoll mode. The heartbeat parameter will accept a value in millisecond and the value needs to be more than zero. #426
