### PR TITLE
#544 Not check for reachability for non-continuous replication

### DIFF
--- a/Source/CBLReplicator_Tests.m
+++ b/Source/CBLReplicator_Tests.m
@@ -437,6 +437,40 @@ TestCase(CBL_Puller_SSL_Pinned) {
     CAssertEq(db.lastSequenceNumber, 2);
 }
 
+TestCase(CBL_Pusher_NonExistentServer) {
+    RequireTestCase(CBL_Pusher);
+    NSURL* remoteURL = [NSURL URLWithString:@"http://mylocalhost/db"];
+    if (!remoteURL) {
+        Warn(@"Skipping test CBL_Pusher_NonExistentServer: invalid URL");
+        return;
+    }
+
+    CBLManager* server = [CBLManager createEmptyAtTemporaryPath: @"CBL_PusherTest"];
+    CBLDatabase* db = [server databaseNamed: @"db" error: NULL];
+    CAssert(db);
+
+    replic8(db, remoteURL, YES, nil, nil, [NSError errorWithDomain: NSURLErrorDomain
+                                                              code: NSURLErrorCannotFindHost
+                                                          userInfo: nil]);
+}
+
+TestCase(CBL_Puller_NonExistentServer) {
+    RequireTestCase(CBL_Puller);
+    NSURL* remoteURL = [NSURL URLWithString:@"http://mylocalhost/db"];
+    if (!remoteURL) {
+        Warn(@"Skipping test CBL_Puller_NonExistentServer: invalid URL");
+        return;
+    }
+
+    CBLManager* server = [CBLManager createEmptyAtTemporaryPath: @"CBL_PullerTest"];
+    CBLDatabase* db = [server databaseNamed: @"db" error: NULL];
+    CAssert(db);
+
+    replic8(db, remoteURL, NO, nil, nil, [NSError errorWithDomain: NSURLErrorDomain
+                                                             code: NSURLErrorCannotFindHost
+                                                         userInfo: nil]);
+}
+
 TestCase(CBL_Puller_DocIDs) {
     RequireTestCase(CBL_Pusher); // CBL_Pusher populates the remote db that this test pulls from...
     
@@ -719,6 +753,8 @@ TestCase(CBLReplicator) {
     RequireTestCase(CBL_Puller_AuthFailure);
     RequireTestCase(CBL_Puller_FromCouchApp);
     RequireTestCase(CBL_Puller_DatabaseValidation);
+    RequireTestCase(CBL_Pusher_NonExistentServer);
+    RequireTestCase(CBL_Puller_NonExistentServer);
     RequireTestCase(CBLPuller_DocIDs);
     RequireTestCase(ParseReplicatorProperties);
 }

--- a/Source/CBL_Replicator.m
+++ b/Source/CBL_Replicator.m
@@ -350,8 +350,8 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 #endif
     
     _online = NO;
-    if ([NSClassFromString(@"CBL_URLProtocol") handlesURL: _remote]) {
-        [self goOnline];    // local-to-local replication
+    if (!_continuous || [NSClassFromString(@"CBL_URLProtocol") handlesURL: _remote]) {
+        [self goOnline];    // non-continuous or local-to-local replication
     } else {
         // Start reachability checks. (This creates another ref cycle, because
         // the block also retains a ref to self. Cycle is also broken in -stopped.)


### PR DESCRIPTION
Stop the non-continuous replicator when the host is not reachable and
post progress changes to notify the stop status appropriately.
