### PR TITLE
Rename the attachment store folder before delete (#308)

### DIFF
--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -104,6 +104,7 @@ extern const CBLChangesOptions kDefaultCBLChangesOptions;
                        manager: (CBLManager*)manager
                       readOnly: (BOOL)readOnly;
 + (BOOL) deleteDatabaseFilesAtPath: (NSString*)dbPath error: (NSError**)outError;
+
 #if DEBUG
 + (instancetype) createEmptyDBAtPath: (NSString*)path;
 #endif

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -100,7 +100,7 @@ NSArray* CBL_RunloopModes;
     return CBLRemoveFileIfExists(dbPath, outError)
         && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-wal"], outError)
         && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-shm"], outError)
-        && CBLRemoveFileIfExists([self attachmentStorePath: dbPath], outError);
+        && CBLRemoveFileIfExistsAsync([self attachmentStorePath: dbPath], outError);
 }
 
 

--- a/Source/CBLMisc.h
+++ b/Source/CBLMisc.h
@@ -79,6 +79,10 @@ BOOL CBLIsFileExistsError( NSError* error );
 /** Removes a file if it exists; does nothing if it doesn't. */
 BOOL CBLRemoveFileIfExists(NSString* path, NSError** outError) __attribute__((nonnull(1)));
 
+/* Remove a file asynchronously if it exists; does nothing if it doesn't.
+   The file will be moved to the temp folder and renamed before it is deleted. */
+BOOL CBLRemoveFileIfExistsAsync(NSString* path, NSError** outError);
+
 /** Returns the hostname of this computer/device (will be of the form "___.local") */
 NSString* CBLGetHostName(void);
 

--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -362,6 +362,32 @@ BOOL CBLRemoveFileIfExists(NSString* path, NSError** outError) {
     }
 }
 
+BOOL CBLRemoveFileIfExistsAsync(NSString* path, NSError** outError) {
+    NSString* renamedPath = [NSTemporaryDirectory()
+                             stringByAppendingPathComponent: CBLCreateUUID()];
+    NSError* error;
+    BOOL result = [[NSFileManager defaultManager] moveItemAtPath: path
+                                                          toPath: renamedPath
+                                                           error: &error];
+    if (result) {
+        LogTo(CBLDatabase, @"Renamed file %@ to %@ for async delete", renamedPath, renamedPath);
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            NSError* outError;
+            if (CBLRemoveFileIfExists(renamedPath, &outError))
+                LogTo(CBLDatabase, @"Deleted file %@", renamedPath);
+            else
+                Warn(@"Failed to delete an attachment folder at %@ with error: %@",
+                     renamedPath, outError);
+        });
+        return YES;
+    } else if (CBLIsFileNotFoundError(error)) {
+        return YES;
+    } else {
+        if (outError)
+            *outError = error;
+        return NO;
+    }
+}
 
 NSString* CBLGetHostName() {
     // From <http://stackoverflow.com/a/16902907/98077>


### PR DESCRIPTION
When deleting a database, renaming the attachment store folder if it exists and delete it in a dispatch queue. #308.
