### PR TITLE
API: Added kCBLBySequence to CBLAllDocsOptions (aka "changes feed")

### DIFF
--- a/Source/API/CBLQuery.h
+++ b/Source/API/CBLQuery.h
@@ -23,7 +23,8 @@ typedef NS_ENUM(unsigned, CBLAllDocsMode) {
     kCBLAllDocs,            /**< Normal behavior for all-docs query */
     kCBLIncludeDeleted,     /**< Will include rows for deleted documents */
     kCBLShowConflicts,      /**< Rows will indicate conflicting revisions */
-    kCBLOnlyConflicts       /**< Will _only_ return rows for docs in conflict */
+    kCBLOnlyConflicts,      /**< Will _only_ return rows for docs in conflict */
+    kCBLBySequence          /**< Order by sequence number (i.e. chronologically) */
 };
 
 

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -455,6 +455,68 @@
 }
 
 
+- (void) test12_AllDocumentsBySequence {
+    static const NSUInteger kNDocs = 10;
+    [self createDocuments: kNDocs];
+
+    // clear the cache so all documents/revisions will be re-fetched:
+    [db _clearDocumentCache];
+
+    CBLQuery* query = [db createAllDocumentsQuery];
+    query.allDocsMode = kCBLBySequence;
+    CBLQueryEnumerator* rows = [query run: NULL];
+    SequenceNumber n = 0;
+    for (CBLQueryRow* row in rows) {
+        n++;
+        CBLDocument* doc = row.document;
+        Assert(doc, @"Couldn't get doc from query");
+        AssertEq(doc.currentRevision.sequence, n);
+    }
+    AssertEq(n, kNDocs);
+
+    query = [db createAllDocumentsQuery];
+    query.allDocsMode = kCBLBySequence;
+    query.startKey = @3;
+    rows = [query run: NULL];
+    n = 2;
+    for (CBLQueryRow* row in rows) {
+        n++;
+        CBLDocument* doc = row.document;
+        Assert(doc, @"Couldn't get doc from query");
+        AssertEq(doc.currentRevision.sequence, n);
+    }
+    AssertEq(n, kNDocs);
+
+    query = [db createAllDocumentsQuery];
+    query.allDocsMode = kCBLBySequence;
+    query.endKey = @6;
+    rows = [query run: NULL];
+    n = 0;
+    for (CBLQueryRow* row in rows) {
+        n++;
+        CBLDocument* doc = row.document;
+        Assert(doc, @"Couldn't get doc from query");
+        AssertEq(doc.currentRevision.sequence, n);
+    }
+    AssertEq(n, 6);
+
+    query = [db createAllDocumentsQuery];
+    query.allDocsMode = kCBLBySequence;
+    query.startKey = @3;
+    query.endKey = @6;
+    query.inclusiveStart = query.inclusiveEnd = NO;
+    rows = [query run: NULL];
+    n = 3;
+    for (CBLQueryRow* row in rows) {
+        n++;
+        CBLDocument* doc = row.document;
+        Assert(doc, @"Couldn't get doc from query");
+        AssertEq(doc.currentRevision.sequence, n);
+    }
+    AssertEq(n, 5);
+}
+
+
 - (void) test13_LocalDocs {
     NSDictionary* props = [db existingLocalDocumentWithID: @"dock"];
     AssertNil(props);


### PR DESCRIPTION
In this mode an all-docs query returns docs in order by sequence number.
The startKey and endKey are interpreted as sequence numbers.
Note: Descending order isn't yet supported.