### PR TITLE
Import last seq for replication when replace a db (#406)

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -446,7 +446,7 @@ static CBLManager* sInstance;
                                                toPath: dstAttachmentsPath
                                                 error: outError]) &&
             [db open: outError] &&
-            [db createLocalCheckpointDocument] &&
+            [db createLocalCheckpointDocument: outError] &&
             [db replaceUUIDs: outError];
 }
 

--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -446,6 +446,7 @@ static CBLManager* sInstance;
                                                toPath: dstAttachmentsPath
                                                 error: outError]) &&
             [db open: outError] &&
+            [db createLocalCheckpointDocument] &&
             [db replaceUUIDs: outError];
 }
 

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -248,7 +248,7 @@ extern const CBLChangesOptions kDefaultCBLChangesOptions;
     before importing. The old localUUID is used by replicators to get the local checkpoint 
     from the imported database in order to start replicating from from the current local 
     checkpoint of the imported database after importing. */
-- (BOOL) createLocalCheckpointDocument;
+- (BOOL) createLocalCheckpointDocument: (NSError**)outError;
 
 /** Returns local checkpoint document if it exists. Otherwise returns nil. */
 - (NSDictionary*) getLocalCheckpointDocument;

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -243,4 +243,17 @@ extern const CBLChangesOptions kDefaultCBLChangesOptions;
  (issue #364). */
 - (void) postNotification: (NSNotification*)notification;
 
+/** Create a local checkpoint document. This method is called only when importing or
+    replacing the database. The local checkpoint contains the old localUUID of the database 
+    before importing. The old localUUID is used by replicators to get the local checkpoint 
+    from the imported database in order to start replicating from from the current local 
+    checkpoint of the imported database after importing. */
+- (BOOL) createLocalCheckpointDocument;
+
+/** Returns local checkpoint document if it exists. Otherwise returns nil. */
+- (NSDictionary*) getLocalCheckpointDocument;
+
+// Local checkpoint document keys:
+#define kCBLDatabaseLocalCheckpoint_LocalUUID @"localUUID"
+
 @end

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -1608,13 +1608,11 @@ const CBLChangesOptions kDefaultCBLChangesOptions = {UINT_MAX, 0, NO, NO, YES};
 
 }
 
-- (BOOL) createLocalCheckpointDocument {
+- (BOOL) createLocalCheckpointDocument: (NSError**)outError {
     NSDictionary* document = @{ kCBLDatabaseLocalCheckpoint_LocalUUID : self.privateUUID };
-    NSError* error;
-    BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: &error];
-    if (!result) {
-        Warn(@"CBLDatabase: Could not create local checkpoint document with an error: %@", error);
-    }
+    BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: outError];
+    if (!result)
+        Warn(@"CBLDatabase: Could not create a local checkpoint document with an error: %@", *outError);
     return result;
 }
 

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -49,6 +49,7 @@ NSArray* CBL_RunloopModes;
 #define kTransactionMaxRetries 10
 #define kTransactionRetryDelay 0.050
 
+#define kLocalCheckpointDocId @"CBL_LocalCheckpoint"
 
 @implementation CBLDatabase (Internal)
 
@@ -1607,6 +1608,19 @@ const CBLChangesOptions kDefaultCBLChangesOptions = {UINT_MAX, 0, NO, NO, YES};
 
 }
 
+- (BOOL) createLocalCheckpointDocument {
+    NSDictionary* document = @{ kCBLDatabaseLocalCheckpoint_LocalUUID : self.privateUUID };
+    NSError* error;
+    BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: &error];
+    if (!result) {
+        Warn(@"CBLDatabase: Could not create local checkpoint document with an error: %@", error);
+    }
+    return result;
+}
+
+- (NSDictionary*) getLocalCheckpointDocument {
+    return [self existingLocalDocumentWithID:kLocalCheckpointDocId];
+}
 
 @end
 


### PR DESCRIPTION
* When replacing a database, creating a local checkpoint document containing the replacing database's localUUID (ID before getting replaced).

* When a replicator fetches remote checkpoint document to setup the last sequence info, if the last sequence is nil, try to get the imported last sequence which is obtained by using the localUUID stored in the local checkpoint document if it's available.

* Added test11_ReplicationWithReplacedDatabase unit test.

#406