### PR TITLE
Rework error status when no matched selectors in CBLRouter

### DIFF
--- a/Source/CBLRouter_Tests.m
+++ b/Source/CBLRouter_Tests.m
@@ -127,11 +127,11 @@ TestCase(CBL_Router_Server) {
     Send(server, @"GET", @"/_all_dbs", kCBLStatusOK, @[]);
     Send(server, @"GET", @"/non-existent", kCBLStatusNotFound, nil);
     Send(server, @"GET", @"/BadName", kCBLStatusBadID, nil);
-    Send(server, @"PUT", @"/", kCBLStatusNotFound, nil);
-    NSDictionary* response = Send(server, @"POST", @"/", kCBLStatusNotFound, nil);
+    Send(server, @"PUT", @"/", kCBLStatusMethodNotAllowed, nil);
+    NSDictionary* response = Send(server, @"POST", @"/", kCBLStatusMethodNotAllowed, nil);
     
-    CAssertEqual(response[@"status"], @(404));
-    CAssertEqual(response[@"error"], @"not_found");
+    CAssertEqual(response[@"status"], @(405));
+    CAssertEqual(response[@"error"], @"method_not_allowed");
     
     NSDictionary* session = Send(server, @"GET", @"/_session", kCBLStatusOK, nil);
     CAssert(session[@"ok"]);
@@ -358,6 +358,32 @@ TestCase(CBL_Router_Views) {
                {@"rows", $array($dict({@"id", @"doc3"}, {@"key", @"bonjour"}),
                                 $dict({@"id", @"doc1"}, {@"key", @"hello"}) )},
                {@"total_rows", @4}));
+}
+
+
+TestCase(CBL_Router_NoMappedSelectors) {
+    CBLManager* server = createDBManager();
+    Send(server, @"PUT", @"/db", kCBLStatusCreated, nil);
+
+    NSDictionary* response = nil;
+
+    response = Send(server, @"GET", @"/", kCBLStatusOK, nil);
+
+    response = Send(server, @"POST", @"/", kCBLStatusMethodNotAllowed, nil);
+    CAssertEqual(response[@"status"], @(405));
+    CAssertEqual(response[@"error"], @"method_not_allowed");
+
+    response = Send(server, @"PUT", @"/", kCBLStatusMethodNotAllowed, nil);
+    CAssertEqual(response[@"status"], @(405));
+    CAssertEqual(response[@"error"], @"method_not_allowed");
+
+    response = Send(server, @"POST", @"/db/doc1", kCBLStatusMethodNotAllowed, nil);
+    CAssertEqual(response[@"status"], @(405));
+    CAssertEqual(response[@"error"], @"method_not_allowed");
+
+    response = Send(server, @"GET", @"/db/_session", kCBLStatusNotFound, nil);
+    CAssertEqual(response[@"status"], @(404));
+    CAssertEqual(response[@"error"], @"not_found");
 }
 
 

--- a/Source/CBLStatus.h
+++ b/Source/CBLStatus.h
@@ -19,6 +19,7 @@ typedef enum {
     kCBLStatusUnauthorized   = 401,
     kCBLStatusForbidden      = 403,
     kCBLStatusNotFound       = 404,
+    kCBLStatusMethodNotAllowed = 405,
     kCBLStatusNotAcceptable  = 406,
     kCBLStatusConflict       = 409,
     kCBLStatusDuplicate      = 412,      // Formally known as "Precondition Failed"

--- a/Source/CBLStatus.m
+++ b/Source/CBLStatus.m
@@ -31,6 +31,7 @@ static const struct StatusMapEntry kStatusMap[] = {
     {kCBLStatusUnauthorized,         401, "unauthorized"},
     {kCBLStatusNotFound,             404, "not_found"},
     {kCBLStatusForbidden,            403, "forbidden"},
+    {kCBLStatusMethodNotAllowed,     405, "method_not_allowed"},
     {kCBLStatusNotAcceptable,        406, "not_acceptable"},
     {kCBLStatusConflict,             409, "conflict"},
     {kCBLStatusDuplicate,            412, "file_exists"},      // really 'Precondition Failed'


### PR DESCRIPTION
In case of no mached selectors, the CBLRouter will return 405 (method not allowed) if there is an alternative method available otherwise returning 404 (not found). This implementation is in sync with the current SG's implementation. #499
