### PR TITLE
Allow a doc to be updated more than once in a single transaction

### DIFF
--- a/Source/API/CBLDatabase.m
+++ b/Source/API/CBLDatabase.m
@@ -109,7 +109,7 @@ static id<CBLFilterCompiler> sFilterCompiler;
     BOOL external = NO;
     for (CBLDatabaseChange* change in changes) {
         // Notify the corresponding instantiated CBLDocument object (if any):
-        [[self _cachedDocumentWithID: change.documentID] revisionAdded: change];
+        [[self _cachedDocumentWithID: change.documentID] revisionAdded: change notify: YES];
         if (change.source != nil)
             external = YES;
     }

--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -158,7 +158,7 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
 
 
 // Notification from the CBLDatabase that a (current, winning) revision has been added
-- (void) revisionAdded: (CBLDatabaseChange*)change {
+- (void) revisionAdded: (CBLDatabaseChange*)change notify: (BOOL)notify {
     CBL_Revision* rev = change.winningRevision;
     if (!rev)
         return; // current revision didn't change
@@ -172,10 +172,12 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
     id<CBLDocumentModel> model = _modelObject; // strong reference to it
     [model document: self didChange: change];
 
-    NSNotification* n = [NSNotification notificationWithName: kCBLDocumentChangeNotification
-                                                      object: self
-                                                    userInfo: @{@"change": change}];
-    [[NSNotificationCenter defaultCenter] postNotification: n];
+    if (notify) {
+        NSNotification* n = [NSNotification notificationWithName: kCBLDocumentChangeNotification
+                                                          object: self
+                                                        userInfo: @{@"change": change}];
+        [[NSNotificationCenter defaultCenter] postNotification: n];
+    }
 }
 
 

--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -70,7 +70,9 @@
 - (instancetype) initWithDatabase: (CBLDatabase*)database
                        documentID: (NSString*)docID                 __attribute__((nonnull));
 - (CBLSavedRevision*) revisionFromRev: (CBL_Revision*)rev;
-- (void) revisionAdded: (CBLDatabaseChange*)change                 __attribute__((nonnull));
+- (void) revisionAdded: (CBLDatabaseChange*)change
+                notify: (BOOL)notify                                __attribute__((nonnull));
+- (void) forgetCurrentRevision;
 - (void) loadCurrentRevisionFrom: (CBLQueryRow*)row                 __attribute__((nonnull));
 - (CBLSavedRevision*) putProperties: (NSDictionary*)properties
                      prevRevID: (NSString*)prevID


### PR DESCRIPTION
This didn't use to work correctly because the CBLDocument's currentRevision didn't
update to the new revision after the first update; then the second update would use
an obsolete _rev and fail with a conflict.
Added code to inform the CBLDocument immediately, even during a transaction, but
prevent the change notification from being posted till the transaction ends.
Fixes #256