### PR TITLE
Propagate validation rejection message

### DIFF
--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -278,11 +278,11 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
                                     properties: nuProperties
                                 prevRevisionID: prevID
                                  allowConflict: allowConflict
-                                        status: &status];
-    if (!newRev) {
-        if (outError) *outError = CBLStatusToNSError(status, nil);
+                                        status: &status
+                                         error: outError];
+    if (!newRev)
         return nil;
-    }
+    
     return [self revisionFromRev: newRev];
 }
 

--- a/Source/CBLDatabase+Attachments.h
+++ b/Source/CBLDatabase+Attachments.h
@@ -71,11 +71,12 @@ typedef enum {
 /** Updates or deletes an attachment, creating a new document revision in the process.
     Used by the PUT / DELETE methods called on attachment URLs. */
 - (CBL_Revision*) updateAttachment: (NSString*)filename
-                            body: (CBL_BlobStoreWriter*)body
-                            type: (NSString*)contentType
-                        encoding: (CBLAttachmentEncoding)encoding
-                         ofDocID: (NSString*)docID
-                           revID: (NSString*)oldRevID
-                          status: (CBLStatus*)outStatus;
+                              body: (CBL_BlobStoreWriter*)body
+                              type: (NSString*)contentType
+                          encoding: (CBLAttachmentEncoding)encoding
+                           ofDocID: (NSString*)docID
+                             revID: (NSString*)oldRevID
+                            status: (CBLStatus*)outStatus
+                             error: (NSError**)outError;
 
 @end

--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -379,16 +379,20 @@ static UInt64 smallestLength(NSDictionary* attachment) {
 /** Replaces or removes a single attachment in a document, by saving a new revision whose only
     change is the value of the attachment. */
 - (CBL_Revision*) updateAttachment: (NSString*)filename
-                            body: (CBL_BlobStoreWriter*)body
-                            type: (NSString*)contentType
-                        encoding: (CBLAttachmentEncoding)encoding
-                         ofDocID: (NSString*)docID
-                           revID: (NSString*)oldRevID
-                          status: (CBLStatus*)outStatus
+                              body: (CBL_BlobStoreWriter*)body
+                              type: (NSString*)contentType
+                          encoding: (CBLAttachmentEncoding)encoding
+                           ofDocID: (NSString*)docID
+                             revID: (NSString*)oldRevID
+                            status: (CBLStatus*)outStatus
+                             error: (NSError**)outError
 {
     *outStatus = kCBLStatusBadAttachment;
-    if (filename.length == 0 || (body && !contentType) || (oldRevID && !docID) || (body && !docID))
+    if (filename.length == 0 || (body && !contentType) || (oldRevID && !docID) || (body && !docID)) {
+        if (outError)
+            *outError = CBLStatusToNSError(*outStatus, nil);
         return nil;
+    }
 
     CBL_MutableRevision* oldRev = [[CBL_MutableRevision alloc] initWithDocID: docID
                                                                        revID: oldRevID
@@ -399,9 +403,11 @@ static UInt64 smallestLength(NSDictionary* attachment) {
         if (CBLStatusIsError(*outStatus)) {
             if (*outStatus == kCBLStatusNotFound
                 && [self getDocumentWithID: docID revisionID: nil withBody: NO
-                                        status: outStatus] != nil) {
+                                    status: outStatus] != nil) {
                 *outStatus = kCBLStatusConflict;   // if some other revision exists, it's a conflict
             }
+            if (outError)
+                *outError = CBLStatusToNSError(*outStatus, nil);
             return nil;
         }
     } else {
@@ -426,6 +432,8 @@ static UInt64 smallestLength(NSDictionary* attachment) {
     } else {
         if (oldRevID && !attachments[filename]) {
             *outStatus = kCBLStatusAttachmentNotFound;
+            if (outError)
+                *outError = CBLStatusToNSError(*outStatus, nil);
             return nil;
         }
         [attachments removeObjectForKey: filename];
@@ -435,10 +443,16 @@ static UInt64 smallestLength(NSDictionary* attachment) {
     oldRev.properties = properties;
 
     // Store a new revision with the updated _attachments:
-    CBL_Revision* newRev = [self putRevision: oldRev prevRevisionID: oldRevID
-                             allowConflict: NO status: outStatus];
+    CBL_Revision* newRev = [self putRevision: oldRev prevRevisionID: oldRevID allowConflict: NO
+                                      status: outStatus error: outError];
     if (!body && *outStatus == kCBLStatusCreated)
         *outStatus = kCBLStatusOK;
+
+    if (CBLStatusIsError(*outStatus)) {
+        if (outError && !*outError)
+            *outError = CBLStatusToNSError(*outStatus, nil);
+    }
+
     return newRev;
 }
 

--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -448,11 +448,6 @@ static UInt64 smallestLength(NSDictionary* attachment) {
     if (!body && *outStatus == kCBLStatusCreated)
         *outStatus = kCBLStatusOK;
 
-    if (CBLStatusIsError(*outStatus)) {
-        if (outError && !*outError)
-            *outError = CBLStatusToNSError(*outStatus, nil);
-    }
-
     return newRev;
 }
 

--- a/Source/CBLDatabase+Insertion.h
+++ b/Source/CBLDatabase+Insertion.h
@@ -24,7 +24,8 @@
                 properties: (NSMutableDictionary*)properties
             prevRevisionID: (NSString*)inPrevRevID
              allowConflict: (BOOL)allowConflict
-                    status: (CBLStatus*)outStatus;
+                    status: (CBLStatus*)outStatus
+                     error: (NSError**)outError;
 
 /** Stores a new (or initial) revision of a document. This is what's invoked by a PUT or POST. As with those, the previous revision ID must be supplied when necessary and the call will fail if it doesn't match.
     @param revision  The revision to add. If the docID is nil, a new UUID will be assigned. Its revID must be nil. It must have a JSON body.
@@ -35,12 +36,14 @@
 - (CBL_Revision*) putRevision: (CBL_MutableRevision*)revision
                prevRevisionID: (NSString*)prevRevID
                 allowConflict: (BOOL)allowConflict
-                       status: (CBLStatus*)outStatus;
+                       status: (CBLStatus*)outStatus
+                        error: (NSError**)outError;
 
 /** Inserts an already-existing revision replicated from a remote database. It must already have a revision ID. This may create a conflict! The revision's history must be given; ancestor revision IDs that don't already exist locally will create phantom revisions with no content. */
 - (CBLStatus) forceInsert: (CBL_Revision*)rev
           revisionHistory: (NSArray*)history
-                   source: (NSURL*)source;
+                   source: (NSURL*)source
+                    error: (NSError**)outError;
 
 /** Parses the _revisions dict from a document into an array of revision ID strings */
 + (NSArray*) parseCouchDBRevisionHistory: (NSDictionary*)docProperties;

--- a/Source/CBLDatabase+Insertion.h
+++ b/Source/CBLDatabase+Insertion.h
@@ -32,6 +32,7 @@
     @param prevRevID  The ID of the revision to replace (same as the "?rev=" parameter to a PUT), or nil if this is a new document.
     @param allowConflict  If NO, an error status kCBLStatusConflict will be returned if the insertion would create a conflict, i.e. if the previous revision already has a child.
     @param outStatus  On return, an HTTP status code indicating success or failure.
+    @param outError  On return, an error indicating a reason of the failure.
     @return  A new CBL_Revision with the docID, revID and sequence filled in (but no body). */
 - (CBL_Revision*) putRevision: (CBL_MutableRevision*)revision
                prevRevisionID: (NSString*)prevRevID

--- a/Source/CBLDatabase+Insertion.m
+++ b/Source/CBLDatabase+Insertion.m
@@ -183,8 +183,11 @@
         tmpRev.properties = properties;
         if (![self processAttachmentsForRevision: tmpRev
                                        prevRevID: prevRevID
-                                          status: outStatus])
+                                          status: outStatus]) {
+            if (outError)
+                *outError = CBLStatusToNSError(*outStatus, nil);
             return nil;
+        }
         properties = [tmpRev.properties mutableCopy];
     }
 
@@ -242,8 +245,11 @@
         NSString* prevRevID = history.count >= 2 ? history[1] : nil;
         if (![self processAttachmentsForRevision: updatedRev
                                        prevRevID: prevRevID
-                                          status: &status])
+                                          status: &status]) {
+            if (outError)
+                *outError = CBLStatusToNSError(status, nil);
             return status;
+        }
         inRev = updatedRev;
     }
 
@@ -274,6 +280,9 @@
                    parentRevID: (NSString*)parentRevID
                          error: (NSError**)outError
 {
+    if (outError)
+        *outError = nil;
+    
     NSDictionary* validations = [self.shared valuesOfType: @"validation" inDatabaseNamed: _name];
     if (validations.count == 0)
         return kCBLStatusOK;

--- a/Source/CBLDatabaseUpgrade.m
+++ b/Source/CBLDatabaseUpgrade.m
@@ -223,7 +223,7 @@ static int collateRevIDs(void *context,
                 }
 
                 LogTo(Upgrade, @"Upgrading doc %@, history = %@", rev, history);
-                status = [_db forceInsert: rev revisionHistory: history source: nil];
+                status = [_db forceInsert: rev revisionHistory: history source: nil error: nil];
                 if (CBLStatusIsError(status))
                     return status;
                 ++_numRevs;

--- a/Source/CBLInternal.h
+++ b/Source/CBLInternal.h
@@ -26,7 +26,8 @@
 
 
 @interface CBLDatabase (Insertion_Internal)
-- (CBLStatus) validateRevision: (CBL_Revision*)newRev previousRevision: (CBL_Revision*)oldRev;
+- (CBLStatus) validateRevision: (CBL_Revision*)newRev previousRevision: (CBL_Revision*)oldRev
+                         error: (NSError **)outError;
 @end
 
 @interface CBLDatabase (Attachments_Internal)

--- a/Source/CBLStatus.h
+++ b/Source/CBLStatus.h
@@ -54,7 +54,8 @@ static inline bool CBLStatusIsError(CBLStatus status) {return status >= 400;}
 int CBLStatusToHTTPStatus( CBLStatus status, NSString** outMessage );
 
 NSError* CBLStatusToNSError( CBLStatus status, NSURL* url );
-NSError* CBLStatusToNSErrorWithInfo( CBLStatus status, NSURL* url, NSDictionary* extraInfo );
+NSError* CBLStatusToNSErrorWithInfo( CBLStatus status, NSString *reason, NSURL* url,
+                                     NSDictionary* extraInfo );
 CBLStatus CBLStatusFromNSError(NSError* error, CBLStatus defaultStatus);
 
 BOOL ReturnNSErrorFromCBLStatus( CBLStatus status, NSError** outError);

--- a/Source/CBLStatus.m
+++ b/Source/CBLStatus.m
@@ -72,9 +72,11 @@ int CBLStatusToHTTPStatus( CBLStatus status, NSString** outMessage ) {
 }
 
 
-NSError* CBLStatusToNSErrorWithInfo( CBLStatus status, NSURL* url, NSDictionary* extraInfo ) {
-    NSString* reason;
-    status = CBLStatusToHTTPStatus(status, &reason);
+NSError* CBLStatusToNSErrorWithInfo( CBLStatus status, NSString *reason, NSURL* url,
+                                     NSDictionary* extraInfo ) {
+    NSString* statusMessage;
+    status = CBLStatusToHTTPStatus(status, &statusMessage);
+    reason = reason != nil ? reason : statusMessage;
     NSMutableDictionary* info = $mdict({NSURLErrorKey, url},
                                        {NSLocalizedFailureReasonErrorKey, reason},
                                        {NSLocalizedDescriptionKey, $sprintf(@"%i %@", status, reason)});
@@ -85,7 +87,7 @@ NSError* CBLStatusToNSErrorWithInfo( CBLStatus status, NSURL* url, NSDictionary*
 
 
 NSError* CBLStatusToNSError( CBLStatus status, NSURL* url ) {
-    return CBLStatusToNSErrorWithInfo(status, url, nil);
+    return CBLStatusToNSErrorWithInfo(status, nil, url, nil);
 }
 
 

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -876,6 +876,9 @@ static void convertRevIDs(NSArray* revIDs,
                     status: (CBLStatus*)outStatus
                      error: (NSError **)outError
 {
+    if (outError)
+        *outError = nil;
+
     if (_forest->isReadOnly()) {
         *outStatus = kCBLStatusForbidden;
         if (outError)
@@ -999,6 +1002,7 @@ static void convertRevIDs(NSArray* revIDs,
     }];
 
     if (CBLStatusIsError(*outStatus)) {
+        // Check if the outError has a value to not override the validation error:
         if (outError && !*outError)
             *outError = CBLStatusToNSError(*outStatus, nil);
         return nil;
@@ -1015,6 +1019,9 @@ static void convertRevIDs(NSArray* revIDs,
                    source: (NSURL*)source
                     error: (NSError **)outError
 {
+    if (outError)
+        *outError = nil;
+
     if (_forest->isReadOnly()) {
         if (outError)
             *outError = CBLStatusToNSError(kCBLStatusForbidden, nil);
@@ -1081,6 +1088,7 @@ static void convertRevIDs(NSArray* revIDs,
         [_delegate databaseStorageChanged: change];
 
     if (CBLStatusIsError(status)) {
+        // Check if the outError has a value to not override the validation error:
         if (outError && !*outError)
             *outError = CBLStatusToNSError(status, nil);
     }

--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -673,11 +673,14 @@ static NSString* joinQuotedEscaped(NSArray* strings);
                       self, rev.docID, [history my_compactDescription]);
 
                 // Insert the revision:
-                int status = [_db forceInsert: rev revisionHistory: history source: _remote];
+                NSError* error;
+                int status = [_db forceInsert: rev revisionHistory: history source: _remote
+                                        error: &error];
                 if (CBLStatusIsError(status)) {
                     if (status == kCBLStatusForbidden) {
                         // Considered a success, since the doc was delivered to the app.
-                        LogTo(Sync, @"%@: Remote rev failed validation: %@", self, rev);
+                        LogTo(Sync, @"%@: Remote rev failed validation: %@ (reason: %@)",
+                              self, rev, error.localizedFailureReason);
                     } else if (status == kCBLStatusDBBusy) {
                         return status;  // abort transaction; _inTransaction will retry
                     } else {

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -1425,6 +1425,9 @@ NSString* CBLJoinSQLQuotedStrings(NSArray* strings) {
                     status: (CBLStatus*)outStatus
                      error: (NSError**)outError
 {
+    if (outError)
+        *outError = nil;
+
     __block NSData* json = nil;
     if (properties) {
         json = [CBL_Revision asCanonicalJSON: properties error: NULL];
@@ -1627,6 +1630,9 @@ NSString* CBLJoinSQLQuotedStrings(NSArray* strings) {
                    source: (NSURL*)source
                     error: (NSError**)outError
 {
+    if (outError)
+        *outError = nil;
+
     CBL_MutableRevision* rev = inRev.mutableCopy;
     rev.sequence = 0;
     NSString* docID = rev.docID;

--- a/Source/CBL_Storage.h
+++ b/Source/CBL_Storage.h
@@ -183,7 +183,8 @@
                   deleting: (BOOL)deleting
              allowConflict: (BOOL)allowConflict
            validationBlock: (CBL_StorageValidationBlock)validationBlock
-                    status: (CBLStatus*)status;
+                    status: (CBLStatus*)status
+                     error: (NSError**)outError;
 
 /** Inserts an already-existing revision (with its revID), plus its ancestry, into a document.
     This is called by the pull replicator to add the revisions received from the server.
@@ -201,7 +202,8 @@
 - (CBLStatus) forceInsert: (CBL_Revision*)inRev
           revisionHistory: (NSArray*)history
           validationBlock: (CBL_StorageValidationBlock)validationBlock
-                   source: (NSURL*)source;
+                   source: (NSURL*)source
+                    error: (NSError**)outError;
 
 /** Purges specific revisions, which deletes them completely from the local database _without_ adding a "tombstone" revision. It's as though they were never there.
     @param docsToRevs  A dictionary mapping document IDs to arrays of revision IDs.

--- a/Source/CBL_Storage.h
+++ b/Source/CBL_Storage.h
@@ -176,6 +176,7 @@
                 the operation by returning an error status.
     @param status  On return a status will be stored here. Note that on success, the
                 status should be 201 for a created revision but 200 for a deletion.
+    @param outError  On return, an error indicating a reason of the failure
     @return  The new revision, with its revID and sequence filled in, or nil on error. */
 - (CBL_Revision*) addDocID: (NSString*)docID
                  prevRevID: (NSString*)prevRevID
@@ -198,6 +199,7 @@
                 the operation by returning an error status.
     @param source  The URL of the remote database this was pulled from, or nil if it's local.
                 (This will be used to create the CBLDatabaseChange object sent to the delegate.)
+    @param outError  On return, an error indicating a reason of the failure.
     @return  Status code; 200 on success, otherwise an error. */
 - (CBLStatus) forceInsert: (CBL_Revision*)inRev
           revisionHistory: (NSArray*)history

--- a/Source/CBL_StorageTypes.h
+++ b/Source/CBL_StorageTypes.h
@@ -21,7 +21,8 @@ typedef CBLQueryRow* (^CBLQueryIteratorBlock)(void);
 /** Document validation callback, passed to the insertion methods. */
 typedef CBLStatus(^CBL_StorageValidationBlock)(CBL_Revision* newRev,
                                                CBL_Revision* prev,
-                                               NSString* parentRevID);
+                                               NSString* parentRevID,
+                                               NSError** outError);
 
 
 /** Standard query options for views. */

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -422,7 +422,8 @@
     doc = [db createDocument];
     Assert(![doc putProperties: properties error: &error]);
     AssertEq(error.code, 403);
-    //AssertEqual(error.localizedDescription, @"forbidden: uncool"); //TODO: Not hooked up yet
+    AssertEqual(error.localizedDescription, @"403 uncool");
+    AssertEqual(error.localizedFailureReason, @"uncool");
 }
 
 

--- a/Unit-Tests/ReplicatorInternal_Tests.m
+++ b/Unit-Tests/ReplicatorInternal_Tests.m
@@ -71,21 +71,27 @@
     NSMutableDictionary* props = $mdict({@"_id", @"doc1"},
                                         {@"foo", @1}, {@"bar", $false});
     CBLStatus status;
+    NSError* error;
     CBL_Revision* rev1 = [db putRevision: [CBL_MutableRevision revisionWithProperties: props]
-                        prevRevisionID: nil allowConflict: NO status: &status];
+                          prevRevisionID: nil allowConflict: NO status: &status error: &error];
     AssertEq(status, kCBLStatusCreated);
+    AssertNil(error);
     
     props[@"_rev"] = rev1.revID;
     props[@"UPDATED"] = $true;
     CBL_Revision* rev2 = [db putRevision: [CBL_MutableRevision revisionWithProperties: props]
-                        prevRevisionID: rev1.revID allowConflict: NO status: &status];
+                          prevRevisionID: rev1.revID allowConflict: NO
+                                  status: &status error: &error];
     AssertEq(status, kCBLStatusCreated);
+    AssertNil(error);
     
     props = $mdict({@"_id", @"doc2"},
                    {@"baz", @(666)}, {@"fnord", $true});
-    [db putRevision: [CBL_MutableRevision revisionWithProperties: props]
-                        prevRevisionID: nil allowConflict: NO status: &status];
+    [db putRevision: [CBL_MutableRevision revisionWithProperties: props ]
+     prevRevisionID: nil allowConflict: NO
+             status: &status error: &error];
     AssertEq(status, kCBLStatusCreated);
+    AssertNil(error);
 #pragma unused(rev2)
     
     // Push them to the remote:
@@ -379,9 +385,11 @@
     for (int i = 1; i <= 10; i++) {
         NSDictionary* props = @{@"_id": $sprintf(@"doc%d", i)};
         CBLStatus status;
+        NSError* error;
         [db putRevision: [CBL_MutableRevision revisionWithProperties: props]
-             prevRevisionID: nil allowConflict: NO status: &status];
+             prevRevisionID: nil allowConflict: NO status: &status error: &error];
         AssertEq(status, kCBLStatusCreated);
+        AssertNil(error);
     }
 
     // Push them to the remote:

--- a/Unit-Tests/Router_Tests.m
+++ b/Unit-Tests/Router_Tests.m
@@ -1206,5 +1206,153 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
     [CBL_URLProtocol setServer: nil];
 }
 
+#pragma mark - Validation:
+
+- (void) test_ValidationMessage {
+    [db setValidationNamed: @"onlyMyDocs"
+                   asBlock: ^(CBLRevision *rev, id<CBLValidationContext> context) {
+                       if (!rev.isDeletion) {
+                           if (![rev.properties[@"type"] isEqualToString:@"doc"])
+                               [context reject];
+                           else if (![rev.properties[@"from"] isEqualToString:@"me"])
+                               [context rejectWithMessage: @"This is not a user doc."];
+                       } else {
+                           BOOL allowed = [rev.parentRevision.properties[@"allow_delete"] boolValue];
+                           if (!allowed)
+                               [context rejectWithMessage: @"This document cannot be deleted."];
+                       }
+    }];
+
+    NSDictionary* result;
+
+    // do_POST OK:
+    result = SendBody(self, @"POST", @"/db",
+             $dict({@"type", @"doc"},
+                   {@"from", @"me"},
+                   {@"title", @"doc1"}), kCBLStatusCreated, nil);
+    Assert(result[@"ok"] != nil);
+    Assert(result[@"id"] != nil);
+    Assert(result[@"rev"] != nil);
+
+    // do_POST forbidden, default message:
+    result = SendBody(self, @"POST", @"/db",
+                      $dict({@"type", @"nondoc"},
+                            {@"from", @"me"},
+                            {@"title", @"nondoc1"}), kCBLStatusForbidden, nil);
+    AssertNil(result[@"rev"]);
+    AssertEqual(result[@"status"], @(403));
+    AssertEqual(result[@"error"], @"forbidden");
+    AssertEqual(result[@"reason"], @"invalid document");
+
+    // do_POST forbidden, custom message:
+    result = SendBody(self, @"POST", @"/db",
+                      $dict({@"type", @"doc"},
+                            {@"from", @"you"},
+                            {@"title", @"doc2"}), kCBLStatusForbidden, nil);
+    AssertEqual(result[@"status"], @(403));
+    AssertEqual(result[@"error"], @"forbidden");
+    AssertEqual(result[@"reason"], @"This is not a user doc.");
+
+    // do_PUT OK:
+    result = SendBody(self, @"PUT", @"/db/doc3",
+                      $dict({@"type", @"doc"},
+                            {@"from", @"me"},
+                            {@"title", @"doc3"}), kCBLStatusCreated, nil);
+    Assert(result[@"ok"] != nil);
+    Assert(result[@"id"] != nil);
+    Assert(result[@"rev"] != nil);
+
+    // do_PUT forbidden, default message:
+    result = SendBody(self, @"PUT", @"/db/doc4",
+                      $dict({@"type", @"nondoc"},
+                            {@"from", @"me"},
+                            {@"title", @"doc4"}), kCBLStatusForbidden, nil);
+    AssertNil(result[@"rev"]);
+    AssertEqual(result[@"status"], @(403));
+    AssertEqual(result[@"error"], @"forbidden");
+    AssertEqual(result[@"reason"], @"invalid document");
+
+    // do_PUT forbidden, custom message:
+    result = SendBody(self, @"PUT", @"/db/doc5",
+                      $dict({@"type", @"doc"},
+                            {@"from", @"you"},
+                            {@"title", @"doc5"}), kCBLStatusForbidden, nil);
+    AssertNil(result[@"rev"]);
+    AssertEqual(result[@"status"], @(403));
+    AssertEqual(result[@"error"], @"forbidden");
+    AssertEqual(result[@"reason"], @"This is not a user doc.");
+
+    // do_POST_bulk_docs, OK:
+    NSArray* bulkResult;
+    bulkResult = SendBody(self, @"POST", @"/db/_bulk_docs",
+                          $dict({@"docs", $array($dict({@"type", @"doc"},
+                                                       {@"from", @"me"},
+                                                       {@"title", @"doc6"}),
+                                                 $dict({@"type", @"doc"},
+                                                       {@"from", @"me"},
+                                                       {@"title", @"doc7"})
+                                                 )}), kCBLStatusCreated, nil);
+    AssertEq((int)bulkResult.count, 2);
+    for (NSDictionary *r in bulkResult) {
+        Assert(r[@"ok"] != nil);
+        Assert(r[@"id"] != nil);
+        Assert(r[@"rev"] != nil);
+    }
+
+    // do_POST_bulk_docs, mixed result:
+    bulkResult = SendBody(self, @"POST", @"/db/_bulk_docs",
+                          $dict({@"docs", $array($dict({@"type", @"doc"},
+                                                       {@"from", @"me"},
+                                                       {@"title", @"doc8"}),
+                                                 $dict({@"type", @"nondoc"},
+                                                       {@"from", @"me"},
+                                                       {@"title", @"doc9"}),
+                                                 $dict({@"type", @"doc"},
+                                                       {@"from", @"you"},
+                                                       {@"title", @"doc10"})
+                                                 )}), kCBLStatusCreated, nil);
+    AssertEq((int)bulkResult.count, 3);
+    Assert(bulkResult[0][@"ok"] != nil);
+    Assert(bulkResult[0][@"id"] != nil);
+    Assert(bulkResult[0][@"rev"] != nil);
+    AssertEqual(bulkResult[1][@"status"], @(403));
+    AssertEqual(bulkResult[1][@"error"], @"forbidden");
+    AssertEqual(bulkResult[1][@"reason"], @"invalid document");
+    AssertEqual(bulkResult[2][@"status"], @(403));
+    AssertEqual(bulkResult[2][@"error"], @"forbidden");
+    AssertEqual(bulkResult[2][@"reason"], @"This is not a user doc.");
+
+    // do_POST_bulk_docs, all_or_nothing=true
+    result = SendBody(self, @"POST", @"/db/_bulk_docs",
+                      $dict({@"all_or_nothing", @"true"},
+                            {@"docs", $array($dict({@"type", @"doc"},
+                                                   {@"from", @"me"},
+                                                   {@"title", @"doc11"}),
+                                             $dict({@"type", @"nondoc"},
+                                                   {@"from", @"me"},
+                                                   {@"title", @"doc12"}),
+                                             $dict({@"type", @"doc"},
+                                                   {@"from", @"you"},
+                                                   {@"title", @"doc13"})
+                                             )}), kCBLStatusForbidden, nil);
+    AssertNil(result[@"rev"]);
+    AssertEqual(result[@"status"], @(403));
+    AssertEqual(result[@"error"], @"forbidden");
+    AssertEqual(result[@"reason"], @"invalid document");
+
+    // do_DELETE
+    result = SendBody(self, @"PUT", @"/db/doc14",
+                      $dict({@"type", @"doc"},
+                            {@"from", @"me"},
+                            {@"title", @"doc14"},
+                            {@"allow_delete", $false}), kCBLStatusCreated, nil);
+    NSString* doc14RevID = result[@"rev"];
+    Assert(doc14RevID != nil);
+    result = Send(self, @"DELETE", $sprintf(@"/db/doc14?rev=%@", doc14RevID),
+                  kCBLStatusForbidden, nil);
+    AssertEqual(result[@"status"], @(403));
+    AssertEqual(result[@"error"], @"forbidden");
+    AssertEqual(result[@"reason"], @"This document cannot be deleted.");
+}
 
 @end


### PR DESCRIPTION
- Propagate rejection message inside an NSError object. This requires to refactor several method to include out NSError object parameters.

- For Router, the result will be sent as part of the response body, for example:
{"status": 403, "error": "forbidden", "reason": "The document cannot be updated!"}

#235