### PR TITLE
Allow subclasses to synthesize their properties

### DIFF
--- a/Source/API/CBLModel.h
+++ b/Source/API/CBLModel.h
@@ -12,7 +12,6 @@
 @class CBLAttachment, CBLDatabase;
 
 
-NS_REQUIRES_PROPERTY_DEFINITIONS  // Don't let compiler auto-synthesize properties in subclasses
 /** Generic model class for CouchbaseLite documents.
     There's a 1::1 mapping between these and CBLDocuments; call +modelForDocument: to get (or create) a model object for a document, and .document to get the document of a model.
     You should subclass this and declare properties in the subclass's @@interface. As with NSManagedObject, you don't need to implement their accessor methods or declare instance variables; simply note them as '@@dynamic' in the class @@implementation. The property value will automatically be fetched from or stored to the document, using the same name.


### PR DESCRIPTION
Commit 256aaecbf012b7935a0db697192874f39d9f7567 disables automatic synthesis of properties in subclasses of CBLModel. While I understand users who do not know to set their properties as `@dynamic` can cause confusion I believe this is an issue of education, not hampering user freedom. This PR re-enables property synthesis in CBLModel subclasses.
