### PR TITLE
Backout the database file layout for SQLite storage

### DIFF
--- a/Source/API/CBLDatabase.m
+++ b/Source/API/CBLDatabase.m
@@ -54,15 +54,15 @@ static id<CBLFilterCompiler> sFilterCompiler;
 
 
 @synthesize manager=_manager, unsavedModelsMutable=_unsavedModelsMutable;
-@synthesize dir=_dir, name=_name, isOpen=_isOpen;
+@synthesize path=_path, name=_name, isOpen=_isOpen;
 
 
-- (instancetype) initWithDir: (NSString*)dir
-                        name: (NSString*)name
-                     manager: (CBLManager*)manager
-                    readOnly: (BOOL)readOnly
+- (instancetype) initWithPath: (NSString*)path
+                         name: (NSString*)name
+                      manager: (CBLManager*)manager
+                     readOnly: (BOOL)readOnly
 {
-    self = [self _initWithDir: dir name: name manager: manager readOnly: readOnly];
+    self = [self _initWithPath: path name: name manager: manager readOnly: readOnly];
     if (self) {
         _unsavedModelsMutable = [NSMutableSet set];
         _allReplications = [[NSMutableSet alloc] init];
@@ -208,7 +208,7 @@ static void catchInBlock(void (^block)()) {
 
 
 - (BOOL) deleteDatabase: (NSError**)outError {
-    LogTo(CBLDatabase, @"Deleting %@", _dir);
+    LogTo(CBLDatabase, @"Deleting %@", _path);
     [[NSNotificationCenter defaultCenter] postNotificationName: CBL_DatabaseWillBeDeletedNotification
                                                         object: self];
     [self _close];
@@ -219,7 +219,7 @@ static void catchInBlock(void (^block)()) {
     if (!self.exists) {
         return YES;
     }
-    return [[self class] deleteDatabaseFilesAtPath: _dir error: outError];
+    return [[self class] deleteDatabaseFilesAtPath: _path error: outError];
 }
 
 

--- a/Source/API/CBLManager.h
+++ b/Source/API/CBLManager.h
@@ -96,14 +96,16 @@ typedef struct CBLManagerOptions {
 @property (readonly) NSArray* allDatabaseNames;
 
 /** Replaces or installs a database from a file.
-    This is primarily used to install a canned database on first launch of an app, in which case you should first check .exists to avoid replacing the database if it exists already. The canned database would have been copied into your app bundle at build time.
-    @param databaseName  The name of the database to replace.
-    @param databaseDir  Path of the database directory that should replace it.
-    @param outError  If an error occurs, it will be stored into this parameter on return.
-    @return  YES if the database was copied, NO if an error occurred. */
+ This is primarily used to install a canned database on first launch of an app, in which case you should first check .exists to avoid replacing the database if it exists already. The canned database would have been copied into your app bundle at build time.
+ @param databaseName  The name of the database to replace.
+ @param databasePath  Path of the database file that should replace it.
+ @param attachmentsPath  Path of the associated attachments directory, or nil if there are no attachments.
+ @param outError  If an error occurs, it will be stored into this parameter on return.
+ @return  YES if the database was copied, NO if an error occurred. */
 - (BOOL) replaceDatabaseNamed: (NSString*)databaseName
-              withDatabaseDir: (NSString*)databaseDir
-                        error: (NSError**)outError;
+             withDatabaseFile: (NSString*)databasePath
+              withAttachments: (NSString*)attachmentsPath
+                        error: (NSError**)outError                  __attribute__((nonnull(1,2)));
 
 #pragma mark - CONCURRENCY:
 

--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -26,10 +26,10 @@
 
 
 @interface CBLDatabase ()
-- (instancetype) initWithDir: (NSString*)dir
-                        name: (NSString*)name
-                     manager: (CBLManager*)manager
-                    readOnly: (BOOL)readOnly;
+- (instancetype) initWithPath: (NSString*)path
+                         name: (NSString*)name
+                      manager: (CBLManager*)manager
+                     readOnly: (BOOL)readOnly;
 @property (readonly, nonatomic) NSMutableSet* unsavedModelsMutable;
 - (void) removeDocumentFromCache: (CBLDocument*)document;
 - (void) doAsyncAfterDelay: (NSTimeInterval)delay block: (void (^)())block;

--- a/Source/CBLDatabase+Attachments.h
+++ b/Source/CBLDatabase+Attachments.h
@@ -20,6 +20,8 @@ typedef enum {
 
 @interface CBLDatabase (Attachments)
 
+// + (NSString*) attachmentStorePath: (NSString*)dbPath;
++ (NSString*) attachmentStorePath: (NSString*)dbPath storageType: (NSString*)storageType;
 @property (readonly) NSString* attachmentStorePath;
 
 + (NSString*) blobKeyToDigest: (CBLBlobKey)key;

--- a/Source/CBLDatabase+Attachments.h
+++ b/Source/CBLDatabase+Attachments.h
@@ -20,8 +20,6 @@ typedef enum {
 
 @interface CBLDatabase (Attachments)
 
-// + (NSString*) attachmentStorePath: (NSString*)dbPath;
-+ (NSString*) attachmentStorePath: (NSString*)dbPath storageType: (NSString*)storageType;
 @property (readonly) NSString* attachmentStorePath;
 
 + (NSString*) blobKeyToDigest: (CBLBlobKey)key;

--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -49,15 +49,8 @@
     return [@"sha1-" stringByAppendingString: [CBLBase64 encode: &key length: sizeof(key)]];
 }
 
-+ (NSString*) attachmentStorePath: (NSString*)dbPath storageType: (NSString*)storageType {
-    if ([storageType isEqualToString: @"ForestDB"] && NSClassFromString(@"CBL_ForestDBStorage"))
-        return [dbPath stringByAppendingPathComponent: @"attachments"];
-    else
-        return [[dbPath stringByDeletingPathExtension] stringByAppendingString: @" attachments"];
-}
-
 - (NSString*) attachmentStorePath {
-    return [[self class] attachmentStorePath: _path storageType: _manager.storageType];
+    return [_storage attachmentStorePath];
 }
 
 

--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -49,8 +49,15 @@
     return [@"sha1-" stringByAppendingString: [CBLBase64 encode: &key length: sizeof(key)]];
 }
 
++ (NSString*) attachmentStorePath: (NSString*)dbPath storageType: (NSString*)storageType {
+    if ([storageType isEqualToString: @"ForestDB"] && NSClassFromString(@"CBL_ForestDBStorage"))
+        return [dbPath stringByAppendingPathComponent: @"attachments"];
+    else
+        return [[dbPath stringByDeletingPathExtension] stringByAppendingString: @" attachments"];
+}
+
 - (NSString*) attachmentStorePath {
-    return [_dir stringByAppendingPathComponent: @"attachments"];
+    return [[self class] attachmentStorePath: _path storageType: _manager.storageType];
 }
 
 

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -37,7 +37,7 @@ extern NSArray* CBL_RunloopModes;
 @interface CBLDatabase ()
 {
     @private
-    NSString* _dir;
+    NSString* _path;
     NSString* _name;
     CBLManager* _manager;
     id<CBL_Storage> _storage;
@@ -60,7 +60,7 @@ extern NSArray* CBL_RunloopModes;
 }
 
 @property (nonatomic, readwrite, copy) NSString* name;  // make it settable
-@property (nonatomic, readonly) NSString* dir;
+@property (nonatomic, readonly) NSString* path;
 @property (nonatomic, readonly) BOOL isOpen;
 
 - (void) postPublicChangeNotification: (NSArray*)changes; // implemented in CBLDatabase.m
@@ -72,10 +72,10 @@ extern NSArray* CBL_RunloopModes;
 // Internal API
 @interface CBLDatabase (Internal) <CBL_StorageDelegate>
 
-- (instancetype) _initWithDir: (NSString*)dirPath
-                         name: (NSString*)name
-                      manager: (CBLManager*)manager
-                     readOnly: (BOOL)readOnly;
+- (instancetype) _initWithPath: (NSString*)path
+                          name: (NSString*)name
+                       manager: (CBLManager*)manager
+                      readOnly: (BOOL)readOnly;
 + (BOOL) deleteDatabaseFilesAtPath: (NSString*)dbPath error: (NSError**)outError;
 
 #if DEBUG

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -95,7 +95,8 @@ static BOOL sAutoCompact = YES;
     if (isDir)
         return CBLRemoveFileIfExists(dbPath, outError);
     else {
-        NSString *attsPath = [self attachmentStorePath: dbPath storageType: @"SQLite"];
+        NSString *attsPath = [[dbPath stringByDeletingPathExtension]
+                              stringByAppendingString: @" attachments"];
         return CBLRemoveFileIfExists(dbPath, outError)
             && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-wal"], outError)
             && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-shm"], outError)
@@ -178,14 +179,6 @@ static BOOL sAutoCompact = YES;
     id<CBL_Storage> storage = [[secondaryStorage alloc] init];
     if (![storage databaseExistsAtPath: _path])
         storage = [[primaryStorage alloc] init];
-
-    if ([storage isKindOfClass: NSClassFromString(@"CBL_ForestDBStorage")]) {
-        if (![[NSFileManager defaultManager] createDirectoryAtPath: _path
-                                   withIntermediateDirectories: YES
-                                                    attributes: nil
-                                                         error: outError])
-            return NO;
-    }
 
     LogTo(CBLDatabase, @"Using %@ for db at %@", [storage class], _path);
 

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -87,17 +87,34 @@ static BOOL sAutoCompact = YES;
 }
 
 
-+ (BOOL) deleteDatabaseFilesAtPath: (NSString*)dbDir error: (NSError**)outError {
-    return CBLRemoveFileIfExists(dbDir, outError);
++ (BOOL) deleteDatabaseFilesAtPath: (NSString*)dbPath error: (NSError**)outError {
+    BOOL isDir;
+    if (![[NSFileManager defaultManager] fileExistsAtPath:dbPath isDirectory:&isDir])
+        return YES;
+
+    if (isDir)
+        return CBLRemoveFileIfExists(dbPath, outError);
+    else {
+        NSString *attsPath = [self attachmentStorePath: dbPath storageType: @"SQLite"];
+        return CBLRemoveFileIfExists(dbPath, outError)
+            && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-wal"], outError)
+            && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-shm"], outError)
+            && CBLRemoveFileIfExists(attsPath, outError)
+#ifdef MOCK_ENCRYPTION
+            && CBLRemoveFileIfExists([[dbPath stringByDeletingPathExtension]
+                                      stringByAppendingString: @" mock_key"], outError)
+#endif
+        ;
+    }
 }
 
 
 #if DEBUG
-+ (instancetype) createEmptyDBAtPath: (NSString*)dir {
++ (instancetype) createEmptyDBAtPath: (NSString*)path {
     [self setAutoCompact: NO]; // unit tests don't want autocompact
-    if (![self deleteDatabaseFilesAtPath: dir error: NULL])
+    if (![self deleteDatabaseFilesAtPath: path error: NULL])
         return nil;
-    CBLDatabase *db = [[self alloc] initWithDir: dir name: nil manager: nil readOnly: NO];
+    CBLDatabase *db = [[self alloc] initWithPath: path name: nil manager: nil readOnly: NO];
     if (![db open: nil])
         return nil;
     AssertEq(db.lastSequenceNumber, 0); // Sanity check that this is not a pre-existing db
@@ -106,16 +123,16 @@ static BOOL sAutoCompact = YES;
 #endif
 
 
-- (instancetype) _initWithDir: (NSString*)dirPath
-                         name: (NSString*)name
-                      manager: (CBLManager*)manager
-                     readOnly: (BOOL)readOnly
+- (instancetype) _initWithPath: (NSString*)path
+                          name: (NSString*)name
+                       manager: (CBLManager*)manager
+                      readOnly: (BOOL)readOnly
 {
     if (self = [super init]) {
-        Assert([dirPath hasPrefix: @"/"], @"Path must be absolute");
-        _dir = [dirPath copy];
+        Assert([path hasPrefix: @"/"], @"Path must be absolute");
+        _path = [path copy];
         _manager = manager;
-        _name = name ?: [dirPath.lastPathComponent.stringByDeletingPathExtension copy];
+        _name = name ?: [_path.lastPathComponent.stringByDeletingPathExtension copy];
         _readOnly = readOnly;
 
         _dispatchQueue = manager.dispatchQueue;
@@ -131,7 +148,7 @@ static BOOL sAutoCompact = YES;
 }
 
 - (BOOL) exists {
-    return [[NSFileManager defaultManager] fileExistsAtPath: _dir];
+    return [[NSFileManager defaultManager] fileExistsAtPath: _path];
 }
 
 
@@ -144,13 +161,6 @@ static BOOL sAutoCompact = YES;
     if (_isOpen)
         return YES;
     LogTo(CBLDatabase, @"Opening %@", self);
-
-    // Create the database directory:
-    if (![[NSFileManager defaultManager] createDirectoryAtPath: _dir
-                                   withIntermediateDirectories: YES
-                                                    attributes: nil
-                                                         error: outError])
-        return NO;
 
     // Instantiate storage:
     NSString* storageType = _manager.storageType ?: @"SQLite";
@@ -166,16 +176,25 @@ static BOOL sAutoCompact = YES;
         secondaryStorage = NSClassFromString(@"CBL_SQLiteStorage");
     // Use primary unless dir already contains a db created by secondary:
     id<CBL_Storage> storage = [[secondaryStorage alloc] init];
-    if (![storage databaseExistsIn: _dir])
+    if (![storage databaseExistsAtPath: _path])
         storage = [[primaryStorage alloc] init];
-    LogTo(CBLDatabase, @"Using %@ for db at %@", [storage class], _dir);
+
+    if ([storage isKindOfClass: NSClassFromString(@"CBL_ForestDBStorage")]) {
+        if (![[NSFileManager defaultManager] createDirectoryAtPath: _path
+                                   withIntermediateDirectories: YES
+                                                    attributes: nil
+                                                         error: outError])
+            return NO;
+    }
+
+    LogTo(CBLDatabase, @"Using %@ for db at %@", [storage class], _path);
 
     _storage = storage;
     _storage.delegate = self;
-    if (![_storage openInDirectory: _dir
-                          readOnly: _readOnly
-                           manager: _manager
-                             error: outError])
+    if (![_storage openAtPath: _path
+                     readOnly: _readOnly
+                      manager: _manager
+                        error: outError])
         return NO;
     _storage.autoCompact = sAutoCompact;
 
@@ -214,7 +233,7 @@ static BOOL sAutoCompact = YES;
 
 - (void) _close {
     if (_isOpen) {
-        LogTo(CBLDatabase, @"Closing <%p> %@", self, _dir);
+        LogTo(CBLDatabase, @"Closing <%p> %@", self, _path);
         // Don't want any models trying to save themselves back to the db. (Generally there shouldn't
         // be any, because the public -close: method saves changes first.)
         for (CBLModel* model in _unsavedModelsMutable.copy)
@@ -252,10 +271,28 @@ static BOOL sAutoCompact = YES;
 
 
 - (UInt64) totalDataSize {
-    NSDirectoryEnumerator* e = [[NSFileManager defaultManager] enumeratorAtPath: _dir];
+    BOOL isDir;
+    if (![[NSFileManager defaultManager] fileExistsAtPath:_path isDirectory:&isDir])
+        return 0;
+
     UInt64 size = 0;
-    while ([e nextObject])
-        size += e.fileAttributes.fileSize;
+    if (isDir) {
+        // New file layout:
+        NSDirectoryEnumerator* e = [[NSFileManager defaultManager] enumeratorAtPath: _path];
+
+        while ([e nextObject])
+            size += e.fileAttributes.fileSize;
+    } else {
+        for (NSString* suffix in @[@"", @"-wal", @"-shm"]) {
+            NSDictionary* attrs = [[NSFileManager defaultManager]
+                                   attributesOfItemAtPath: [_path stringByAppendingString: suffix]
+                                   error: NULL];
+            if (!attrs)
+                continue;
+            size = size + attrs.fileSize + _attachments.totalDataSize;
+        }
+    }
+    
     return size;
 }
 
@@ -363,7 +400,7 @@ static BOOL sAutoCompact = YES;
 - (void) dbChanged: (NSNotification*)n {
     CBLDatabase* senderDB = n.object;
     // Was this posted by a _different_ CBLDatabase instance on the same database as me?
-    if (senderDB != self && [senderDB.dir isEqualToString: _dir]) {
+    if (senderDB != self && [senderDB.path isEqualToString: _path]) {
         // Careful: I am being called on senderDB's thread, not my own!
         if ([[n name] isEqualToString: CBL_DatabaseChangesNotification]) {
             NSMutableArray* echoedChanges = $marray();

--- a/Source/CBLMisc.h
+++ b/Source/CBLMisc.h
@@ -93,6 +93,8 @@ BOOL CBLRemoveFileIfExists(NSString* path, NSError** outError) __attribute__((no
    The file will be moved to the temp folder and renamed before it is deleted. */
 BOOL CBLRemoveFileIfExistsAsync(NSString* path, NSError** outError);
 
+BOOL CBLCopyFileIfExists(NSString*atPath, NSString* toPath, NSError** outError) __attribute__((nonnull(1, 2)));
+
 /** Returns the hostname of this computer/device (will be of the form "___.local") */
 NSString* CBLGetHostName(void);
 

--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -402,6 +402,21 @@ BOOL CBLRemoveFileIfExistsAsync(NSString* path, NSError** outError) {
     }
 }
 
+BOOL CBLCopyFileIfExists(NSString* atPath, NSString* toPath, NSError** outError) {
+    NSFileManager *fmgr = [NSFileManager defaultManager];
+    if ([fmgr fileExistsAtPath:atPath isDirectory:NULL]) {
+        NSError *error;
+        if ([fmgr copyItemAtPath: atPath toPath: toPath error: &error])
+            return YES;
+        else {
+            if (outError)
+                *outError = error;
+            return NO;
+        }
+    } else
+        return YES;
+}
+
 NSString* CBLGetHostName() {
     // From <http://stackoverflow.com/a/16902907/98077>
     char baseHostName[256];

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -97,22 +97,22 @@ static void FDBLogCallback(forestdb::logLevel level, const char *message) {
 }
 
 
-- (BOOL) databaseExistsIn: (NSString*)directory {
-    NSString* dbPath = [directory stringByAppendingPathComponent: kDBFilename];
+- (BOOL) databaseExistsAtPath: (NSString*)path {
+    NSString* dbPath = [path stringByAppendingPathComponent: kDBFilename];
     return [[NSFileManager defaultManager] fileExistsAtPath: dbPath isDirectory: NULL];
 }
 
 
-- (BOOL)openInDirectory: (NSString *)directory
-               readOnly: (BOOL)readOnly
-                manager: (CBLManager*)manager
-                  error: (NSError**)outError
+- (BOOL)openAtPath: (NSString *)path
+          readOnly: (BOOL)readOnly
+           manager: (CBLManager*)manager
+             error: (NSError**)outError
 {
     if (_delegate.encryptionKey)
         return ReturnNSErrorFromCBLStatus(kCBLStatusNotImplemented, outError);
 
-    _directory = [directory copy];
-    NSString* forestPath = [directory stringByAppendingPathComponent: kDBFilename];
+    _directory = [path copy];
+    NSString* forestPath = [path stringByAppendingPathComponent: kDBFilename];
     fdb_open_flags flags = readOnly ? FDB_OPEN_FLAG_RDONLY : FDB_OPEN_FLAG_CREATE;
 
     Database::config config = Database::defaultConfig();

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -108,6 +108,13 @@ static void FDBLogCallback(forestdb::logLevel level, const char *message) {
            manager: (CBLManager*)manager
              error: (NSError**)outError
 {
+    if (![[NSFileManager defaultManager] createDirectoryAtPath: path
+                                   withIntermediateDirectories: YES
+                                                    attributes: nil
+                                                         error: outError]) {
+        return NO;
+    }
+
     if (_delegate.encryptionKey)
         return ReturnNSErrorFromCBLStatus(kCBLStatusNotImplemented, outError);
 
@@ -222,6 +229,12 @@ static void FDBLogCallback(forestdb::logLevel level, const char *message) {
     return _transactionLevel > 0;
 }
 
+
+#pragma mark - ATTACHMENT STORE PATH:
+
+- (NSString*) attachmentStorePath {
+    return [_directory stringByAppendingPathComponent: @"attachments"];
+}
 
 #pragma mark - DOCUMENTS:
 

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -526,6 +526,12 @@ static void CBLComputeFTSRank(sqlite3_context *pCtx, int nVal, sqlite3_value **a
 }
 
 
+#pragma mark - ATTACHMENT STORE PATH:
+
+- (NSString*) attachmentStorePath {
+    return [[_path stringByDeletingPathExtension] stringByAppendingString: @" attachments"];
+}
+
 #pragma mark - DOCUMENTS:
 
 

--- a/Source/CBL_Storage.h
+++ b/Source/CBL_Storage.h
@@ -80,6 +80,9 @@
 - (CBLStatus) inTransaction: (CBLStatus(^)())block;
 
 
+// ATTACHMENT STORE PATH:
+@property (readonly) NSString* attachmentStorePath;
+
 // DOCUMENTS:
 
 /** Retrieves a document revision by ID.

--- a/Source/CBL_Storage.h
+++ b/Source/CBL_Storage.h
@@ -19,23 +19,23 @@
 
 // INITIALIZATION AND CONFIGURATION:
 
-/** Preflight to see if a database file exists in this directory. Called _before_ -open! */
-- (BOOL) databaseExistsIn: (NSString*)directory;
+/** Preflight to see if a database file exists in this path. Called _before_ -open! */
+- (BOOL) databaseExistsAtPath: (NSString*)path;
 
 /** Opens storage. Files will be created in the directory, which must already exist.
-    @param directory  The existing directory to put data files into. The implementation may
-        create as many files as it wants here. There will be a subdirectory called "attachments"
-        which contains attachments; don't mess with that.
+    @param path  The existing database path which could be a path to a sqlite file for the 
+        SQLite storage or a bundle directory including database files and an attachments folder
+        for the ForestDB storage.
     @param readOnly  If this is YES, the database is opened read-only and any attempt to modify
         it must return an error.
     @param manager  The owning CBLManager; this is provided so the storage can examine its
         properties.
     @param error  On failure, store an NSError here if it's non-NULL.
     @return  YES on success, NO on failure. */
-- (BOOL) openInDirectory: (NSString*)directory
-                readOnly: (BOOL)readOnly
-                 manager: (CBLManager*)manager
-                   error: (NSError**)error;
+- (BOOL) openAtPath: (NSString*)path
+           readOnly: (BOOL)readOnly
+            manager: (CBLManager*)manager
+              error: (NSError**)error;
 
 /** Closes storage before it's deallocated. */
 - (void) close;

--- a/Unit-Tests/ViewInternal_Tests.m
+++ b/Unit-Tests/ViewInternal_Tests.m
@@ -433,7 +433,7 @@ static NSArray* rowsToDictsSettingDB(CBLDatabase* db, CBLQueryIteratorBlock iter
     db = nil;
 
     // Re-open database:
-    db = [[CBLDatabase alloc] initWithDir: dbPath name: nil manager: nil readOnly: NO];
+    db = [[CBLDatabase alloc] initWithPath: dbPath name: nil manager: nil readOnly: NO];
     Assert([db open: nil]);
     view = [self createView];
     Assert(!view.stale);


### PR DESCRIPTION
- SQLite storage uses the 1.0 layout:
  Database: .../DB_NAME.cblite
  Attachments: .../DB_NAME attachments/

- ForestDB storage uses the new bundle layout with .cblite folder name extension:
  Database: .../DB_NAME.cblite/db.forest
  Attachments: .../DB_NAME.cblite/attachments/

- Set SQLite scheme version to 101 (non-backward compatible). Bumped non-backward version check to 200.

#676