### PR TITLE
Change docid prefix

### DIFF
--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -99,7 +99,7 @@ NSString* CBLCreateUUID() {
     [uuid replaceOccurrencesOfString: @"+" withString: @"-" options: 0 range: NSMakeRange(0, 22)];
     // prefix a '!' to make it more clear where this string came from and prevent having a leading
     // '_' character:
-    [uuid insertString: @"!" atIndex: 0];
+    [uuid insertString: @"-" atIndex: 0];
     return uuid;
 }
 


### PR DESCRIPTION
Change docid prefix from '!' to '-'. Using '!' doesn't work with sync function for the case of using the docid to construct a channel name. Sync gateway doesn't allow '!' as part of the channel name.

#661