### PR TITLE
Fix #432 Add index on maps and attachments table

### DIFF
--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -442,6 +442,15 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
         dbVersion = 14;
     }
 
+    if (dbVersion < 15) {
+        // Version 15: Add sequence index on maps and attachments for revs(sequence) on DELETE CASCADE
+        NSString* sql = @"CREATE INDEX maps_sequence ON maps(sequence); \
+                          CREATE INDEX attachments_sequence ON attachments(sequence); \
+                          PRAGMA user_version = 15";
+        if (![self initialize: sql error: outError])
+            return NO;
+        dbVersion = 15;
+    }
 
     if (isNew && ![self initialize: @"END TRANSACTION" error: outError])
         return NO;


### PR DESCRIPTION
- Add sequence index on maps and attachments for revs(sequence) on DELETE CASCADE
- The fix was taken from
  https://github.com/hermanccw/couchbase-lite-ios/commit/efa70ee9e18986dd62488fa1d7d4ac7b91c185f0
