### PR TITLE
Fix for Issue 648

### DIFF
--- a/Source/API/CBLModel+Properties.m
+++ b/Source/API/CBLModel+Properties.m
@@ -239,10 +239,6 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                 };
             }
         }
-        else if ( [itemClass isSubclassOfClass: [NSObject class]] && ![itemClass isSubclassOfClass:[NSDate class]])
-        {
-            return [super impForGetterOfProperty: property ofClass: propertyClass];
-        }
         else {
             // Typed array of scalar class:
             ValueConverter itemConverter = valueConverterToClass(itemClass);
@@ -252,6 +248,10 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                     return [receiver getProperty: property withConverter: converter];
                 };
             }
+            else if([itemClass isSubclassOfClass: [NSObject class]])
+            {
+                return [super impForGetterOfProperty: property ofClass: itemClass];
+            }
         }
     } else if ([propertyClass isSubclassOfClass: [CBLModel class]]) {
         // Model-valued property:
@@ -259,10 +259,7 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
             return [receiver getModelProperty: property];
         };
     }
-    else if ( [propertyClass isSubclassOfClass: [NSObject class]] && ![propertyClass isSubclassOfClass:[NSDate class]])
-    {
-        return [super impForGetterOfProperty: property ofClass: propertyClass];
-    }
+
     else {
         // Other property type -- use a ValueConverter if we have one:
         ValueConverter converter = valueConverterToClass(propertyClass);
@@ -270,6 +267,10 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
             impBlock = ^id(CBLModel* receiver) {
                 return [receiver getProperty: property withConverter: converter];
             };
+        }
+        else if([propertyClass isSubclassOfClass: [NSObject class]])
+        {
+            return [super impForGetterOfProperty: property ofClass: propertyClass];
         }
     }
 

--- a/Source/API/CBLModel+Properties.m
+++ b/Source/API/CBLModel+Properties.m
@@ -238,7 +238,12 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                     return [receiver getArrayRelationProperty: property withModelClass: itemClass];
                 };
             }
-        } else {
+        }
+        else if ( [itemClass isSubclassOfClass: [NSObject class]] && ![itemClass isSubclassOfClass:[NSDate class]])
+        {
+            return [super impForGetterOfProperty: property ofClass: propertyClass];
+        }
+        else {
             // Typed array of scalar class:
             ValueConverter itemConverter = valueConverterToClass(itemClass);
             if (itemConverter) {
@@ -253,7 +258,12 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
         impBlock = ^id(CBLModel* receiver) {
             return [receiver getModelProperty: property];
         };
-    } else {
+    }
+    else if ( [propertyClass isSubclassOfClass: [NSObject class]] && ![propertyClass isSubclassOfClass:[NSDate class]])
+    {
+        return [super impForGetterOfProperty: property ofClass: propertyClass];
+    }
+    else {
         // Other property type -- use a ValueConverter if we have one:
         ValueConverter converter = valueConverterToClass(propertyClass);
         if (converter) {
@@ -300,7 +310,13 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
                 }
                 [receiver setValue: value ofProperty: property];
             };
-        } else {
+        }
+        else if ([propertyClass isSubclassOfClass: [NSObject class]])
+        {
+             return [super impForSetterOfProperty: property ofClass: propertyClass];
+        }
+        
+        else {
             // Scalar-valued array:
             impBlock = ^(CBLModel* receiver, NSArray* value) {
                 [receiver setValue: value ofProperty: property];
@@ -316,7 +332,12 @@ static ValueConverter arrayValueConverter(ValueConverter itemConverter) {
             }
             [receiver setValue: value ofProperty: property];
         };
-    } else {
+    }
+    else if ([propertyClass isSubclassOfClass: [NSObject class]])
+    {
+        return [super impForSetterOfProperty: property ofClass: propertyClass];
+    }
+    else {
         return [super impForSetterOfProperty: property ofClass: propertyClass];
     }
 


### PR DESCRIPTION
Improved fix for #648 

Adding a "bottom of the totem pole" check for generating methods for getter implementation in unhandled cases of NSObject subclasses.

Essentially, defaults to "Nil" behavior if we can't get a better/more specific implementation for NSObject subclasses. 