### PR TITLE
Not pre-open stream in CBL_BlobStore's blobInputStreamForKey

### DIFF
--- a/Source/CBL_BlobStore.m
+++ b/Source/CBL_BlobStore.m
@@ -149,9 +149,10 @@
         }
     }
     NSInputStream* stream = [NSInputStream inputStreamWithFileAtPath: path];
-    [stream open];
-    if (_encryptionKey)
+    if (_encryptionKey) {
+        [stream open];
         stream = [_encryptionKey decryptStream: stream];
+    }
     return stream;
 }
 


### PR DESCRIPTION
- Not pre-opening the stream for non-encrypted BlobStore while getting an InputStream by a blob key.
- This helps reduce number of opened file descriptors when pushing high volumes of documents with attachments in multipart mode as each opened stream will get queued up into an input array of the CBLMultiStreamWriter.

#649