### PR TITLE
Adding a way to set the type of a new document automatically

### DIFF
--- a/Source/API/CBLModel.m
+++ b/Source/API/CBLModel.m
@@ -58,6 +58,10 @@
     }
 
     CBLModel *model = [[self alloc] initWithDocument:nil orDatabase:database];
+    NSString *documentType = [database.modelFactory documentTypeForClass:[self class]];
+    if(documentType != nil){
+        model.type = documentType;
+    }
     return model;
 }
 

--- a/Source/API/CBLModelFactory.h
+++ b/Source/API/CBLModelFactory.h
@@ -37,6 +37,9 @@
 /** Looks up the CBLModel subclass that's been registered for a document type. */
 - (Class) classForDocumentType: (NSString*)type                         __attribute__((nonnull));
 
+/** Looks up the document type for which the argument class has ben registered. */
+- (NSString*)documentTypeForClass: (Class)modelClass                    __attribute__((nonnull));
+
 @end
 
 

--- a/Source/API/CBLModelFactory.m
+++ b/Source/API/CBLModelFactory.m
@@ -63,14 +63,9 @@ static CBLModelFactory* sSharedInstance;
 }
 
 - (NSString*)documentTypeForClass: (Class)modelClass {
-    NSString *type = nil;
-    for (NSString *key in _typeDict) {
-        if(modelClass == _typeDict[key]){
-            type = key;
-            break;
-        }
-    }
-    return type;
+    NSArray *keys = [_typeDict allKeysForObject:modelClass];
+    if(keys.count == 0) return nil;
+    else return keys[0];
 }
 
 - (Class) classForDocument: (CBLDocument*)document {

--- a/Source/API/CBLModelFactory.m
+++ b/Source/API/CBLModelFactory.m
@@ -62,6 +62,16 @@ static CBLModelFactory* sSharedInstance;
     return klass;
 }
 
+- (NSString*)documentTypeForClass: (Class)modelClass {
+    NSString *type = nil;
+    for (NSString *key in _typeDict) {
+        if(modelClass == _typeDict[key]){
+            type = key;
+            break;
+        }
+    }
+    return type;
+}
 
 - (Class) classForDocument: (CBLDocument*)document {
     NSString* type = [document propertyForKey: @"type"];

--- a/Unit-Tests/Model_Tests.m
+++ b/Unit-Tests/Model_Tests.m
@@ -226,6 +226,15 @@
                                             @"type": @"Dummy"}));
 }
 
+- (void)test00_AutoTypeProperty {
+    [db.modelFactory registerClass:[TestModel class] forDocumentType:@"Dummy"];
+    
+    TestModel *model = [TestModel modelForNewDocumentInDatabase:db];
+    AssertEqual(model.type, @"Dummy");
+    AssertEqual([model getValueOfProperty:@"type"], @"Dummy");
+    AssertEqual(model.propertiesToSave, (@{@"_id": model.document.documentID,
+                                           @"type": @"Dummy"}));
+}
 
 - (void) test00_DeleteProperty {
     NSArray* strings = @[@"fee", @"fie", @"foe", @"fum"];


### PR DESCRIPTION
 based on the mapping available in database.modelFactory

I tried to write a unit test for this new feature, but I couldn't run the unit tests to make sure it passes because I needed a signing identity. And I'm not sure it's actually correct because if you're doing real unit testing then database won't have a proper implementation of modelFactory that would be necessary for this test to pass.