### PR TITLE
Fix #550 Ensure to send response header before finishing read document body

### DIFF
--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -931,6 +931,7 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
                     status = kCBLStatusBadRequest;
             }
             _response.internalStatus = status;
+            [self sendResponseHeaders];
             [self finished];
         }];
 


### PR DESCRIPTION
Ensure to send response header before call finish() method after finish reading document body. This is for do_PUT and do_POST router handler.
