### PR TITLE
Fix awakeFromInitializer document assertion fail (#521)

### DIFF
--- a/Source/API/CBLModel.m
+++ b/Source/API/CBLModel.m
@@ -30,8 +30,9 @@
 @dynamic type;
 
 
-- (instancetype) initWithDocument: (CBLDocument*)document
+- (instancetype) initWithDocument: (CBLDocument*)document orDatabase:(CBLDatabase *)database
 {
+    NSParameterAssert(document || database);
     self = [super init];
     if (self) {
         if (document) {
@@ -39,8 +40,9 @@
             self.document = document;
             [self didLoadFromDocument];
         } else {
+            LogTo(CBLModel, @"%@ initWithDatabase: %@", self.class, database);
             _isNew = true;
-            LogTo(CBLModel, @"%@ init", self);
+            self.database = database;
         }
         [self awakeFromInitializer];
     }
@@ -55,8 +57,7 @@
         return nil;
     }
 
-    CBLModel *model = [[self alloc] initWithDocument:nil];
-    model.database = database;
+    CBLModel *model = [[self alloc] initWithDocument:nil orDatabase:database];
     return model;
 }
 
@@ -70,7 +71,7 @@
                  self, document, model);
     } else if (self != [CBLModel class]) {
         // If invoked on a subclass of CBLModel, create an instance of that subclass:
-        model = [[self alloc] initWithDocument: document];
+        model = [[self alloc] initWithDocument: document orDatabase:nil];
     } else {
         // If invoked on CBLModel itself, ask the factory to instantiate the appropriate class:
         model = [document.database.modelFactory modelForDocument: document];

--- a/Source/API/CBLModel_Internal.h
+++ b/Source/API/CBLModel_Internal.h
@@ -25,7 +25,8 @@
 @property (readwrite) bool needsSave;
 @property (readonly) NSDictionary* currentProperties;
 
-- (instancetype) initWithDocument: (CBLDocument*)document NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithDocument: (CBLDocument*)document
+                       orDatabase: (CBLDatabase*)database NS_DESIGNATED_INITIALIZER;
 
 - (id) getValueOfProperty: (NSString*)property ofClass: (Class)klass;
 - (void) cacheValue: (id)value ofProperty: (NSString*)property changed: (BOOL)changed;

--- a/Unit-Tests/Model_Tests.m
+++ b/Unit-Tests/Model_Tests.m
@@ -63,6 +63,10 @@
 @end
 
 
+@interface CBL_TestAwakeInitModel : CBLModel
+@property BOOL didAwake;
+@end
+
 #pragma mark - TEST CASES:
 
 
@@ -525,9 +529,14 @@
 }
 
 
+- (void) test00_AwakeFromInitializer {
+    CBL_TestAwakeInitModel* model = [CBL_TestAwakeInitModel modelForNewDocumentInDatabase: db];
+    Assert(model.didAwake);
+    NSError *error;
+    Assert([model save: &error], @"Save of new model object failed: %@", error);
+}
+
 @end
-
-
 
 
 @implementation TestModel
@@ -611,3 +620,15 @@
 }
 
 @end
+
+@implementation CBL_TestAwakeInitModel
+
+@dynamic didAwake;
+
+- (void) awakeFromInitializer {
+    self.didAwake = YES;
+}
+
+@end
+
+


### PR DESCRIPTION
* Not checking the existence of the document when the model is new.
* Include API_ModelAwakeFromInitializer unit test.

#521