### PR TITLE
Feature/issue #543 Implement a cookie store per replicator

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -634,6 +634,11 @@
 		792867D0178DE03E00248AF0 /* CBLJSFunction.m in Sources */ = {isa = PBXBuildFile; fileRef = 792867CC178DE03E00248AF0 /* CBLJSFunction.m */; };
 		792867D2178DE03E00248AF0 /* CBLJSViewCompiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 792867CF178DE03E00248AF0 /* CBLJSViewCompiler.m */; };
 		792867DE178E0AED00248AF0 /* CBLRegisterJSViewCompiler.h in Copy Extras */ = {isa = PBXBuildFile; fileRef = 792867D9178E021F00248AF0 /* CBLRegisterJSViewCompiler.h */; };
+		93D21AF01A955480000AD9AF /* CBLCookieStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D21AEE1A955480000AD9AF /* CBLCookieStorage.h */; };
+		93D21AF11A955480000AD9AF /* CBLCookieStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 93D21AEF1A955480000AD9AF /* CBLCookieStorage.m */; };
+		93D21AF21A958CEC000AD9AF /* CBLCookieStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 93D21AEF1A955480000AD9AF /* CBLCookieStorage.m */; };
+		93D21B021A9857A1000AD9AF /* CookieStorage_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93D21B011A9857A1000AD9AF /* CookieStorage_Tests.m */; };
+		93D21B031A9857A1000AD9AF /* CookieStorage_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93D21B011A9857A1000AD9AF /* CookieStorage_Tests.m */; };
 		AA1776BC1857AE4D00CB01A3 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA1776BB1857AE4D00CB01A3 /* CoreData.framework */; };
 		AA24F8E4184538AE0091D577 /* CBLDatabaseChange.h in Headers */ = {isa = PBXBuildFile; fileRef = 2776A62E16A9BCBC006FF199 /* CBLDatabaseChange.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA023B4614BCA94C008184BB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27F0745C11CD50A600E9A2AB /* Foundation.framework */; };
@@ -1485,6 +1490,9 @@
 		792867CF178DE03E00248AF0 /* CBLJSViewCompiler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLJSViewCompiler.m; sourceTree = "<group>"; };
 		792867D9178E021F00248AF0 /* CBLRegisterJSViewCompiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLRegisterJSViewCompiler.h; sourceTree = "<group>"; };
 		792867DA178E021F00248AF0 /* CBLRegisterJSViewCompiler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLRegisterJSViewCompiler.m; sourceTree = "<group>"; };
+		93D21AEE1A955480000AD9AF /* CBLCookieStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLCookieStorage.h; sourceTree = "<group>"; };
+		93D21AEF1A955480000AD9AF /* CBLCookieStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLCookieStorage.m; sourceTree = "<group>"; };
+		93D21B011A9857A1000AD9AF /* CookieStorage_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CookieStorage_Tests.m; sourceTree = "<group>"; };
 		AA1776B61857ADDB00CB01A3 /* CBLIncrementalStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLIncrementalStore.h; sourceTree = "<group>"; };
 		AA1776B71857ADDB00CB01A3 /* CBLIncrementalStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLIncrementalStore.m; sourceTree = "<group>"; };
 		AA1776BB1857AE4D00CB01A3 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
@@ -1761,6 +1769,7 @@
 				2740D8501A8C240500809EE0 /* Tokenizer_Test.mm */,
 				2740D8511A8C240500809EE0 /* GeoHash_Test.mm */,
 				2740D8521A8C240500809EE0 /* GeoIndex_Test.mm */,
+				93D21B011A9857A1000AD9AF /* CookieStorage_Tests.m */,
 				274E163119B90F420066CA5E /* TestData */,
 				276E68331A5C4511006D6EEB /* Server */,
 			);
@@ -2408,6 +2417,8 @@
 				27BDA81D181973EF00F27A11 /* CBLBulkDownloader.m */,
 				27103F8114E9CE4400DF7209 /* CBLReachability.h */,
 				27103F8214E9CE4400DF7209 /* CBLReachability.m */,
+				93D21AEE1A955480000AD9AF /* CBLCookieStorage.h */,
+				93D21AEF1A955480000AD9AF /* CBLCookieStorage.m */,
 			);
 			name = Networking;
 			sourceTree = "<group>";
@@ -2594,6 +2605,7 @@
 				27486F2B1A606C76008D94F0 /* CBLJSONReader.h in Headers */,
 				2762AB5818D36F1B00649D47 /* CBLReplication+Transformation.h in Headers */,
 				2753157A14ACEFC90065964D /* HTTPAuthenticationRequest.h in Headers */,
+				93D21AF01A955480000AD9AF /* CBLCookieStorage.h in Headers */,
 				272401BE1860CBE00080E082 /* GCDAsyncSocket.h in Headers */,
 				2753157E14ACEFC90065964D /* HTTPConnection.h in Headers */,
 				2753158214ACEFC90065964D /* HTTPLogging.h in Headers */,
@@ -3422,6 +3434,7 @@
 				272AA81A1A48A023004B8D55 /* Model_Tests.m in Sources */,
 				27486F3D1A608BC6008D94F0 /* CBLJSONValidator.m in Sources */,
 				272AA8751A49EE5D004B8D55 /* Multipart_Tests.m in Sources */,
+				93D21B021A9857A1000AD9AF /* CookieStorage_Tests.m in Sources */,
 				2764D2CA1A5F2418005AC95A /* CBLIncrementalStore.m in Sources */,
 				272AA81E1A48A8BF004B8D55 /* Replication_Tests.m in Sources */,
 				272AA81C1A48A301004B8D55 /* QueryBuilder_Tests.m in Sources */,
@@ -3446,6 +3459,7 @@
 				27EF7F9C1912EB5200A327B9 /* CBLForestBridge.mm in Sources */,
 				270B3E111489382F00E0A926 /* CBLDatabase+Internal.m in Sources */,
 				270B3E121489382F00E0A926 /* CBL_Body.m in Sources */,
+				93D21AF11A955480000AD9AF /* CBLCookieStorage.m in Sources */,
 				2764D2B91A5F054D005AC95A /* CBLChangeMatcher.m in Sources */,
 				27DF57B219C782DE00FFB075 /* MYReadWriteLock.m in Sources */,
 				270B3E131489382F00E0A926 /* CBL_Server.m in Sources */,
@@ -3573,6 +3587,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				272AA8601A49D4A9004B8D55 /* BlobStore_Tests.m in Sources */,
+				93D21B031A9857A1000AD9AF /* CookieStorage_Tests.m in Sources */,
 				2764D2B21A5E240D005AC95A /* JSON_Tests.m in Sources */,
 				272AA8661A49D95B004B8D55 /* ReplicatorInternal_Tests.m in Sources */,
 				273FA2BC1A92683C002B413B /* DatabaseEncryption_Tests.m in Sources */,
@@ -3690,6 +3705,7 @@
 				270F5707156AE0BF000FEB8F /* CBLAuthorizer.m in Sources */,
 				27ED8632157D0FC600712B33 /* CBLDocument.m in Sources */,
 				2762AB5A18D36F1B00649D47 /* CBLReplication+Transformation.m in Sources */,
+				93D21AF21A958CEC000AD9AF /* CBLCookieStorage.m in Sources */,
 				27DA42FA158E66DD00F9E7B5 /* CBLRevision.m in Sources */,
 				27A7552D1A8BD715008BCD4D /* CBLQueryEnumerator.m in Sources */,
 				274C6C271A3F838500F9BDF7 /* CBLReduceFuncs.m in Sources */,

--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -1742,6 +1742,7 @@
 			children = (
 				272AA85E1A49D4A9004B8D55 /* BlobStore_Tests.m */,
 				272AA8611A49D5B0004B8D55 /* ChangeTracker_Tests.m */,
+				93D21B011A9857A1000AD9AF /* CookieStorage_Tests.m */,
 				272AA8571A48ECD4004B8D55 /* DatabaseInternal_Tests.m */,
 				2700358F1A44E9270015B9F4 /* Database_Tests.m */,
 				273FA2BA1A92683C002B413B /* DatabaseEncryption_Tests.m */,
@@ -1769,7 +1770,6 @@
 				2740D8501A8C240500809EE0 /* Tokenizer_Test.mm */,
 				2740D8511A8C240500809EE0 /* GeoHash_Test.mm */,
 				2740D8521A8C240500809EE0 /* GeoIndex_Test.mm */,
-				93D21B011A9857A1000AD9AF /* CookieStorage_Tests.m */,
 				274E163119B90F420066CA5E /* TestData */,
 				276E68331A5C4511006D6EEB /* Server */,
 			);

--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -526,7 +526,7 @@ static CBLManager* sInstance;
     return CBLRemoveFileIfExists(db.dir, outError) &&
             [fmgr copyItemAtPath: databaseDir toPath: db.dir error: outError] &&
             [db open: outError] &&
-            [db createLocalCheckpointDocument: outError] &&
+            [db saveLocalUUIDInLocalCheckpointDocument: outError] &&
             [db replaceUUIDs: outError];
 }
 

--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -23,6 +23,7 @@
 #import "CBL_Server.h"
 #import "CBLPersonaAuthorizer.h"
 #import "CBLFacebookAuthorizer.h"
+#import "CBLCookieStorage.h"
 #import "MYBlockUtils.h"
 #import "MYURLUtils.h"
 
@@ -47,6 +48,7 @@ NSString* const kCBLReplicationChangeNotification = @"CBLReplicationChange";
     NSSet* _pendingDocIDs;
     bool _started;
     CBL_Replicator* _bg_replicator;       // ONLY used on the server thread
+    NSMutableArray* _pendingCookies;
 }
 
 
@@ -209,16 +211,26 @@ NSString* const kCBLReplicationChangeNotification = @"CBLReplicationChange";
         Warn(@"%@: Could not create cookie from parameters", self);
         return;
     }
-    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie: cookie];
+
+    if (_bg_replicator)
+        [_bg_replicator.cookieStorage setCookie: cookie];
+    else {
+        if (!_pendingCookies)
+            _pendingCookies = [NSMutableArray array];
+        [_pendingCookies addObject: cookie];
+    }
 }
 
 
 -(void) deleteCookieNamed: (NSString*)name {
-    NSArray* cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL: _remoteURL];
+    NSArray* cookies = [_bg_replicator.cookieStorage cookiesForURL: _remoteURL];
     for (NSHTTPCookie* cookie in cookies) {
         if ([cookie.name isEqualToString: name]) {
-            [[NSHTTPCookieStorage sharedHTTPCookieStorage] deleteCookie: cookie];
-            return;
+            if (_bg_replicator)
+                [_bg_replicator.cookieStorage deleteCookie: cookie];
+            else
+                [_pendingCookies removeObject: cookie];
+            break;
         }
     }
 }
@@ -447,6 +459,12 @@ NSString* const kCBLReplicationChangeNotification = @"CBLReplicationChange";
     }
     if (auth)
         repl.authorizer = auth;
+
+    if ([_pendingCookies count] > 0) {
+        for (NSHTTPCookie* cookie in _pendingCookies)
+            [repl.cookieStorage setCookie: cookie];
+        _pendingCookies = nil;
+    }
 
     CBLPropertiesTransformationBlock xformer = self.propertiesTransformationBlock;
     if (xformer) {

--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -10,6 +10,14 @@
 
 @class CBLDatabase;
 
+/** NSNotification posted when the cookies stored in the CBLCookieStorage instance have changed. 
+    The notification does not contain a userInfo dictionary */
+extern NSString* const CBLCookieStorageCookiesChangedNotification;
+
+/** NSNotification posted when the acceptance policy of the CBLCookieStorage instance has changed. 
+    The notification does not contain a userInfo dictionary. */
+extern NSString* const CBLCookieStorageAcceptPolicyChangedNotification;
+
 @interface CBLCookieStorage : NSObject
 
 /** All cookies that haven't been expired. */
@@ -29,11 +37,14 @@
 /** Returns an array of cookies orted according to a given set of sort descriptors. */
 - (NSArray*) sortedCookiesUsingDescriptors: (NSArray*)sortOrder;
 
-/** Stores a cookie in the cookie storage */
+/** Stores a cookie in the cookie storage. */
 - (void) setCookie: (NSHTTPCookie*)aCookie;
 
 /** Deletes a specified cookie from the cookie storage. */
 - (void) deleteCookie: (NSHTTPCookie*)aCookie;
+
+/** Deletes all cookies by name case-sensitively. */
+- (void) deleteCookiesNamed: (NSString*)name;
 
 /** Deletes all cookies from the cookie storage. */
 - (void) deleteAllCookies;

--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -38,7 +38,13 @@
 /** Deletes all cookies from the cookie storage. */
 - (void) deleteAllCookies;
 
-/** Close the storage, clear reference to the database */
-- (void) close;
+@end
+
+
+@interface CBLCookieStorage (NSURLRequestResponse)
+
+- (void) addCookieHeaderForRequest: (NSMutableURLRequest*)request;
+
+- (void) setCookieForResponse: (NSHTTPURLResponse*)response;
 
 @end

--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -1,0 +1,44 @@
+//
+//  CBLCookieStorage.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 2/18/15.
+//  Copyright (c) 2015 Couchbase, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class CBLDatabase;
+
+@interface CBLCookieStorage : NSObject
+
+/** All cookies that haven't been expired. */
+@property(readonly, copy) NSArray* cookies;
+
+/** The cookie storage’s cookie accept policy. 
+    Currently support NSHTTPCookieAcceptPolicyAlways (Default) and NSHTTPCookieAcceptPolicyNever. */
+@property NSHTTPCookieAcceptPolicy cookieAcceptPolicy;
+
+/** Creates a cookie storage that will store cookies inside the given database as a local document 
+    referenced by a unique storage key. */
+- (instancetype) initWithDB: (CBLDatabase*)db storageKey: (NSString*)storageKey;
+
+/** Returns an array of cookies that match with the given url. */
+- (NSArray*) cookiesForURL: (NSURL*)theURL;
+
+/** Returns an array of cookies orted according to a given set of sort descriptors. */
+- (NSArray*) sortedCookiesUsingDescriptors: (NSArray*)sortOrder;
+
+/** Stores a cookie in the cookie storage */
+- (void) setCookie: (NSHTTPCookie*)aCookie;
+
+/** Deletes a specified cookie from the cookie storage. */
+- (void) deleteCookie: (NSHTTPCookie*)aCookie;
+
+/** Deletes all cookies from the cookie storage. */
+- (void) deleteAllCookies;
+
+/** Close the storage, clear reference to the database */
+- (void) close;
+
+@end

--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -14,10 +14,6 @@
     The notification does not contain a userInfo dictionary */
 extern NSString* const CBLCookieStorageCookiesChangedNotification;
 
-/** NSNotification posted when the acceptance policy of the CBLCookieStorage instance has changed. 
-    The notification does not contain a userInfo dictionary. */
-extern NSString* const CBLCookieStorageAcceptPolicyChangedNotification;
-
 @interface CBLCookieStorage : NSObject
 
 /** All cookies that haven't been expired. */
@@ -54,8 +50,8 @@ extern NSString* const CBLCookieStorageAcceptPolicyChangedNotification;
 
 @interface CBLCookieStorage (NSURLRequestResponse)
 
-- (void) addCookieHeaderForRequest: (NSMutableURLRequest*)request;
+- (void) addCookieHeaderToRequest: (NSMutableURLRequest*)request;
 
-- (void) setCookieForResponse: (NSHTTPURLResponse*)response;
+- (void) setCookieFromResponse: (NSHTTPURLResponse*)response;
 
 @end

--- a/Source/CBLCookieStorage.m
+++ b/Source/CBLCookieStorage.m
@@ -1,0 +1,345 @@
+//
+//  CBLCookieStorage.m
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 2/18/15.
+//  Copyright (c) 2015 Couchbase, Inc. All rights reserved.
+//
+
+#import "CBLCookieStorage.h"
+#import "CBLDatabase.h"
+#import "CBLMisc.h"
+#import "Logging.h"
+
+
+#define kLocalDocKeyPrefix @"cbl_cookie_storage"
+#define kLocalDocCookiesKey @"cookies"
+
+@interface CBLCookieStorage ()
+- (NSString*) localDocKey;
+- (void) loadCookies;
+- (BOOL) deleteCookie: (NSHTTPCookie*)aCookie outIndex: (NSUInteger*)outIndex;
+- (BOOL) saveCookies: (NSError **)error;
+- (BOOL) isExpiredCookie: (NSHTTPCookie*)cookie;
+- (BOOL) isDomainMatchedBetweenCookie: (NSHTTPCookie*)cookie andUrl: (NSURL*)url;
+- (BOOL) isPathMatchedBetweenCookie: (NSHTTPCookie*)cookie andUrl: (NSURL*)url;
+@end
+
+
+@implementation CBLCookieStorage
+{
+    NSMutableArray* _cookies;
+    CBLDatabase* _db;
+    NSString* _storageKey;
+}
+
+@synthesize cookieAcceptPolicy = _cookieAcceptPolicy;
+
+- (instancetype) initWithDB: (CBLDatabase*)db storageKey: (NSString*)storageKey {
+    self = [super init];
+    if (self) {
+        Assert(db != nil, @"database cannot be nil.");
+        Assert(storageKey != nil, @"storageKey cannot be nil.");
+
+        _db = db;
+        _storageKey = storageKey;
+
+        self.cookieAcceptPolicy = NSHTTPCookieAcceptPolicyAlways;
+
+        [self loadCookies];
+    }
+    return self;
+}
+
+
+- (NSArray*)cookies {
+     NSMutableArray *cookies = [NSMutableArray array];
+    [_cookies enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL* stop) {
+        NSHTTPCookie* cookie = (NSHTTPCookie*)obj;
+        if (![self isExpiredCookie: cookie]) {
+            [cookies addObject: cookie];
+        }
+    }];
+    return cookies;
+}
+
+
+- (NSArray*) cookiesForURL: (NSURL*)url {
+    if (!url)
+        return nil;
+
+    NSMutableArray* cookies = [NSMutableArray array];
+    [_cookies enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL* stop) {
+        NSHTTPCookie* cookie = (NSHTTPCookie*)obj;
+
+        // Check whether the cookie is expired:
+        if ([self isExpiredCookie: cookie])
+            return;
+
+        // NOTE:
+        // From https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSHTTPCookie_Class/index.html :
+        // NSHTTPCookiePort : An NSString object containing comma-separated integer values specifying
+        // the ports for the cookie. Only valid for Version 1 cookies or later. The default value is
+        // an empty string (""). This cookie attribute is optional.
+        //
+        // However, there are a few discrepancies based on a test result as of 02/23/2015:
+        // 1. Setting NSHTTPCookiePort also has effect on cookies version 0.
+        // 2. Setting multiple values with comma-separated doesn't work. Only the first value is
+        //    accepted.
+        // 3. Setting to an empty string ("") results to a port number 0.
+        //
+        // So we are maintaining the same behaviors as what we have seen in the test result.
+        //
+        // If the cookie has no port list this method returns nil and the cookie will be sent
+        // to any port. Otherwise, the cookie is only sent to ports specified in the port list.
+        if ([cookie.portList count] > 0 && ![cookie.portList containsObject: url.port])
+            return;
+
+        // If a cookie is secure, it will be sent to only the secure urls:
+        NSString* urlScheme = [url.scheme lowercaseString];
+        if (cookie.isSecure && ![urlScheme isEqualToString: @"https"])
+            return;
+
+        //
+        // Matching Rules:
+        //
+        // Domain Matching Rules:
+        // 1. Matched if cookie domain == URL Host (Case insensitively).
+        // 2. Or if Cookie domain begins with '.' (global domain cookies), matched if the URL host
+        //    has the same domain as the cookie domain after dot. A url, which is a submodule of
+        //    the cookie domain is also counted.
+        //
+        // Path Matching Rules (After the domain and the host are matched):
+        // 1. Matched if the cookie path is a '/' or '<EMPTY>' string regardless of the url path.
+        // 2. Or matched if the cookie path is a prefix of the url path.
+        //
+        if ([self isDomainMatchedBetweenCookie: cookie andUrl: url] &&
+            [self isPathMatchedBetweenCookie: cookie andUrl: url])
+            [cookies addObject:cookie];
+    }];
+
+    return cookies;
+}
+
+
+- (NSArray*) sortedCookiesUsingDescriptors: (NSArray*)sortOrder {
+    NSMutableArray* cookies = [NSMutableArray array];
+    [_cookies enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL* stop) {
+        NSHTTPCookie* cookie = (NSHTTPCookie*)obj;
+        if (![self isExpiredCookie: cookie]) {
+            [cookies addObject:cookie];
+        }
+    }];
+
+    return [cookies sortedArrayUsingDescriptors: sortOrder];
+}
+
+
+- (void) setCookie: (NSHTTPCookie*)cookie {
+    if (!cookie)
+        return;
+
+    if (self.cookieAcceptPolicy == NSHTTPCookieAcceptPolicyNever)
+        return;
+
+    NSUInteger idx;
+    if ([self deleteCookie: cookie outIndex: &idx])
+        [_cookies insertObject:cookie atIndex:idx];
+    else
+        [_cookies addObject: cookie];
+
+    NSError* error;
+    if (![self saveCookies: &error])
+        Warn(@"%@: Cannot save the cookie %@ with an error : %@", self, cookie, error);
+}
+
+/*
+   The behavior of NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain and this method on 
+   NSHTTPCookieStorage are unclear. NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain doesn't
+   seem to be taking into consideration.
+- (void) setCookies: (NSArray*)cookies forURL: (NSURL*)theURL mainDocumentURL: (NSURL*)mainDocumentURL {
+    if (self.cookieAcceptPolicy == NSHTTPCookieAcceptPolicyNever)
+        return;
+
+    if (self.cookieAcceptPolicy == NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain &&
+        !mainDocumentURL)
+        return;
+
+    for (NSHTTPCookie* cookie in cookies) {
+        NSUInteger idx;
+        if ([self deleteCookie: cookie outIndex: &idx])
+            [_cookies insertObject:cookie atIndex:idx];
+        else
+            [_cookies addObject: cookie];
+    }
+
+    NSError* error;
+    if (![self saveCookies: &error])
+        Warn(@"%@: Cannot save cookies with an error : %@", self, error);
+}
+*/
+
+
+- (void) deleteCookie: (NSHTTPCookie*)aCookie {
+    if (!aCookie)
+        return;
+
+    // NOTE: There is discrepancy about path matching when observing NSHTTPCookieStore behaviors:
+    // 1. When adding or deleting a cookie, Comparing the cookie paths is case-insensitive.
+    // 2. When getting cookies for a url, Matching the cookie paths is case-sensitive.
+    [self deleteCookie:aCookie outIndex:nil];
+
+    NSError* error;
+    if (![self saveCookies: &error]) {
+        Warn(@"%@: Cannot save cookies with an error : %@", self, error);
+    }
+}
+
+
+- (void) deleteAllCookies {
+    [_cookies removeAllObjects];
+
+    NSError* error;
+    if (![self saveCookies: &error]) {
+        Warn(@"%@: Cannot save cookies with an error : %@", self, error);
+    }
+}
+
+
+- (void) close {
+    _db = nil;
+    _cookies = nil;
+}
+
+
+# pragma mark - Private
+
+
+- (NSString*) localDocKey {
+    return [NSString stringWithFormat: @"%@_%@", kLocalDocKeyPrefix, _storageKey];
+}
+
+
+- (BOOL) deleteCookie: (NSHTTPCookie*)aCookie outIndex: (NSUInteger*)outIndex {
+    __block NSInteger foundIndex = -1;
+    [_cookies enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL* stop) {
+        NSHTTPCookie* cookie = (NSHTTPCookie*)obj;
+        if ([aCookie.name caseInsensitiveCompare: cookie.name] == 0 &&
+            [aCookie.domain caseInsensitiveCompare: cookie.domain] == 0 &&
+            [aCookie.path caseInsensitiveCompare: cookie.path] == 0) {
+            foundIndex = idx;
+            *stop = YES;
+        }
+    }];
+
+    if (foundIndex >= 0)
+        [_cookies removeObjectAtIndex:foundIndex];
+
+    if (outIndex)
+        *outIndex = foundIndex;
+
+    return (foundIndex >= 0);
+}
+
+- (void) loadCookies {
+    NSString* key = [self localDocKey];
+    NSDictionary* doc = [_db existingLocalDocumentWithID: key];
+    NSArray* allCookies = [doc objectForKey: kLocalDocCookiesKey];
+
+    _cookies = [NSMutableArray array];
+    [allCookies enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL* stop) {
+        NSDictionary *props = [self cookiePropertiesFromJSONDocument: obj];
+        NSHTTPCookie* cookie = [NSHTTPCookie cookieWithProperties: props];
+        if (cookie)
+            [_cookies addObject: cookie];
+    }];
+}
+
+
+- (BOOL) saveCookies: (NSError **)error {
+    NSMutableArray* cookies = [NSMutableArray array];
+    [_cookies enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL* stop) {
+        NSHTTPCookie* cookie = (NSHTTPCookie*)obj;
+        if ([self shouldSaveCookie:cookie]) {
+            NSDictionary *props = [self JSONDocumentFromCookieProperties: cookie.properties];
+            [cookies addObject: props];
+        }
+    }];
+
+    NSString* docKey = [self localDocKey];
+    return [_db putLocalDocument: @{kLocalDocCookiesKey: cookies} withID: docKey error: error];
+}
+
+
+- (BOOL) isExpiredCookie: (NSHTTPCookie*)cookie {
+    NSDate* expDate = cookie.expiresDate;
+    return (expDate && [expDate compare: [NSDate date]] != NSOrderedDescending);
+}
+
+
+- (BOOL) shouldSaveCookie: (NSHTTPCookie*)cookie {
+    return !cookie.sessionOnly && cookie.expiresDate && ![self isExpiredCookie: cookie];
+}
+
+
+- (BOOL) isDomainMatchedBetweenCookie: (NSHTTPCookie*)cookie andUrl: (NSURL*)url {
+    NSString* urlHost = [url.host lowercaseString];
+    NSString* cookieDomain = [cookie.domain lowercaseString];
+
+    BOOL domainMatched = NO;
+    if ([cookieDomain hasPrefix: @"."]) { // global domain cookie.
+        NSString* domainAfterDot = [cookieDomain substringFromIndex: 1];
+        domainMatched = [urlHost hasSuffix: domainAfterDot];
+    } else
+        domainMatched = [urlHost isEqualToString: cookieDomain];
+
+    return domainMatched;
+}
+
+
+- (BOOL) isPathMatchedBetweenCookie: (NSHTTPCookie*)cookie andUrl: (NSURL*)url {
+    NSString* cookiePath = cookie.path;
+    if (cookiePath.length == 0 || [cookiePath isEqualToString: @"/"])
+        return YES;
+
+#ifdef GNUSTEP
+    NSString* urlPath = [url pathWithEscapes];
+#else
+    #ifdef __OBJC_GC__
+    NSString* urlPath = NSMakeCollectable(CFURLCopyPath((CFURLRef)url));
+    #else
+    NSString* urlPath = (__bridge_transfer NSString *)CFURLCopyPath((__bridge CFURLRef)url);
+    #endif
+#endif
+
+    if (![urlPath hasPrefix: cookiePath])
+        return NO;
+
+    BOOL matched =
+        (urlPath.length == cookiePath.length) ||
+        [urlPath characterAtIndex: cookiePath.length -
+            ([cookiePath hasSuffix: @"/"] ? 1 : 0)] == '/';
+    return matched;
+}
+
+
+- (NSDictionary*) JSONDocumentFromCookieProperties: (NSDictionary*)props {
+    if (props[NSHTTPCookieExpires]) {
+        NSMutableDictionary* newProps = [NSMutableDictionary dictionaryWithDictionary: props];
+        newProps[NSHTTPCookieExpires] = [CBLJSON JSONObjectWithDate: props[NSHTTPCookieExpires]];
+        props = newProps;
+    }
+    return props;
+}
+
+
+- (NSDictionary*) cookiePropertiesFromJSONDocument: (NSDictionary*)props {
+    if (props[NSHTTPCookieExpires]) {
+        NSMutableDictionary* newProps = [NSMutableDictionary dictionaryWithDictionary: props];
+        newProps[NSHTTPCookieExpires] = [CBLJSON dateWithJSONObject: props[NSHTTPCookieExpires]];
+        props = newProps;
+    }
+    return props;
+}
+
+@end

--- a/Source/CBLCookieStorage.m
+++ b/Source/CBLCookieStorage.m
@@ -206,7 +206,7 @@
 }
 
 
-- (void) close {
+- (void) dealloc {
     _db = nil;
     _cookies = nil;
 }
@@ -340,6 +340,28 @@
         props = newProps;
     }
     return props;
+}
+
+@end
+
+@implementation CBLCookieStorage (NSURLRequestResponse)
+
+- (void) addCookieHeaderForRequest: (NSMutableURLRequest*)request {
+    request.HTTPShouldHandleCookies = NO;
+    NSArray* cookies = [self cookiesForURL: request.URL];
+    if ([cookies count] > 0) {
+        NSDictionary* cookieHeaders = [NSHTTPCookie requestHeaderFieldsWithCookies: cookies];
+        [cookieHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+            [request setValue:value forHTTPHeaderField:key];
+        }];
+    }
+}
+
+- (void) setCookieForResponse: (NSHTTPURLResponse*)response {
+    NSArray* cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:
+                        response.allHeaderFields forURL: response.URL];
+    for (NSHTTPCookie* cookie in cookies)
+        [self setCookie: cookie];
 }
 
 @end

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -149,12 +149,19 @@ extern NSArray* CBL_RunloopModes;
  (issue #364). */
 - (void) postNotification: (NSNotification*)notification;
 
-/** Create a local checkpoint document. This method is called only when importing or
-    replacing the database. The local checkpoint contains the old localUUID of the database 
-    before importing. The old localUUID is used by replicators to get the local checkpoint 
-    from the imported database in order to start replicating from from the current local 
-    checkpoint of the imported database after importing. */
-- (BOOL) createLocalCheckpointDocument: (NSError**)outError;
+/** Save current local uuid into the local checkpoint document. This method is called only
+    when importing or replacing the database. The old localUUID is used by replicators 
+    to get the local checkpoint from the imported database in order to start replicating 
+    from from the current local checkpoint of the imported database after importing. */
+- (BOOL) saveLocalUUIDInLocalCheckpointDocument: (NSError**)outError;
+
+/** Put a property with a given key and value into the local checkpoint document. */
+- (BOOL) putLocalCheckpointDocumentWithKey: (NSString*)key
+                                     value:(id)value
+                                  outError: (NSError**)outError;
+
+/** Returns a property value specifiec by the key from the local checkpoint document. */
+- (id) getLocalCheckpointDocumentPropertyValueForKey: (NSString*)key;
 
 /** Returns local checkpoint document if it exists. Otherwise returns nil. */
 - (NSDictionary*) getLocalCheckpointDocument;

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -575,17 +575,35 @@ static BOOL sAutoCompact = YES;
     }];
 }
 
+- (BOOL) saveLocalUUIDInLocalCheckpointDocument: (NSError**)outError {
+    return [self putLocalCheckpointDocumentWithKey: kCBLDatabaseLocalCheckpoint_LocalUUID
+                                             value: self.privateUUID
+                                          outError: outError];
+}
 
-    - (BOOL) createLocalCheckpointDocument: (NSError**)outError {
-    NSDictionary* document = @{ kCBLDatabaseLocalCheckpoint_LocalUUID : self.privateUUID };
+- (BOOL) putLocalCheckpointDocumentWithKey: (NSString*)key
+                                     value:(id)value
+                                  outError: (NSError**)outError {
+    if (key == nil || value == nil)
+        return NO;
+
+    NSMutableDictionary* document = [NSMutableDictionary dictionaryWithDictionary:
+                                        [self getLocalCheckpointDocument]];
+    document[key] = value;
     BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: outError];
     if (!result)
         Warn(@"CBLDatabase: Could not create a local checkpoint document with an error: %@", *outError);
     return result;
 }
 
+
 - (NSDictionary*) getLocalCheckpointDocument {
-    return [self existingLocalDocumentWithID:kLocalCheckpointDocId];
+    return [self existingLocalDocumentWithID: kLocalCheckpointDocId];
+}
+
+
+- (id) getLocalCheckpointDocumentPropertyValueForKey: (NSString*)key {
+    return [[self getLocalCheckpointDocument] objectForKey: key];
 }
 
 

--- a/Source/CBLRemoteRequest.h
+++ b/Source/CBLRemoteRequest.h
@@ -10,6 +10,8 @@
 @protocol CBLAuthorizer, CBLRemoteRequestDelegate;
 
 
+@class CBLCookieStorage;
+
 /** The signature of the completion block called by a CBLRemoteRequest.
     @param result  On success, a 'result' object; by default this is the CBLRemoteRequest iself, but subclasses may return something else. On failure, this will likely be nil.
     @param error  The error, if any, else nil. */
@@ -29,6 +31,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
     @protected
     NSMutableURLRequest* _request;
     id<CBLAuthorizer> _authorizer;
+    CBLCookieStorage* _cookieStorage;
     id<CBLRemoteRequestDelegate> _delegate;
     CBLRemoteRequestCompletionBlock _onCompletion;
     NSURLConnection* _connection;
@@ -49,6 +52,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
 @property NSTimeInterval timeoutInterval;
 @property (strong, nonatomic) id<CBLAuthorizer> authorizer;
 @property (strong, nonatomic) id<CBLRemoteRequestDelegate> delegate;
+@property (strong, nonatomic) CBLCookieStorage* cookieStorage;
 
 /** Applies GZip compression to the request body if appropriate. */
 - (BOOL) compressBody;

--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -109,7 +109,7 @@
     if (_cookieStorage != cookieStorage) {
         _cookieStorage = cookieStorage;
         if (_request.HTTPShouldHandleCookies) {
-            [_cookieStorage addCookieHeaderForRequest: _request];
+            [_cookieStorage addCookieHeaderToRequest: _request];
         }
     }
 }
@@ -330,7 +330,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust) {
     _responseHeaders = ((NSHTTPURLResponse*)response).allHeaderFields;
 
     if (_cookieStorage)
-        [_cookieStorage setCookieForResponse: (NSHTTPURLResponse*)response];
+        [_cookieStorage setCookieFromResponse: (NSHTTPURLResponse*)response];
 
     LogTo(RemoteRequest, @"%@: Got response, status %d", self, _status);
     if (_status == 401) {

--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -25,6 +25,7 @@
 #import "Test.h"
 #import "MYURLUtils.h"
 #import "GTMNSData+zlib.h"
+#import "CBLCookieStorage.h"
 
 
 // Max number of retry attempts for a transient failure, and the backoff time formula
@@ -35,7 +36,7 @@
 @implementation CBLRemoteRequest
 
 
-@synthesize delegate=_delegate, responseHeaders=_responseHeaders;
+@synthesize delegate=_delegate, responseHeaders=_responseHeaders, cookieStorage=_cookieStorage;
 
 
 + (NSString*) userAgentHeader {
@@ -75,7 +76,7 @@
             if ([key caseInsensitiveCompare: @"Cookie"] == 0)
                 _request.HTTPShouldHandleCookies = NO;
         }];
-        
+
         [self setupRequest: _request withBody: body];
 
     }
@@ -101,6 +102,15 @@
         _authorizer = authorizer;
         [_request setValue: [authorizer authorizeURLRequest: _request forRealm: nil]
         forHTTPHeaderField: @"Authorization"];
+    }
+}
+
+- (void) setCookieStorage:(CBLCookieStorage *)cookieStorage {
+    if (_cookieStorage != cookieStorage) {
+        _cookieStorage = cookieStorage;
+        if (_request.HTTPShouldHandleCookies) {
+            [_cookieStorage addCookieHeaderForRequest: _request];
+        }
     }
 }
 
@@ -318,6 +328,10 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust) {
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
     _status = (int) ((NSHTTPURLResponse*)response).statusCode;
     _responseHeaders = ((NSHTTPURLResponse*)response).allHeaderFields;
+
+    if (_cookieStorage)
+        [_cookieStorage setCookieForResponse: (NSHTTPURLResponse*)response];
+
     LogTo(RemoteRequest, @"%@: Got response, status %d", self, _status);
     if (_status == 401) {
         // CouchDB says we're unauthorized but it didn't present a 'WWW-Authenticate' header
@@ -325,7 +339,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust) {
         if ([self retryWithCredential])
             return;
     }
-    
+
 #if DEBUG
     if (!CBLStatusIsError(_status)) {
         // By setting the user default "CBLFakeFailureRate" to a number between 0.0 and 1.0,

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -25,6 +25,7 @@
 #import "CBLBatcher.h"
 #import "CBLMultipartDownloader.h"
 #import "CBLBulkDownloader.h"
+#import "CBLCookieStorage.h"
 #import "CBLSequenceMap.h"
 #import "CBLInternal.h"
 #import "CBLMisc.h"
@@ -119,6 +120,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     _changeTracker.filterParameters = _filterParameters;
     _changeTracker.docIDs = _docIDs;
     _changeTracker.authorizer = _authorizer;
+    _changeTracker.cookieStorage = _cookieStorage;
     _changeTracker.usePOST = [self serverIsSyncGatewayVersion: @"0.93"];
 
     unsigned heartbeat = $castIf(NSNumber, _options[kCBLReplicatorOption_Heartbeat]).unsignedIntValue;

--- a/Source/CBL_Replicator.h
+++ b/Source/CBL_Replicator.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class CBLDatabase, CBL_Revision, CBL_RevisionList, CBLBatcher, CBLReachability;
+@class CBLDatabase, CBL_Revision, CBL_RevisionList, CBLBatcher, CBLReachability, CBLCookieStorage;
 @protocol CBLAuthorizer;
 
 typedef CBL_Revision* (^RevisionBodyTransformationBlock)(CBL_Revision*);
@@ -36,6 +36,7 @@ extern NSString* CBL_ReplicatorStoppedNotification;
     NSDictionary* _options;
     NSDictionary* _requestHeaders;
     NSString* _serverType;
+    CBLCookieStorage* _cookieStorage;
 #if TARGET_OS_IPHONE
     NSUInteger /*UIBackgroundTaskIdentifier*/ _bgTask;
 #endif
@@ -56,6 +57,7 @@ extern NSString* CBL_ReplicatorStoppedNotification;
 @property (readonly) NSURL* remote;
 @property (readonly) BOOL isPush;
 @property (readonly) BOOL continuous;
+@property (readonly) CBLCookieStorage* cookieStorage;
 @property (copy) NSString* filterName;
 @property (copy) NSDictionary* filterParameters;
 @property (copy) NSArray *docIDs;

--- a/Source/ChangeTracker/CBLChangeTracker.h
+++ b/Source/ChangeTracker/CBLChangeTracker.h
@@ -15,6 +15,7 @@
 
 #import <Foundation/Foundation.h>
 @class CBLChangeTracker;
+@class CBLCookieStorage;
 @protocol CBLAuthorizer;
 
 
@@ -59,6 +60,7 @@ typedef enum CBLChangeTrackerMode {
     NSTimeInterval _heartbeat;
     NSDictionary* _requestHeaders;
     id<CBLAuthorizer> _authorizer;
+    CBLCookieStorage* _cookieStorage;
     unsigned _retryCount;
     BOOL _caughtUp;
 }
@@ -79,6 +81,8 @@ typedef enum CBLChangeTrackerMode {
 @property (weak, nonatomic) id<CBLChangeTrackerClient> client;
 @property (strong, nonatomic) NSDictionary *requestHeaders;
 @property (strong, nonatomic) id<CBLAuthorizer> authorizer;
+@property (strong, nonatomic) CBLCookieStorage* cookieStorage;
+
 @property (nonatomic) BOOL usePOST;
 
 @property (nonatomic) CBLChangeTrackerMode mode;

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -46,7 +46,7 @@
 @synthesize lastSequenceID=_lastSequenceID, databaseURL=_databaseURL, mode=_mode;
 @synthesize limit=_limit, heartbeat=_heartbeat, error=_error, continuous=_continuous;
 @synthesize client=_client, filterName=_filterName, filterParameters=_filterParameters;
-@synthesize requestHeaders = _requestHeaders, authorizer=_authorizer;
+@synthesize requestHeaders = _requestHeaders, authorizer=_authorizer, cookieStorage=_cookieStorage;
 @synthesize docIDs = _docIDs, pollInterval=_pollInterval, usePOST=_usePOST;
 @synthesize paused=_paused;
 

--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -18,6 +18,7 @@
 #import "CBLSocketChangeTracker.h"
 #import "CBLRemoteRequest.h"
 #import "CBLAuthorizer.h"
+#import "CBLCookieStorage.h"
 #import "CBLStatus.h"
 #import "CBLBase64.h"
 #import "MYBlockUtils.h"
@@ -58,7 +59,12 @@
         // Add headers from my .requestHeaders property:
         [self.requestHeaders enumerateKeysAndObjectsUsingBlock: ^(id key, id value, BOOL *stop) {
             _http[key] = value;
+            if ([key caseInsensitiveCompare: @"Cookie"] == 0)
+                urlRequest.HTTPShouldHandleCookies = NO;
         }];
+
+        if (urlRequest.HTTPShouldHandleCookies)
+            [self.cookieStorage addCookieHeaderForRequest: urlRequest];
     }
 
     CFHTTPMessageRef request = [_http newHTTPRequest];

--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -64,7 +64,7 @@
         }
 
         if (urlRequest.HTTPShouldHandleCookies) {
-            [self.cookieStorage addCookieHeaderForRequest: urlRequest];
+            [self.cookieStorage addCookieHeaderToRequest: urlRequest];
         }
 
         _http = [[WebSocketHTTPLogic alloc] initWithURLRequest: urlRequest];

--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -55,16 +55,24 @@
             urlRequest.HTTPBody = self.changesFeedPOSTBody;
             [urlRequest setValue: @"application/json" forHTTPHeaderField: @"Content-Type"];
         }
+
+        for (NSString* key in self.requestHeaders) {
+            if ([key caseInsensitiveCompare: @"Cookie"] == 0) {
+                urlRequest.HTTPShouldHandleCookies = NO;
+                break;
+            }
+        }
+
+        if (urlRequest.HTTPShouldHandleCookies) {
+            [self.cookieStorage addCookieHeaderForRequest: urlRequest];
+        }
+
         _http = [[WebSocketHTTPLogic alloc] initWithURLRequest: urlRequest];
+
         // Add headers from my .requestHeaders property:
         [self.requestHeaders enumerateKeysAndObjectsUsingBlock: ^(id key, id value, BOOL *stop) {
             _http[key] = value;
-            if ([key caseInsensitiveCompare: @"Cookie"] == 0)
-                urlRequest.HTTPShouldHandleCookies = NO;
         }];
-
-        if (urlRequest.HTTPShouldHandleCookies)
-            [self.cookieStorage addCookieHeaderForRequest: urlRequest];
     }
 
     CFHTTPMessageRef request = [_http newHTTPRequest];

--- a/Source/ChangeTracker/CBLWebSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLWebSocketChangeTracker.m
@@ -15,6 +15,7 @@
 
 #import "CBLWebSocketChangeTracker.h"
 #import "CBLAuthorizer.h"
+#import "CBLCookieStorage.h"
 #import "WebSocketClient.h"
 #import "CBLMisc.h"
 #import "MYBlockUtils.h"
@@ -60,7 +61,13 @@
     // Add headers from my .requestHeaders property:
     [self.requestHeaders enumerateKeysAndObjectsUsingBlock: ^(id key, id value, BOOL *stop) {
         [request setValue: value forHTTPHeaderField: key];
+        
+        if ([key caseInsensitiveCompare: @"Cookie"] == 0)
+            request.HTTPShouldHandleCookies = NO;
     }];
+
+    if (request.HTTPShouldHandleCookies)
+        [self.cookieStorage addCookieHeaderForRequest: request];
 
     if (_authorizer) {
         // Let the Authorizer add its own credential:

--- a/Source/ChangeTracker/CBLWebSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLWebSocketChangeTracker.m
@@ -67,7 +67,7 @@
     }];
 
     if (request.HTTPShouldHandleCookies)
-        [self.cookieStorage addCookieHeaderForRequest: request];
+        [self.cookieStorage addCookieHeaderToRequest: request];
 
     if (_authorizer) {
         // Let the Authorizer add its own credential:

--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -1,0 +1,1056 @@
+//
+//  CookieStorage_Tests.m
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 2/20/15.
+//  Copyright (c) 2015 Couchbase, Inc. All rights reserved.
+//
+
+#import "CBLTestCase.h"
+#import "CBLCookieStorage.h"
+
+#define $URL(urlStr)                            ([NSURL URLWithString: urlStr])
+#define COMPARE_COOKIES(cookies1, cookies2)     [self compareCookies: cookies1 withCookies: cookies2]
+
+@interface CookieStorage_Tests : CBLTestCaseWithDB
+
+@end
+
+@implementation CookieStorage_Tests
+{
+    CBLCookieStorage* _cookieStore;
+    NSHTTPCookieStorage* _appleCookieStore;
+}
+
+- (void)setUp {
+    [super setUp];
+    _cookieStore = [[CBLCookieStorage alloc] initWithDB: db
+                                             storageKey: @"cookie_store_unit_test"];
+    _appleCookieStore = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+}
+
+- (void)tearDown {
+    [super tearDown];
+
+    [_cookieStore close];
+
+    for (NSHTTPCookie *cookie in _appleCookieStore.cookies)
+        [_appleCookieStore deleteCookie:cookie];
+}
+
+- (void) reloadCookieStore {
+    [_cookieStore close];
+    _cookieStore = [[CBLCookieStorage alloc] initWithDB: db
+                                             storageKey: @"cookie_store_unit_test"];
+}
+
+- (NSHTTPCookie*) cookie: (NSDictionary*)props {
+    return [NSHTTPCookie cookieWithProperties:props];
+}
+
+- (void) addCookie2BothStores: (NSHTTPCookie*)cookie {
+    [_cookieStore setCookie: cookie];
+    [_appleCookieStore setCookie:cookie];
+}
+
+- (BOOL)compareCookies: (NSArray*)cookies1 withCookies: (NSArray*)cookies2 {
+    // Expect no duplicate cookies in an array.
+    if ([cookies1 count] != [cookies2 count])
+        return NO;
+
+    NSSet* cookie2Set = [NSSet setWithArray: cookies2];
+    for (NSHTTPCookie* cookie in cookies1) {
+        if (![cookie2Set containsObject: cookie])
+            return NO;
+    }
+    return YES;
+}
+
+- (void) test_SetCookie_Persistent {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieComment: @"yummy",
+                                             NSHTTPCookieCommentURL: @"www.mycookie.com",
+                                             NSHTTPCookieExpires: [NSDate dateWithTimeIntervalSinceNow:60.0],
+                                             NSHTTPCookieVersion: @"0"
+                            }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"darkchoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieComment: @"yummy",
+                                             NSHTTPCookieCommentURL: @"www.mycookie.com",
+                                             NSHTTPCookieMaximumAge: @(60),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+
+    // Set cookie with same name, domain, and path
+    // with one of the previously set cookies:
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"darkchoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"bitter sweet",
+                                             NSHTTPCookieComment: @"yummy",
+                                             NSHTTPCookieCommentURL: @"www.mycookie.com",
+                                             NSHTTPCookieMaximumAge: @(60),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie3];
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie3);
+
+    [self reloadCookieStore];
+
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie3);
+}
+
+- (void) test_SetCookie_NameDomainPath {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/path",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie3];
+
+    NSHTTPCookie* cookie4 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/path/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie4];
+
+    NSHTTPCookie* cookie5 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @".mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie5];
+
+    NSHTTPCookie* cookie6 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie6];
+
+    NSHTTPCookie* cookie7 = [self cookie: @{ NSHTTPCookieName: @"cookie7",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie7];
+
+    AssertEq(_cookieStore.cookies.count, 7u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+    AssertEqual(_cookieStore.cookies[2], cookie3);
+    AssertEqual(_cookieStore.cookies[3], cookie4);
+    AssertEqual(_cookieStore.cookies[4], cookie5);
+    AssertEqual(_cookieStore.cookies[5], cookie6);
+    AssertEqual(_cookieStore.cookies[6], cookie7);
+
+    NSHTTPCookie* cookie8 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"bitter, sweet",
+                                             }];
+    [_cookieStore setCookie: cookie8];
+
+    AssertEq(_cookieStore.cookies.count, 7u);
+    AssertEqual(_cookieStore.cookies[0], cookie8);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+    AssertEqual(_cookieStore.cookies[2], cookie3);
+    AssertEqual(_cookieStore.cookies[3], cookie4);
+    AssertEqual(_cookieStore.cookies[4], cookie5);
+    AssertEqual(_cookieStore.cookies[5], cookie6);
+    AssertEqual(_cookieStore.cookies[6], cookie7);
+}
+
+- (void) test_SetCookie_SessionOnly {
+    // No expires date specified for a cookie v0:
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieVersion: @"0"
+                                             }];
+    AssertEq(cookie1.sessionOnly, YES);
+    [_cookieStore setCookie: cookie1];
+
+    // No max age specified for a cookie v1:
+    NSHTTPCookie *cookie2 = [self cookie: @{ NSHTTPCookieName: @"oatmeal_raisin",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    AssertEq(cookie2.sessionOnly, YES);
+    [_cookieStore setCookie: cookie2];
+
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+
+    [self reloadCookieStore];
+
+    // Sessions cookies are all discard:
+    AssertEq(_cookieStore.cookies.count, 0u);
+}
+
+
+- (void) test_SetCookie_AcceptPolicy {
+    _cookieStore.cookieAcceptPolicy = NSHTTPCookieAcceptPolicyAlways;
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet"
+                                             }];
+    [_cookieStore setCookie: cookie1];
+    AssertEq(_cookieStore.cookies.count, 1u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+
+    _cookieStore.cookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"oatmeal_raisin",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie2];
+    AssertEq(_cookieStore.cookies.count, 1u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+}
+
+- (void) test_DeleteCookie {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"oatmeal_raisin",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"darkchoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie3];
+
+    AssertEq(_cookieStore.cookies.count, 3u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+    AssertEqual(_cookieStore.cookies[2], cookie3);
+
+    [_cookieStore deleteCookie: cookie2];
+
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie3);
+
+    [self reloadCookieStore];
+
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie3);
+
+    [_cookieStore deleteCookie: cookie1];
+    [_cookieStore deleteCookie: cookie3];
+
+    AssertEq(_cookieStore.cookies.count, 0u);
+
+    [self reloadCookieStore];
+
+    AssertEq(_cookieStore.cookies.count, 0u);
+}
+
+- (void) test_DeleteAllCookies {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"oatmeal_raisin",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"darkchoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie3];
+
+    AssertEq(_cookieStore.cookies.count, 3u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+    AssertEqual(_cookieStore.cookies[2], cookie3);
+
+    [_cookieStore deleteAllCookies];
+
+    AssertEq(_cookieStore.cookies.count, 0u);
+
+    [self reloadCookieStore];
+
+    AssertEq(_cookieStore.cookies.count, 0u);
+}
+
+- (void) test_CookiesForURL {
+    NSHTTPCookie* cookie00 = [self cookie: @{ NSHTTPCookieName: @"cookie00",
+                                             NSHTTPCookieDomain: @"",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie00];
+
+    NSHTTPCookie* cookie01 = [self cookie: @{ NSHTTPCookieName: @"cookie01",
+                                              NSHTTPCookieDomain: @"",
+                                              NSHTTPCookiePath: @"/",
+                                              NSHTTPCookieValue: @"sweet",
+                                              }];
+    [self addCookie2BothStores: cookie01];
+
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"cookie2",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"cookie3",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/morning",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie3];
+
+    NSHTTPCookie* cookie4 = [self cookie: @{ NSHTTPCookieName: @"cookie4",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/morning/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie4];
+
+    NSHTTPCookie* cookie5 = [self cookie: @{ NSHTTPCookieName: @"cookie5",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/morning/specials",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie5];
+
+    NSHTTPCookie* cookie6 = [self cookie: @{ NSHTTPCookieName: @"cookie6",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/morning/specials/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie6];
+
+    NSHTTPCookie* cookie7 = [self cookie: @{ NSHTTPCookieName: @"cookie7",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie7];
+
+    NSHTTPCookie* cookie8 = [self cookie: @{ NSHTTPCookieName: @"cookie8",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie8];
+
+    NSHTTPCookie* cookie9 = [self cookie: @{ NSHTTPCookieName: @"cookie9",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/summer",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie9];
+
+    NSHTTPCookie* cookie10 = [self cookie: @{ NSHTTPCookieName: @"cookie10",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/summer/specials",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie10];
+
+    NSHTTPCookie* cookie11 = [self cookie: @{ NSHTTPCookieName: @"cookie10",
+                                              NSHTTPCookieDomain: @"www.mycookie.com",
+                                              NSHTTPCookiePath: @"summer",
+                                              NSHTTPCookieValue: @"sweet",
+                                              }];
+    [self addCookie2BothStores: cookie11];
+
+    NSHTTPCookie* cookie12 = [self cookie: @{ NSHTTPCookieName: @"cookie10",
+                                              NSHTTPCookieDomain: @"www.mycookie.com",
+                                              NSHTTPCookiePath: @"summer/specials",
+                                              NSHTTPCookieValue: @"sweet",
+                                              }];
+    [self addCookie2BothStores: cookie12];
+
+    NSArray* cookies1 = nil;
+    NSArray* cookies2 = nil;
+    NSURL* url = nil;
+
+    url = $URL(@"http://mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://MyCookiE.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://MyCookiE.com/");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/morning");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 3u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/morning/");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 4u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/MorNinG");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/MorNinG/");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/afternoon");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/morning/123");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 4u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/morning/specials");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 5u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    AssertEqual(cookies1[4], cookie5);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/morning/specials/");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 6u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    AssertEqual(cookies1[4], cookie5);
+    AssertEqual(cookies1[5], cookie6);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/morning/specials/123");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 6u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    AssertEqual(cookies1[4], cookie5);
+    AssertEqual(cookies1[5], cookie6);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com/");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie7);
+    AssertEqual(cookies1[1], cookie8);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com/summer");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 3u);
+    AssertEqual(cookies1[0], cookie7);
+    AssertEqual(cookies1[1], cookie8);
+    AssertEqual(cookies1[2], cookie9);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com/summer/");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 3u);
+    AssertEqual(cookies1[0], cookie7);
+    AssertEqual(cookies1[1], cookie8);
+    AssertEqual(cookies1[2], cookie9);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com/summer/specials");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 4u);
+    AssertEqual(cookies1[0], cookie7);
+    AssertEqual(cookies1[1], cookie8);
+    AssertEqual(cookies1[2], cookie9);
+    AssertEqual(cookies1[3], cookie10);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://notmycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 0u);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.notmycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 0u);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www2.mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 0u);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www2.mycookie.com/summer");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 0u);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+}
+
+- (void) test_CookiesForURL_DomainCookies {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @".mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"cookie2",
+                                             NSHTTPCookieDomain: @".mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"cookie3",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie3];
+
+    NSHTTPCookie* cookie4 = [self cookie: @{ NSHTTPCookieName: @"cookie4",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie4];
+
+    NSHTTPCookie* cookie5 = [self cookie: @{ NSHTTPCookieName: @"cookie5",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/morning",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie5];
+
+    NSHTTPCookie* cookie6 = [self cookie: @{ NSHTTPCookieName: @"cookie6",
+                                             NSHTTPCookieDomain: @".www.mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie6];
+
+    NSHTTPCookie* cookie7 = [self cookie: @{ NSHTTPCookieName: @"cookie7",
+                                             NSHTTPCookieDomain: @".www.mycookie.com",
+                                             NSHTTPCookiePath: @"/morning",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie7];
+
+    NSHTTPCookie* cookie8 = [self cookie: @{ NSHTTPCookieName: @"cookie8",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie8];
+
+    NSHTTPCookie* cookie9 = [self cookie: @{ NSHTTPCookieName: @"cookie9",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/morning",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [self addCookie2BothStores: cookie9];
+
+    NSArray* cookies1 = nil;
+    NSArray* cookies2 = nil;
+    NSURL* url = nil;
+
+    url = $URL(@"http://mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 4u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://MyCooKie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 4u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie.com/morning");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 5u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    AssertEqual(cookies1[4], cookie5);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 4u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie6);
+    AssertEqual(cookies1[3], cookie8);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com/morning");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 6u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie6);
+    AssertEqual(cookies1[3], cookie7);
+    AssertEqual(cookies1[4], cookie8);
+    AssertEqual(cookies1[5], cookie9);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com/morning/123");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 6u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie6);
+    AssertEqual(cookies1[3], cookie7);
+    AssertEqual(cookies1[4], cookie8);
+    AssertEqual(cookies1[5], cookie9);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www2.mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www2.MyCooKie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://sub1.sub2.mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://mycookie2.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 0u);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+}
+
+- (void) test_CookiesForURL_Secure {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieSecure: @"TRUE"
+                                             }];
+    [self addCookie2BothStores: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"cookie2",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet"
+                                             }];
+    [self addCookie2BothStores: cookie2];
+
+    Assert(cookie1.isSecure);
+    Assert(!cookie2.isSecure);
+
+    NSArray* cookies1 = nil;
+    NSArray* cookies2 = nil;
+    NSURL* url = nil;
+
+    // Get only matched non-secure cookies:
+    url = $URL(@"http://www.mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 1u);
+    AssertEqual(cookies1[0], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    // Get both matched secure and non-secure cookies:
+    url = $URL(@"https://www.mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 2u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+}
+
+- (void) test_CookiesForURL_Ports {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [self addCookie2BothStores: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"cookie2",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookiePort: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [self addCookie2BothStores: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"cookie3",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookiePort: @"4984",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [self addCookie2BothStores: cookie3];
+
+    NSHTTPCookie* cookie4 = [self cookie: @{ NSHTTPCookieName: @"cookie4",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/morning",
+                                             NSHTTPCookiePort: @"4984",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [self addCookie2BothStores: cookie4];
+
+    NSHTTPCookie* cookie5 = [self cookie: @{ NSHTTPCookieName: @"cookie5",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookiePort: @"4984",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieVersion: @"0"
+                                             }];
+    [self addCookie2BothStores: cookie5];
+
+    NSArray* cookies1 = nil;
+    NSArray* cookies2 = nil;
+    NSURL* url = nil;
+
+    cookies1 = _cookieStore.cookies;
+    cookies2 = _appleCookieStore.cookies;
+    AssertEq(cookies1.count, 5u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie2);
+    AssertEqual(cookies1[2], cookie3);
+    AssertEqual(cookies1[3], cookie4);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    // Setting to an empty string ("") currently results to a port number 0 (SDK BUG).
+    // As a result, only one cookie will be returned here instead of two.
+    // https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSHTTPCookie_Class/index.html
+    url = $URL(@"http://www.mycookie.com");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 1u);
+    AssertEqual(cookies1[0], cookie1);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    // Setting NSHTTPCookiePort also has effect on cookies version 0, which is different
+    // from what is being said the apple document. We are maintaining the same behavior here.
+    url = $URL(@"http://www.mycookie.com:4984");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 3u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie3);
+    AssertEqual(cookies1[2], cookie5);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com/morning");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 1u);
+    AssertEqual(cookies1[0], cookie1);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+
+    url = $URL(@"http://www.mycookie.com:4984/morning");
+    cookies1 = [_cookieStore cookiesForURL: url];
+    cookies2 = [_appleCookieStore cookiesForURL: url];
+    AssertEq(cookies1.count, 4u);
+    AssertEqual(cookies1[0], cookie1);
+    AssertEqual(cookies1[1], cookie3);
+    AssertEqual(cookies1[2], cookie4);
+    AssertEqual(cookies1[3], cookie5);
+    Assert(COMPARE_COOKIES(cookies1, cookies2));
+}
+
+- (void) test_CookiesEscapedURL {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"cookie1",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"cookie2",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/with%20space",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"cookie3",
+                                             NSHTTPCookieDomain: @"www.mycookie.com",
+                                             NSHTTPCookiePath: @"/with%20space/123",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie3];
+
+    NSArray* cookies = nil;
+
+    cookies = [_cookieStore cookiesForURL: $URL(@"http://www.mycookie.com")];
+    AssertEq(cookies.count, 1u);
+    AssertEqual(cookies[0], cookie1);
+
+    cookies = [_cookieStore cookiesForURL: $URL(@"http://www.mycookie.com/with%20space")];
+    AssertEq(cookies.count, 2u);
+    AssertEqual(cookies[0], cookie1);
+    AssertEqual(cookies[1], cookie2);
+
+    cookies = [_cookieStore cookiesForURL: $URL(@"http://www.mycookie.com/with%20space/123")];
+    AssertEq(cookies.count, 3u);
+    AssertEqual(cookies[0], cookie1);
+    AssertEqual(cookies[1], cookie2);
+    AssertEqual(cookies[2], cookie3);
+}
+
+
+- (void) test_CookieExpires {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieExpires: [NSDate dateWithTimeIntervalSinceNow: 1.0],
+                                             NSHTTPCookieVersion: @"0"
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"darkchoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(1.0),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+
+    [NSThread sleepForTimeInterval: 1.5];
+
+    AssertEq(_cookieStore.cookies.count, 0u);
+}
+
+- (void) test_SortedCookies {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"cookieB",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"cookieA",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"cookieD",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/morning",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie3];
+
+    NSHTTPCookie* cookie4 = [self cookie: @{ NSHTTPCookieName: @"cookieC",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/morning/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             }];
+    [_cookieStore setCookie: cookie4];
+
+    NSArray* cookies = nil;
+
+    cookies = _cookieStore.cookies;
+    AssertEq(cookies.count, 4u);
+    AssertEqual(cookies[0], cookie1);
+    AssertEqual(cookies[1], cookie2);
+    AssertEqual(cookies[2], cookie3);
+    AssertEqual(cookies[3], cookie4);
+
+    NSSortDescriptor *nameAsc = [[NSSortDescriptor alloc] initWithKey: @"name" ascending: YES];
+    cookies = [_cookieStore sortedCookiesUsingDescriptors: @[nameAsc]];
+    AssertEq(cookies.count, 4u);
+    AssertEqual(cookies[0], cookie2);
+    AssertEqual(cookies[1], cookie1);
+    AssertEqual(cookies[2], cookie4);
+    AssertEqual(cookies[3], cookie3);
+
+    NSSortDescriptor *nameDesc = [[NSSortDescriptor alloc] initWithKey: @"name" ascending: NO];
+    cookies = [_cookieStore sortedCookiesUsingDescriptors: @[nameDesc]];
+    AssertEq(cookies.count, 4u);
+    AssertEqual(cookies[0], cookie3);
+    AssertEqual(cookies[1], cookie4);
+    AssertEqual(cookies[2], cookie1);
+    AssertEqual(cookies[3], cookie2);
+}
+
+@end

--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -298,6 +298,60 @@
     AssertEq(_cookieStore.cookies.count, 0u);
 }
 
+- (void) test_DeleteCookiesByName {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"oatmeal_raisin",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"WhiteChoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/supersweet",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie3];
+
+    AssertEq(_cookieStore.cookies.count, 3u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+    AssertEqual(_cookieStore.cookies[2], cookie3);
+
+    [_cookieStore deleteCookiesNamed: @"WHITECHOCO"];
+    AssertEq(_cookieStore.cookies.count, 3u);
+    AssertEqual(_cookieStore.cookies[0], cookie1);
+    AssertEqual(_cookieStore.cookies[1], cookie2);
+    AssertEqual(_cookieStore.cookies[2], cookie3);
+
+    [_cookieStore deleteCookiesNamed: @"whitechoco"];
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], cookie2);
+    AssertEqual(_cookieStore.cookies[1], cookie3);
+
+    [_cookieStore deleteCookiesNamed: @"WhiteChoco"];
+    AssertEq(_cookieStore.cookies.count, 1u);
+    AssertEqual(_cookieStore.cookies[0], cookie2);
+
+    [self reloadCookieStore];
+
+    AssertEq(_cookieStore.cookies.count, 1u);
+    AssertEqual(_cookieStore.cookies[0], cookie2);
+}
+
 - (void) test_DeleteAllCookies {
     NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
                                              NSHTTPCookieDomain: @"mycookie.com",

--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -31,15 +31,12 @@
 
 - (void)tearDown {
     [super tearDown];
-
-    [_cookieStore close];
-
+    
     for (NSHTTPCookie *cookie in _appleCookieStore.cookies)
         [_appleCookieStore deleteCookie:cookie];
 }
 
 - (void) reloadCookieStore {
-    [_cookieStore close];
     _cookieStore = [[CBLCookieStorage alloc] initWithDB: db
                                              storageKey: @"cookie_store_unit_test"];
 }


### PR DESCRIPTION
Implement CBLCookieStorage:
* Stores cookies in the local checkpoint document. Each storage is referenced by a unique store key given when initializing the cookie storage instance. When integrating with the CBL_Replicator, the unique store key will be remoteCheckpointDocID.
* Implement the most of the feature sets of NSHTTPCookieStorage except the following 2 features: NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain policy and setCookies:forURL:mainDocumentURL: method.
* Simply handle multiple thread access by using synchronized directive.
* Include a Unit Test file named CookieStorage_tests.m.

Replicator Integration:
* CBLRemoteRequest now has a cookieStorage property. If the cookie storage is set, the remote request object will get the cookies from the specified storage and set the cookies into the request header accordingly.
* CBLChangeTracker now has a cookieStorage property. When the cookie storage is set, its CBLSocketChangeTracker and CBLWebSocketChangeTracker subclass will use the cookies from the storage and set to request header accordingly.
* Add _pendingCookies to CBLReplicator to handle set and delete cookies before starting the replicator. Once the replicator is started, the cookie objects in _pendingCookies will be added to the cookie storage and the deleted cookie named in _pendingCookies will be used to delete the cookies from the storage.
* Manually tested the storage and integration with ToDoLite-iOS with both socket and websocket change tracker.

Reference issue #543 