### PR TITLE
Fix #516 Create and Register log() function

### DIFF
--- a/Source/CBLJSViewCompiler_Test.m
+++ b/Source/CBLJSViewCompiler_Test.m
@@ -83,8 +83,28 @@ TestCase(JSFilterFunctionWithParams) {
 }
 
 
+TestCase(JSLogFunction) {
+    // This case will test that calling log() function doesn't cause any errors running the JS map
+    // map function.
+    CBLJSViewCompiler* c = [[CBLJSViewCompiler alloc] init];
+    CBLMapBlock mapBlock = [c compileMapFunction: @"function(doc){log('Log Message'); emit(doc.key, doc);}"
+                                        language: @"javascript"];
+    CAssert(mapBlock);
+
+    NSDictionary* doc = @{@"_id": @"doc1", @"_rev": @"1-xyzzy", @"key": @"value"};
+    NSMutableArray* emitted = [NSMutableArray array];
+    CBLMapEmitBlock emit = ^(id key, id value) {
+        [emitted addObject: value];
+    };
+    mapBlock(doc, emit);
+    CAssertEqual(emitted, (@[doc]));
+}
+
+
 TestCase(CBLJSCompiler) {
     RequireTestCase(JSMapFunction);
     RequireTestCase(JSReduceFunction);
     RequireTestCase(JSFilterFunction);
+    RequireTestCase(JSFilterFunctionWithParams);
+    RequireTestCase(JSLogFunction);
 }


### PR DESCRIPTION
Create and register log function, supported by couchdb so that the JS map function including log function calls can be run inside CBL Lite without any issues.
