### PR TITLE
Fix continuous replication reachablity issue

### DIFF
--- a/Source/CBLInternal.h
+++ b/Source/CBLInternal.h
@@ -90,6 +90,7 @@
 - (void) reachabilityChanged: (CBLReachability*)host;
 - (BOOL) goOffline;
 - (BOOL) goOnline;
+- (void) goOnlineAfterDelay;
 - (BOOL) checkSSLServerTrust: (SecTrustRef)trust forHost: (NSString*)host port: (UInt16)port;
 #if DEBUG
 @property (readonly) BOOL savingCheckpoint;

--- a/Source/CBLInternal.h
+++ b/Source/CBLInternal.h
@@ -86,7 +86,7 @@
 - (void) databaseClosing;
 - (void) revisionFailed;    // subclasses call this if a transfer fails
 - (void) retry;
-- (void) retryOnlineAfterDelay;
+- (void) retryGoOnlineAfterDelay;
 
 - (void) reachabilityChanged: (CBLReachability*)host;
 - (BOOL) goOffline;

--- a/Source/CBLInternal.h
+++ b/Source/CBLInternal.h
@@ -86,11 +86,11 @@
 - (void) databaseClosing;
 - (void) revisionFailed;    // subclasses call this if a transfer fails
 - (void) retry;
+- (void) retryOnlineAfterDelay;
 
 - (void) reachabilityChanged: (CBLReachability*)host;
 - (BOOL) goOffline;
 - (BOOL) goOnline;
-- (void) goOnlineAfterDelay;
 - (BOOL) checkSSLServerTrust: (SecTrustRef)trust forHost: (NSString*)host port: (UInt16)port;
 #if DEBUG
 @property (readonly) BOOL savingCheckpoint;

--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -297,8 +297,11 @@ BOOL CBLIsOfflineError( NSError* error ) {
     NSString* domain = error.domain;
     NSInteger code = error.code;
     if ($equal(domain, NSURLErrorDomain))
-        return code == NSURLErrorDNSLookupFailed
-            || code == NSURLErrorNotConnectedToInternet
+        return code == NSURLErrorCannotFindHost
+        || code == NSURLErrorCannotConnectToHost
+        || code == NSURLErrorDNSLookupFailed
+        || code == NSURLErrorNetworkConnectionLost
+        || code == NSURLErrorNotConnectedToInternet
 #ifndef GNUSTEP
             || code == NSURLErrorInternationalRoamingOff
 #endif

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -271,7 +271,8 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     if (error) {
         if (CBLIsOfflineError(error)) {
             [self goOffline];
-            [self goOnlineAfterDelay];
+            if (continous)
+                [self retryOnlineAfterDelay];
         }
         
         if (!self.error)

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -272,7 +272,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
         if (CBLIsOfflineError(error)) {
             [self goOffline];
             if (continous)
-                [self retryOnlineAfterDelay];
+                [self retryGoOnlineAfterDelay];
         }
         
         if (!self.error)

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -269,9 +269,12 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     _changeTracker = nil;
     
     if (error) {
-        if (CBLIsOfflineError(error))
+        if (CBLIsOfflineError(error)) {
             [self goOffline];
-        else if (!self.error)
+            [self goOnlineAfterDelay];
+        }
+        
+        if (!self.error)
             self.error = error;
     }
     

--- a/Source/CBL_Replicator.m
+++ b/Source/CBL_Replicator.m
@@ -385,6 +385,8 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
     [self stopRemoteRequests];
     [NSObject cancelPreviousPerformRequestsWithTarget: self
                                              selector: @selector(retryIfReady) object: nil];
+    [NSObject cancelPreviousPerformRequestsWithTarget: self
+                                             selector: @selector(retryGoOnline) object: nil];
     if (_running && _asyncTaskCount == 0)
         [self stopped];
 }
@@ -435,6 +437,9 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 
 
 - (void) retryGoOnline {
+    [NSObject cancelPreviousPerformRequestsWithTarget: self
+                                             selector: @selector(retryGoOnline) object: nil];
+
     [self goOnline];
     if (_host)
         [self reachabilityChanged:_host];
@@ -461,9 +466,6 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 }
 
 - (BOOL) goOnline {
-    [NSObject cancelPreviousPerformRequestsWithTarget: self
-                                             selector: @selector(goOnline) object: nil];
-
     if (_online)
         return NO;
     LogTo(Sync, @"%@: Going online", self);

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -236,7 +236,7 @@
     NSInteger code = error.code;
     if ($equal(domain, NSPOSIXErrorDomain)) {
         // Map POSIX errors from CFStream to higher-level NSURLError ones:
-        if (code == ECONNREFUSED)
+        if (code == ECONNREFUSED || code == ENETDOWN || code == ENETUNREACH || code == ENOTCONN)
             error = [NSError errorWithDomain: NSURLErrorDomain
                                         code: NSURLErrorCannotConnectToHost
                                     userInfo: error.userInfo];
@@ -255,7 +255,8 @@
     }
 
     // If the error may be transient (flaky network, server glitch), retry:
-    if (!CBLIsPermanentError(error) && (_continuous || CBLMayBeTransientError(error))) {
+    if (!CBLIsPermanentError(error) && !CBLIsOfflineError(error) &&
+        (_continuous || CBLMayBeTransientError(error))) {
         NSTimeInterval retryDelay = kInitialRetryDelay * (1 << MIN(_retryCount, 16U));
         retryDelay = MIN(retryDelay, kMaxRetryDelay);
         ++_retryCount;

--- a/Unit-Tests/ChangeTracker_Tests.m
+++ b/Unit-Tests/ChangeTracker_Tests.m
@@ -139,6 +139,13 @@
 }
 
 
+- (void) test_ReachabilityError {
+    NSURL* url = [NSURL URLWithString: @"https://localhost:5999/db"];
+    CBLChangeTracker* tracker = [[CBLChangeTracker alloc] initWithDatabaseURL: url mode: kOneShot conflicts: NO lastSequence: 0 client: self];
+    [self run: tracker expectingError: [NSError errorWithDomain: NSURLErrorDomain code: NSURLErrorCannotConnectToHost userInfo: nil]];
+}
+
+
 - (void) test_CBLWebSocketChangeTracker_Auth {
     // This Sync Gateway database requires authentication to access at all.
     NSURL* url = [self remoteTestDBURL: @"cbl_auth_test"];


### PR DESCRIPTION
## Changes:

- Always try to bring the replication online first time regardless of the replicator mode

- When the replication is in the continuous mode and the protocol is not CBL_URLProtocol, start the reachability. The reachability is now responsible for 2 things when the host is reachable (Ignore not-reachable status, which could be false negative):

 (1) It checks if the host is reachable on an allowed network (based on the kCBLReplicatorOption_Network option value). If the host is reachable in a forbidden network, it will bring the replicator offline.

 (2) It triggers the replicator retry logic if the replication is already online. If the replicator is not online, it will bring the replicator online.

- When `ChangeTracker` or `CBLRemoteRequest` gets a `reachability` error, it will report the error immediately without retrying. Once the error gets propagated to the CBL_Replicator, the CBL_Replicator will bring the replicator offline manually and then it will try to bring it online after 5 mins.

- Expand CBLIsOfflineError to cover more `reachability` error codes.

## Note:
The reachability is still using to restrict the network access based on value set for kCBLReplicatorOption_Network option. This is not perfect as the reachability sometimes reports a wrong status. In another word, I'm ignoring this issue for now. To fix this we can set the NSMutableURLRequest's allowsCellularAccess property and CFStream's kCFStreamPropertyConnectionIsCellular property instead of using the reachability. However the solution is not completed as we are using CocoaAsycSocket for the WebSocket version of the ChangeTracker and we couldn't find a way to restrict the cellular network access.

#536