### PR TITLE
Try to connect when rechability reports not-reachable

### DIFF
--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -299,9 +299,6 @@ BOOL CBLIsOfflineError( NSError* error ) {
     if ($equal(domain, NSURLErrorDomain))
         return code == NSURLErrorDNSLookupFailed
             || code == NSURLErrorNotConnectedToInternet
-            || code == NSURLErrorCannotConnectToHost
-            || code == NSURLErrorCannotFindHost
-            || code == NSURLErrorNetworkConnectionLost
 #ifndef GNUSTEP
             || code == NSURLErrorInternationalRoamingOff
 #endif

--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -299,6 +299,9 @@ BOOL CBLIsOfflineError( NSError* error ) {
     if ($equal(domain, NSURLErrorDomain))
         return code == NSURLErrorDNSLookupFailed
             || code == NSURLErrorNotConnectedToInternet
+            || code == NSURLErrorCannotConnectToHost
+            || code == NSURLErrorCannotFindHost
+            || code == NSURLErrorNetworkConnectionLost
 #ifndef GNUSTEP
             || code == NSURLErrorInternationalRoamingOff
 #endif

--- a/Source/CBLRemoteRequest.h
+++ b/Source/CBLRemoteRequest.h
@@ -40,6 +40,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
     UInt8 _retryCount;
     bool _dontLog404;
     bool _challenged;
+    bool _autoRetry;
 }
 
 /** Creates a request; call -start to send it on its way. */
@@ -53,6 +54,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
 @property (strong, nonatomic) id<CBLAuthorizer> authorizer;
 @property (strong, nonatomic) id<CBLRemoteRequestDelegate> delegate;
 @property (strong, nonatomic) CBLCookieStorage* cookieStorage;
+@property (nonatomic) bool autoRetry;   // Default value is YES
 
 /** Applies GZip compression to the request body if appropriate. */
 - (BOOL) compressBody;

--- a/Source/CBL_Replicator.h
+++ b/Source/CBL_Replicator.h
@@ -133,3 +133,7 @@ extern NSString* CBL_ReplicatorStoppedNotification;
 #define kCBLReplicatorOption_Network @"network"             // "WiFi" or "Cell"
 #define kCBLReplicatorOption_UseWebSocket @"websocket"      // Boolean; default is YES
 #define kCBLReplicatorOption_PinnedCert @"pinnedCert"       // NSData or (hex) NSString
+
+// Boolean; default is YES. Setting this option will have no effect and result to always 'trust' if
+// the kCBLReplicatorOption_Network option is also set.
+#define kCBLReplicatorOption_TrustReachability @"trust_reachability"


### PR DESCRIPTION
- Attempt to connect to the remote url when the reachability reports not-reachable. If an offline error returns, bring the replicator offline. Otherwise, bring the replicator online.

- Used request timeout of 10 seconds.

- Added autoRetry parameter to CBLRemoteRequest to be able to enable/disable retry feature; set auto retry to NO when trying to check if the server is reachable nor not.

- Extended NSURLErrorCannotConnectToHost, NSURLErrorCannotFindHost, and NSURLErrorNetworkConnectionLost to the CBLMisc.CBLIsOfflineError method.

#536