### PR TITLE
Fix stop idle replicator not getting change notification

### DIFF
--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -304,13 +304,8 @@ NSString* const kCBLReplicationChangeNotification = @"CBLReplicationChange";
     [self tellReplicatorAndWait:^id(CBL_Replicator * bgReplicator) {
         // This runs on the server thread:
         [bgReplicator stop];
-        [[NSNotificationCenter defaultCenter] removeObserver: self name: nil
-                                                      object: _bg_replicator];
         return @(YES);
     }];
-
-    _started = NO;
-    [_database forgetReplication: self];
 }
 
 

--- a/Source/CBL_Replicator.m
+++ b/Source/CBL_Replicator.m
@@ -398,8 +398,10 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
     [self stopRemoteRequests];
     [NSObject cancelPreviousPerformRequestsWithTarget: self
                                              selector: @selector(retryIfReady) object: nil];
-    if (_running && _asyncTaskCount == 0)
+    if (_running && _asyncTaskCount == 0) {
         [self stopped];
+        [self postProgressChanged];
+    }
 }
 
 


### PR DESCRIPTION
- In CBL_Replicator's stop method, post progress changed notification after calling stopped.

- Refactor CBLReplication's stop method to just calling stop method on the background replicator.

- The rest of the logic including forgetting the replicator and setting _started variable will be done in the updateStatus:error:processed:ofTotal: serverCert: method after getting the progress changed notitification after the replication get stopped.

#639