### PR TITLE
Fixed CBLSocketChangeTracker to use correct OS proxy settings

### DIFF
--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -96,13 +96,13 @@
     _http.handleRedirects = NO;  // CFStream will handle redirects instead
 
     // Configure HTTP proxy -- CFNetwork makes us do this manually, unlike NSURLConnection :-p
-    NSDictionary* proxy = url.my_proxySettings;
-    if (proxy) {
-        LogTo(ChangeTracker, @"Changes feed using proxy %@", proxy);
-        bool ok = CFReadStreamSetProperty(cfInputStream, kCFStreamPropertyHTTPProxy,
-                                          (CFDictionaryRef)proxy);
+    CFDictionaryRef proxySettings = CFNetworkCopySystemProxySettings();
+    if (proxySettings) {
+        LogTo(ChangeTracker, @"Changes feed using proxy settings %@", proxySettings);
+        Boolean ok = CFReadStreamSetProperty(cfInputStream, kCFStreamPropertyHTTPProxy, proxySettings);
         Assert(ok);
     }
+    CFRelease(proxySettings);
 
     NSDictionary* tls = self.TLSSettings;
     if (tls)

--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -101,8 +101,8 @@
         LogTo(ChangeTracker, @"Changes feed using proxy settings %@", proxySettings);
         Boolean ok = CFReadStreamSetProperty(cfInputStream, kCFStreamPropertyHTTPProxy, proxySettings);
         Assert(ok);
+        CFRelease(proxySettings);
     }
-    CFRelease(proxySettings);
 
     NSDictionary* tls = self.TLSSettings;
     if (tls)


### PR DESCRIPTION
See #622 for details on this.

Short version: `-my_proxySettings` returned the wrong proxy settings for `CFReadStreamSetProperty()` to use.