### PR TITLE
Fix pulling documents with sub attachments failure

### DIFF
--- a/Source/CBLBulkDownloader.m
+++ b/Source/CBLBulkDownloader.m
@@ -48,10 +48,10 @@
 {
     // Build up a JSON body describing what revisions we want:
     NSArray* keys = [revs my_map: ^(CBL_Revision* rev) {
-        NSArray* attsSince = [_db.storage getPossibleAncestorRevisionIDs: rev
+        NSArray* attsSince = [database.storage getPossibleAncestorRevisionIDs: rev
                                                            limit: kMaxNumberOfAttsSince
                                                  onlyAttachments: YES];
-        if (!attsSince.count == 0)
+        if (attsSince.count == 0)
             attsSince = nil;
         return $dict({@"id", rev.docID},
                      {@"rev", rev.revID},

--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -279,7 +279,7 @@ static UInt64 smallestLength(NSDictionary* attachment) {
     unsigned generation = [CBL_Revision generationFromRevID: prevRevID] + 1;
     __block NSDictionary* parentAttachments = nil;
 
-    return [rev mutateAttachments: ^NSDictionary *(NSString *name, NSDictionary *attachInfo) {
+    [rev mutateAttachments: ^NSDictionary *(NSString *name, NSDictionary *attachInfo) {
         CBL_Attachment* attachment = [[CBL_Attachment alloc] initWithName: name
                                                                      info: attachInfo
                                                                    status: outStatus];
@@ -338,6 +338,8 @@ static UInt64 smallestLength(NSDictionary* attachment) {
         Assert(attachment.isValid);
         return attachment.asStubDictionary;
     }];
+
+    return !CBLStatusIsError(*outStatus);
 }
 
 

--- a/Source/CBLDatabase+Insertion.m
+++ b/Source/CBLDatabase+Insertion.m
@@ -228,8 +228,8 @@
         NSString* prevRevID = history.count >= 2 ? history[1] : nil;
         if (![self processAttachmentsForRevision: updatedRev
                                        prevRevID: prevRevID
-                                          status: &status])
-        return status;
+                                          status: &status] && CBLStatusIsError(status))
+            return status;
         inRev = updatedRev;
     }
 

--- a/Source/CBLDatabase+Insertion.m
+++ b/Source/CBLDatabase+Insertion.m
@@ -228,7 +228,7 @@
         NSString* prevRevID = history.count >= 2 ? history[1] : nil;
         if (![self processAttachmentsForRevision: updatedRev
                                        prevRevID: prevRevID
-                                          status: &status] && CBLStatusIsError(status))
+                                          status: &status])
             return status;
         inRev = updatedRev;
     }

--- a/Source/CBL_Pusher.m
+++ b/Source/CBL_Pusher.m
@@ -293,7 +293,7 @@
                             // Look for the latest common ancestor and stub out older attachments:
                             int minRevPos = CBLFindCommonAncestor(populatedRev, possibleAncestors);
                             if (![db expandAttachmentsIn: populatedRev
-                                             minRevPos: minRevPos
+                                               minRevPos: minRevPos + 1
                                             allowFollows: !_dontSendMultipart
                                                   decode: NO
                                                   status: &status]) {

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -614,9 +614,12 @@ static void CBLComputeFTSRank(sqlite3_context *pCtx, int nVal, sqlite3_value **a
     CBLStatus status = kCBLStatusNotFound;
     if ([r next]) {
         // Found the rev. But the JSON still might be null if the database has been compacted.
-        status = kCBLStatusOK;
-        rev.sequence = [r longLongIntForColumnIndex: 0];
-        rev.asJSON = [r dataNoCopyForColumnIndex: 1];
+        NSData* json = [r dataNoCopyForColumnIndex: 1];
+        if (json) {
+            status = kCBLStatusOK;
+            rev.sequence = [r longLongIntForColumnIndex: 0];
+            rev.asJSON = json;
+        }
     }
     [r close];
     return status;


### PR DESCRIPTION
Two related issues have been fixed:
1. Correct minRevPos value when stripping the (non modified) attachments. This corrects the performance optimization when pushing documents that have non-modified attachments.
2. Applying a patch from @snej that "if the attachment is a stub, and the parent revision's JSON isn't known, but the attachment exists locally (based on its digest), just leave the stub alone".

#672