### PR TITLE
Reset _willUpdate at the top of the update method

### DIFF
--- a/Source/API/CBLQuery.m
+++ b/Source/API/CBLQuery.m
@@ -408,6 +408,8 @@
 
 
 - (void) update {
+    _willUpdate = NO;
+
     SequenceNumber lastSequence = self.database.lastSequenceNumber;
     if (_rows && _lastSequence >= lastSequence) {
         return; // db hasn't changed since last query
@@ -421,7 +423,6 @@
         return;
     }
 
-    _willUpdate = NO;
     _updateAgain = NO;
     _isUpdatingAtSequence = lastSequence;
     _lastUpdatedAt = CFAbsoluteTimeGetCurrent();


### PR DESCRIPTION
Adding a new document which will not get emitted prior to creating a live query object could cause the _lastSequence tracked by the live query object equal to the database lastsequence (e.g. both are one). This could happen easily during the first luanch of the app and the database is fresh.

When the above situation happens, _willUpdate flag will never get reset as the update method will return immedidately before the flag is reset due to an if check at the top. As a result, the live query stops updating itself when there are new documents added to the database as the databaseChanged: call back method will return immdiately when it sees _willUpdate flag = YES.

#542