### PR TITLE
Fix conflict between function and class name in Swift

### DIFF
--- a/Source/API/CBLDocument.h
+++ b/Source/API/CBLDocument.h
@@ -122,8 +122,8 @@
 @protocol CBLDocumentModel <NSObject>
 /** Called whenever a new revision is added to the document.
     (Equivalent to kCBLDocumentChangeNotification.) */
-- (void) CBLDocument: (CBLDocument*)doc
-           didChange: (CBLDatabaseChange*)change                        __attribute__((nonnull));
+- (void) document: (CBLDocument*)doc
+        didChange: (CBLDatabaseChange*)change                        __attribute__((nonnull));
 @end
 
 

--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -169,7 +169,7 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
     }
 
     id<CBLDocumentModel> model = _modelObject; // strong reference to it
-    [model CBLDocument: self didChange: change];
+    [model document: self didChange: change];
 
     NSNotification* n = [NSNotification notificationWithName: kCBLDocumentChangeNotification
                                                       object: self

--- a/Source/API/CBLModel.h
+++ b/Source/API/CBLModel.h
@@ -8,7 +8,8 @@
 
 #import "MYDynamicObject.h"
 #import "CBLDocument.h"
-@class CBLAttachment, CBLDatabase, CBLDocument;
+
+@class CBLAttachment, CBLDatabase;
 
 
 NS_REQUIRES_PROPERTY_DEFINITIONS  // Don't let compiler auto-synthesize properties in subclasses

--- a/Source/API/CBLModel.m
+++ b/Source/API/CBLModel.m
@@ -166,7 +166,7 @@
 
 
 // Respond to an external change (likely from sync). This is called by my CBLDocument.
-- (void) CBLDocument: (CBLDocument*)doc didChange:(CBLDatabaseChange*)change {
+- (void) document: (CBLDocument*)doc didChange:(CBLDatabaseChange*)change {
     NSAssert(doc == _document, @"Notified for wrong document");
     if (_saving)
         return;  // this is just an echo from my -justSave: method, below, so ignore it


### PR DESCRIPTION
Declaring the delegate method the same name as the class name leads to a conflit between function and class name in Swift.

There is also the discussion about the same issue here : https://devforums.apple.com/message/1002447#1002447.
