### PR TITLE
Added CBLModel support for inverse relations [API CHANGE]

### DIFF
--- a/Source/API/CBLModel.h
+++ b/Source/API/CBLModel.h
@@ -107,6 +107,22 @@ NS_REQUIRES_PROPERTY_DEFINITIONS  // Don't let compiler auto-synthesize properti
        ofProperty: (NSString*)property;
 
 
+/** Follows an _inverse_ relationship: returns the other models in the database that have a
+    property named `inverseProperty` that points to this object. For example, if model class
+    ListItem has a property 'list' that's a relation to a List model, then calling this method
+    on a List instance, with relation 'list', will return all the ListItems that refer to this List.
+
+    Specifically, what this does is run a CBLQuery that finds documents whose `relation`
+    property value is equal to the document ID of the receiver. (And if `fromClass` is given,
+    it's restricted to documents whose `type` property is one of the ones mapped to `fromClass`
+    in the CBLModelFactory.)
+    @param relation  The property name to look at
+    @param fromClass  (Optional) The CBLModel subclass to restrict the search to.
+    @return  An array of model objects found, or nil on error. */
+- (NSArray*) findInverseOfRelation: (NSString*)relation
+                         fromClass: (nullable Class)fromClass;
+
+
 /** The names of all attachments (array of strings).
     This reflects unsaved changes made by creating or deleting attachments. */
 @property (readonly, nullable) NSArray* attachmentNames;
@@ -187,6 +203,21 @@ NS_REQUIRES_PROPERTY_DEFINITIONS  // Don't let compiler auto-synthesize properti
     In general you'll find it easier to implement the '+propertyItemClass' method(s) rather
     than overriding this one. */
 + (nullable Class) itemClassForArrayProperty: (NSString*)property;
+
+/** General method for declaring the that an array-of-models-valued property is a computed inverse
+    of a relation from another class.
+    Given the property name, the override should return the name of the relation property in the
+    item class (the one returned by +itemClassForArrayProperty:). If it returns nil, then this
+    property will be interpreted as an explicit JSON property whose value is an array of strings
+    corresponding to the other models.
+ 
+    The default implementation of this method checks for the existence of a class method with
+    selector of the form +propertyInverseRelation where 'property' is replaced by the actual
+    property name. If such a method exists it is called, and must return a string.
+ 
+    In general you'll find it easier to implement the '+propertyInverseRelation' method(s) rather
+    than overriding this one. */
++ (nullable NSString*) inverseRelationForArrayProperty: (NSString*)property;
 
 /** The type of document. This is optional, but is commonly used in document databases 
     to distinguish different types of documents. CBLModelFactory can use this property to 

--- a/Source/API/CBLModelArray.h
+++ b/Source/API/CBLModelArray.h
@@ -26,14 +26,14 @@
 /** Initializes a model array from an array of document ID strings.
     Returns nil if docIDs contains items that are non-strings, or invalid document IDs. */
 - (instancetype) initWithOwner: (CBLModel*)owner
-                      property: (NSString*)property
-                     itemClass: (Class)itemClass
+                      property: (nullable NSString*)property
+                     itemClass: (nullable Class)itemClass
                         docIDs: (NSArray*)docIDs;
 
 /** Initializes a model array from an array of CBLModels. */
 - (instancetype) initWithOwner: (CBLModel*)owner
-                      property: (NSString*)property
-                     itemClass: (Class)itemClass
+                      property: (nullable NSString*)property
+                     itemClass: (nullable Class)itemClass
                         models: (NSArray*)models;
 
 @property (readonly) NSArray* docIDs;

--- a/Source/API/CBLModelFactory.h
+++ b/Source/API/CBLModelFactory.h
@@ -29,7 +29,7 @@
     If the document's modelObject property is set, it returns that value.
     If the document's "type" property has been registered, instantiates the associated class.
     Otherwise returns nil. */
-- (id) modelForDocument: (CBLDocument*)document                         __attribute__((nonnull));
+- (id) modelForDocument: (CBLDocument*)document;
 
 /** Associates a value of the "type" property with a CBLModel subclass.
     When a document with this type value is loaded as a model, the given subclass will be
@@ -39,18 +39,21 @@
     @param classOrName  Either a CBLModel subclass, or its class name as an NSString.
     @param type  The value value of a document's "type" property that should indicate this class. */
 - (void) registerClass: (id)classOrName
-       forDocumentType: (NSString*)type                                 __attribute__((nonnull(2)));
+       forDocumentType: (NSString*)type;
 
 /** Returns the appropriate CBLModel subclass for this document.
     The default implementation just passes the document's "type" property value to -classForDocumentType:, but subclasses could override this to use different properties (or even the document ID) to decide. */
-- (nullable Class) classForDocument: (CBLDocument*)document                      __attribute__((nonnull));
+- (nullable Class) classForDocument: (CBLDocument*)document;
 
 /** Looks up the CBLModel subclass that's been registered for a document type. */
-- (Class) classForDocumentType: (NSString*)type                         __attribute__((nonnull));
+- (Class) classForDocumentType: (NSString*)type;
 
 /** Looks up the document type for which the given class has been registered.
     If it's unregistered, or registered with multiple types, returns nil. */
-- (nullable NSString*) documentTypeForClass: (Class)modelClass                   __attribute__((nonnull));
+- (nullable NSString*) documentTypeForClass: (Class)modelClass;
+
+/** Looks up the document types for which the given class has been registered. */
+- (NSArray*) documentTypesForClass: (Class)modelClass;
 
 @end
 

--- a/Source/API/CBLModelFactory.m
+++ b/Source/API/CBLModelFactory.m
@@ -21,6 +21,7 @@
 @implementation CBLModelFactory
 {
     NSMutableDictionary* _typeDict;
+    NSMutableDictionary* _queryBuilders;
 }
 
 
@@ -62,13 +63,16 @@ static CBLModelFactory* sSharedInstance;
     return klass;
 }
 
-- (NSString*) documentTypeForClass: (Class)modelClass {
+- (NSArray*) documentTypesForClass: (Class)modelClass {
     NSArray *keys = [_typeDict allKeysForObject:modelClass];
     if (keys.count == 0)
         keys = [_typeDict allKeysForObject: NSStringFromClass(modelClass)];
-    if (keys.count != 1)
-        return nil; // Either not found, or ambiguous (multiple types registered)
-    return keys.firstObject;
+    return keys;
+}
+
+- (NSString*) documentTypeForClass: (Class)modelClass {
+    NSArray *keys = [self documentTypesForClass: modelClass];
+    return keys.count == 1 ? keys.firstObject : nil;
 }
 
 - (Class) classForDocument: (CBLDocument*)document {
@@ -83,6 +87,25 @@ static CBLModelFactory* sSharedInstance;
         return model;
     return [[self classForDocument: document] modelForDocument: document];
 }
+
+
+- (void) setQueryBuilder: (CBLQueryBuilder*)builder
+                forClass: (Class)klass
+                property: (NSString*)property
+{
+    id key = [[NSArray alloc] initWithObjects: property, klass, nil];  // klass might be nil
+    if (!_queryBuilders)
+        _queryBuilders = [[NSMutableDictionary alloc] init];
+    _queryBuilders[key] = builder;
+}
+
+- (CBLQueryBuilder*) queryBuilderForClass: (Class)klass
+                                 property: (NSString*)property
+{
+    id key = [[NSArray alloc] initWithObjects: property, klass, nil];  // klass might be nil
+    return _queryBuilders[key];
+}
+
 
 
 @end

--- a/Source/API/CBLQuery.m
+++ b/Source/API/CBLQuery.m
@@ -59,6 +59,7 @@
 
 // A nil view refers to 'all documents'
 - (instancetype) initWithDatabase: (CBLDatabase*)database view: (CBLView*)view {
+    Assert(database);
     self = [super init];
     if (self) {
         _database = database;

--- a/Source/API/CBLView.m
+++ b/Source/API/CBLView.m
@@ -346,7 +346,10 @@ static id<CBLViewCompiler> sCompiler;
         iterator = [_storage reducedQueryWithOptions: options status: outStatus];
     else
         iterator = [_storage regularQueryWithOptions: options status: outStatus];
-    LogTo(Query, @"Query %@: Returning iterator", _name);
+    if (iterator)
+        LogTo(Query, @"Query %@: Returning iterator", _name);
+    else
+        LogTo(Query, @"Query %@: Failed with status %d", _name, *outStatus);
     return iterator;
 }
 

--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -179,3 +179,12 @@ NSString* CBLKeyPathForQueryRow(NSString* keyPath); // for testing
                              pull: (BOOL)pull                       __attribute__((nonnull));
 @property (nonatomic, readonly) NSDictionary* properties;
 @end
+
+
+@interface CBLModelFactory ()
+- (CBLQueryBuilder*) queryBuilderForClass: (Class)klass
+                                 property: (NSString*)property;
+- (void) setQueryBuilder: (CBLQueryBuilder*)builder
+                forClass: (Class)klass
+                property: (NSString*)property;
+@end


### PR DESCRIPTION
* -[CBLModel findInverseOfRelation:fromClass:] explicitly computes an
  inverse relation.
* An array-of-models-valued property can be declared as a computed
  inverse relation by overriding +inverseRelationForArrayProperty or by
  implementing +{property}InverseRelation.
  
See the doc-comments and issue #606 for more details.

Fixes #606