### PR TITLE
Remove NSDataReadingMappedIfSafe when reading attachment content

### DIFF
--- a/Source/API/CBLAttachment.m
+++ b/Source/API/CBLAttachment.m
@@ -118,7 +118,7 @@
             return _body;
         else if ([_body isKindOfClass: [NSURL class]] && [_body isFileURL]) {
             return [NSData dataWithContentsOfURL: _body
-                                         options: NSDataReadingMappedIfSafe | NSDataReadingUncached
+                                         options: NSDataReadingUncached
                                            error: nil];
         }
         return nil;

--- a/Source/CBL_BlobStore.m
+++ b/Source/CBL_BlobStore.m
@@ -120,8 +120,7 @@
 
 - (NSData*) blobForKey: (CBLBlobKey)key {
     NSString* path = [self rawPathForKey: key];
-    NSData* blob =  [NSData dataWithContentsOfFile: path options: NSDataReadingMappedIfSafe
-                                             error: NULL];
+    NSData* blob = [NSData dataWithContentsOfFile: path options: NSDataReadingUncached error: NULL];
     if (_encryptionKey && blob) {
         blob = [_encryptionKey decryptData: blob];
         CBLBlobKey decodedKey = [[self class] keyForBlob: blob];


### PR DESCRIPTION
NSDataReadingMappedIfSafe option can keep the file descriptors of the attachments open if the client application keeps holding the NSData object returned by CBLAttachment.content. For a very big attachment, alternatively, users can call contentURL and read the NSData with the NSDataReadingMappedIfSafe option themselves.

Changes:
1. Remove NSDataReadingMappedIfSafe option from  CBLAttachment.content method.
2. Still keep NSDataReadingMappedIfSafe option in the CBL_BlobStore.blobForKey() method as it gets used internally and no retaining NSData returned by the method.
3. Still keep NSDataReadingMappedIfSafe option in the CBL_BlobStore.blobData() method as the method doesn't get called by any codes.

#649