### PR TITLE
Prevent CBLReplicator to be released when the bg notification is called

### DIFF
--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -502,6 +502,9 @@ NSString* const kCBLReplicationChangeNotification = @"CBLReplicationChange";
 
 // CAREFUL: This is called on the server's background thread!
 - (void) bg_updateProgress {
+    // Prevent _processor block from deallocating me (#624)
+    __unused id retainSelf = self;
+
     CBLReplicationStatus status;
     if (!_bg_replicator.running)
         status = kCBLReplicationStopped;


### PR DESCRIPTION
Added a little trick to retain itself at the beginning of the method.