### PR TITLE
Fix #256 Conflict when updating a doc multiple times in a transaction

### DIFF
--- a/Source/API/APITests.m
+++ b/Source/API/APITests.m
@@ -327,6 +327,27 @@ TestCase(API_CreateNewRevisions) {
     closeTestDB(db);
 }
 
+TestCase(API_CreateNewRevisionsInTransaction) {
+    RequireTestCase(API_CreateNewRevisions);
+    CBLDatabase* db = createEmptyDB();
+    CBLDocument* doc = [db createDocument];
+    NSError* error;
+    CBLSavedRevision* rev = [doc putProperties: @{@"toogle":@YES} error: &error];
+    CAssert(rev, @"Save rev failed: %@", error);
+
+    [db inTransaction:^BOOL{
+        for (int i = 0; i < 10; i++) {
+            NSMutableDictionary* properties = [doc.properties mutableCopy];
+            bool wasChecked = [[properties objectForKey:@"toggle"] boolValue];
+            [properties setObject: [NSNumber numberWithBool: !wasChecked] forKey: @"toggle"];
+            NSError* error;
+            CBLSavedRevision* rev = [doc putProperties: properties error: &error];
+            CAssert(rev, @"Save rev failed: %@", error);
+        }
+        return YES;
+    }];
+}
+
 #if 0
 TestCase(API_SaveMultipleDocuments) {
     CBLDatabase* db = createEmptyDB();

--- a/Source/API/CBLDatabase.m
+++ b/Source/API/CBLDatabase.m
@@ -94,14 +94,20 @@ static id<CBLFilterCompiler> sFilterCompiler;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
+- (void) notifyDocumentsRevisionAdded: (NSArray*)changes {
+    for (CBLDatabaseChange* change in changes) {
+        // Notify the corresponding instantiated CBLDocument object (if any):
+        [[self _cachedDocumentWithID: change.documentID] revisionAdded: change];
+    }
+}
 
 - (void) postPublicChangeNotification: (NSArray*)changes {
     BOOL external = NO;
     for (CBLDatabaseChange* change in changes) {
-        // Notify the corresponding instantiated CBLDocument object (if any):
-        [[self _cachedDocumentWithID: change.documentID] revisionAdded: change];
-        if (change.source != nil)
+        if (change.source != nil) {
             external = YES;
+            break;
+        }
     }
 
     // Post the public kCBLDatabaseChangeNotification:

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -86,6 +86,7 @@ extern const CBLChangesOptions kDefaultCBLChangesOptions;
 @property (nonatomic, readonly) NSString* path;
 @property (nonatomic, readonly) BOOL isOpen;
 
+- (void) notifyDocumentsRevisionAdded: (NSArray*)changes; // implemented in CBLDatabase.m
 - (void) postPublicChangeNotification: (NSArray*)changes; // implemented in CBLDatabase.m
 
 @end

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -651,6 +651,7 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
 /** Posts a local NSNotification of a new revision of a document. */
 - (void) notifyChange: (CBLDatabaseChange*)change {
     LogTo(CBLDatabase, @"Added: %@ (seq=%lld)", change.addedRevision, change.addedRevision.sequence);
+    [self notifyDocumentsRevisionAdded:@[change]];
     if (!_changesToNotify)
         _changesToNotify = [[NSMutableArray alloc] init];
     [_changesToNotify addObject: change];
@@ -659,6 +660,7 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
 
 /** Posts a local NSNotification of multiple new revisions. */
 - (void) notifyChanges: (NSArray*)changes {
+    [self notifyDocumentsRevisionAdded:changes];
     if (!_changesToNotify)
         _changesToNotify = [[NSMutableArray alloc] init];
     [_changesToNotify addObjectsFromArray: changes];


### PR DESCRIPTION
* Separate posting revisionAdded: notification out of postPublicChangeNotification: method.

* Notify a document with revisionAdded: everytime that a new revision is added.