### PR TITLE
Fix bg database not getting closed

### DIFF
--- a/Source/API/CBLQuery.m
+++ b/Source/API/CBLQuery.m
@@ -261,6 +261,11 @@
             }
         }
 
+        NSError* error;
+        LogTo(Query, @"%@: Close background database: %@", self, bgdb);
+        if (![bgdb close: &error])
+            Warn(@"Failed to close background database: %@", error);
+
         [_database doAsync: ^{
             // Back on original thread, call the onComplete block:
             LogTo(Query, @"%@: ...async query finished (%u rows, status %d)",

--- a/Source/CBL_Replicator.m
+++ b/Source/CBL_Replicator.m
@@ -161,6 +161,9 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 
 
 - (void) databaseClosing {
+    if (!_db)
+        return; // The database has already been closed and cleared.
+    
     [self saveLastSequence];
     [self stop];
     [self clearDbRef];

--- a/Source/CBL_Server.h
+++ b/Source/CBL_Server.h
@@ -24,6 +24,7 @@
 
 @property (readonly) NSString* directory;
 @property (readonly) NSDictionary *customHTTPHeaders;
+@property (readonly) CBLManager* manager;
 
 - (void) queue: (void(^)())block;
 - (void) tellDatabaseManager: (void (^)(CBLManager*))block;

--- a/Source/CBL_Server.m
+++ b/Source/CBL_Server.m
@@ -25,6 +25,7 @@
 
 @implementation CBL_Server
 
+@synthesize manager = _manager;
 @dynamic customHTTPHeaders;
 
 #if DEBUG


### PR DESCRIPTION
1. Close the background database when the replication stopped.

2. Close the background database when async query is finished.

3. Fixed replication stop method that the updateStatus: method is not get called to update the stopped status when the stop method is called from CBLDatabase's close: method.

Note: I manually verified as of sqlite v.3.8.5 if the WAL mode is enabled, a proper close sqlite database doesn't remove the -wal and -shm file but the -wal file size will be zero bytes.

#686