### PR TITLE
Add stale parameter support on view query requests

### DIFF
--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -204,6 +204,17 @@
     options->group = [self boolQuery: @"group"];
     options->content = [self contentOptions];
 
+    // Stale options (ok or update_after):
+    NSString *stale = [self query: @"stale"];
+    if (stale) {
+        if ([stale isEqualToString:@"ok"])
+            options->indexUpdateMode = kCBLUpdateIndexNever;
+        else if ([stale isEqualToString:@"update_after"])
+            options->indexUpdateMode = kCBLUpdateIndexAfter;
+        else
+            return nil;
+    }
+    
     // Handle 'keys' and 'key' options:
     NSError* error = nil;
     id keys = [self jsonQuery: @"keys" error: &error];


### PR DESCRIPTION
- Based on CouchDB spec (http://wiki.apache.org/couchdb/HTTP_view_API), the stale option can be 'ok' or 'update_after'.

- If there is no stale specified or if the view has never updated its index before (first time), the index will be updated first. The result will be queried and returned after the index is updated.

- If stale=ok is set, the view will not update its index and the result will be returned as is.

- If stale=update_after, the view will return the result and then update its index after.

#584