### PR TITLE
Fix for CBL-ios issue 648

### DIFF
--- a/Source/API/CBLModel+Properties.m
+++ b/Source/API/CBLModel+Properties.m
@@ -239,10 +239,6 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                 };
             }
         }
-        else if ( [itemClass isSubclassOfClass: [NSObject class]] && ![itemClass isSubclassOfClass:[NSDate class]])
-        {
-            return [super impForGetterOfProperty: property ofClass: propertyClass];
-        }
         else {
             // Typed array of scalar class:
             ValueConverter itemConverter = valueConverterToClass(itemClass);
@@ -252,6 +248,10 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                     return [receiver getProperty: property withConverter: converter];
                 };
             }
+            else if([itemClass isSubclassOfClass: [NSObject class]])
+            {
+                return [super impForGetterOfProperty: property ofClass: itemClass];
+            }
         }
     } else if ([propertyClass isSubclassOfClass: [CBLModel class]]) {
         // Model-valued property:
@@ -259,10 +259,7 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
             return [receiver getModelProperty: property];
         };
     }
-    else if ( [propertyClass isSubclassOfClass: [NSObject class]] && ![propertyClass isSubclassOfClass:[NSDate class]])
-    {
-        return [super impForGetterOfProperty: property ofClass: propertyClass];
-    }
+
     else {
         // Other property type -- use a ValueConverter if we have one:
         ValueConverter converter = valueConverterToClass(propertyClass);
@@ -270,6 +267,10 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
             impBlock = ^id(CBLModel* receiver) {
                 return [receiver getProperty: property withConverter: converter];
             };
+        }
+        else if([propertyClass isSubclassOfClass: [NSObject class]])
+        {
+            return [super impForGetterOfProperty: property ofClass: propertyClass];
         }
     }
 

--- a/Source/API/CBLModel+Properties.m
+++ b/Source/API/CBLModel+Properties.m
@@ -238,7 +238,12 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                     return [receiver getArrayRelationProperty: property withModelClass: itemClass];
                 };
             }
-        } else {
+        }
+        else if ( [itemClass isSubclassOfClass: [NSObject class]] && ![itemClass isSubclassOfClass:[NSDate class]])
+        {
+            return [super impForGetterOfProperty: property ofClass: propertyClass];
+        }
+        else {
             // Typed array of scalar class:
             ValueConverter itemConverter = valueConverterToClass(itemClass);
             if (itemConverter) {
@@ -253,7 +258,12 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
         impBlock = ^id(CBLModel* receiver) {
             return [receiver getModelProperty: property];
         };
-    } else {
+    }
+    else if ( [propertyClass isSubclassOfClass: [NSObject class]] && ![propertyClass isSubclassOfClass:[NSDate class]])
+    {
+        return [super impForGetterOfProperty: property ofClass: propertyClass];
+    }
+    else {
         // Other property type -- use a ValueConverter if we have one:
         ValueConverter converter = valueConverterToClass(propertyClass);
         if (converter) {
@@ -300,7 +310,13 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                 }
                 [receiver setValue: value ofProperty: property];
             };
-        } else {
+        }
+        else if ([propertyClass isSubclassOfClass: [NSObject class]])
+        {
+             return [super impForSetterOfProperty: property ofClass: propertyClass];
+        }
+        
+        else {
             // Scalar-valued array:
             impBlock = ^(CBLModel* receiver, NSArray* value) {
                 [receiver setValue: value ofProperty: property];
@@ -316,7 +332,12 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
             }
             [receiver setValue: value ofProperty: property];
         };
-    } else {
+    }
+    else if ([propertyClass isSubclassOfClass: [NSObject class]])
+    {
+        return [super impForSetterOfProperty: property ofClass: propertyClass];
+    }
+    else {
         return [super impForSetterOfProperty: property ofClass: propertyClass];
     }
 


### PR DESCRIPTION
This is my fix for #648. Intentionally excluding NSDate in the NSObject subclass check since it is handled best in the final else catch-all case, and NSObject handing of NSDate is not appropriate/does not work. Maybe more elegant way to implement this as there might be other cases (e.g. other classes) that the coe should be letting the final catch-all else handle using ValueConverter handle (I doubt NSDate is the only such case?), but wanted to avoid significantly changing the structure/flow of this code as it is not originally my code and my understanding of it is not good enough and wanted to leave the least trace possible with this fix, I can imagine reworking this in a few ways to handle this, but it would probably change the method and break other cases, so excluding NSDate subclasses in the NSObject else if I added for now...

https://github.com/couchbase/couchbase-lite-ios/issues/648