### PR TITLE
Fix REST API getting _changes feed in descending mode

### DIFF
--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -41,7 +41,7 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
 NSString* const CBL_PrivateRunloopMode = @"CouchbaseLitePrivate";
 NSArray* CBL_RunloopModes;
 
-const CBLChangesOptions kDefaultCBLChangesOptions = {UINT_MAX, NO, NO, YES};
+const CBLChangesOptions kDefaultCBLChangesOptions = {UINT_MAX, NO, NO, YES, NO};
 
 // When this many changes pile up in _changesToNotify, start removing their bodies to save RAM
 #define kManyChangesToNotify 5000

--- a/Source/CBLRouter+Changes.m
+++ b/Source/CBLRouter+Changes.m
@@ -47,6 +47,13 @@ NSTimeInterval kMinHeartbeat = 5.0;
     options.includeDocs = _changesIncludeDocs;
     options.includeConflicts = _changesIncludeConflicts;
     options.sortBySequence = !options.includeConflicts;
+
+    BOOL descending = [self boolQuery: @"descending"] && options.sortBySequence;
+    // valid option only when the mode is NormalFeed:
+    if (descending && _changesMode != kNormalFeed)
+        return kCBLStatusBadParam;
+    options.descending = descending;
+
     options.limit = [self intQuery: @"limit" defaultValue: options.limit];
     int since = [[self query: @"since"] intValue];
     

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -436,6 +436,13 @@ static void FDBLogCallback(forestdb::logLevel level, const char *message) {
     // http://wiki.apache.org/couchdb/HTTP_database_API#Changes
     // Translate options to ForestDB:
     if (!options) options = &kDefaultCBLChangesOptions;
+    
+    if (options->descending) {
+        // https://github.com/couchbase/couchbase-lite-ios/issues/641
+        *outStatus = kCBLStatusNotImplemented;
+        return nil;
+    }
+
     auto forestOpts = DocEnumerator::Options::kDefault;
     forestOpts.limit = options->limit;
     forestOpts.inclusiveEnd = YES;

--- a/Source/CBL_Revision.h
+++ b/Source/CBL_Revision.h
@@ -65,6 +65,8 @@ typedef SInt64 SequenceNumber;
 
 - (NSComparisonResult) compareSequences: (CBL_Revision*)rev;
 
+- (NSComparisonResult) compareSequencesDescending: (CBL_Revision*)rev;
+
 /** Generation number: 1 for a new document, 2 for the 2nd revision, ...
     Extracted from the numeric prefix of the revID. */
 @property (readonly) unsigned generation;
@@ -130,7 +132,7 @@ typedef SInt64 SequenceNumber;
 - (void) removeObjectAtIndex: (NSUInteger)index;
 
 - (void) limit: (NSUInteger)limit;
-- (void) sortBySequence;
+- (void) sortBySequenceAscending:(BOOL)ascending;
 - (void) sortByDocID;
 
 @end

--- a/Source/CBL_Revision.m
+++ b/Source/CBL_Revision.m
@@ -182,6 +182,11 @@
     return CBLSequenceCompare(_sequence, rev->_sequence);
 }
 
+- (NSComparisonResult) compareSequencesDescending: (CBL_Revision*)rev {
+    NSParameterAssert(rev != nil);
+    return CBLSequenceCompare(_sequence, rev->_sequence) * -1;
+}
+
 - (CBL_MutableRevision*) mutableCopyWithDocID: (UU NSString*)docID revID: (UU NSString*)revID {
     CBL_MutableRevision* rev = [self mutableCopy];
     [rev setDocID: docID revID: revID];
@@ -454,8 +459,11 @@
         [_revs removeObjectsInRange: NSMakeRange(limit, _revs.count - limit)];
 }
 
-- (void) sortBySequence {
-    [_revs sortUsingSelector: @selector(compareSequences:)];
+- (void) sortBySequenceAscending:(BOOL)ascending {
+    if (ascending)
+        [_revs sortUsingSelector: @selector(compareSequences:)];
+    else
+        [_revs sortUsingSelector: @selector(compareSequencesDescending:)];
 }
 
 - (void) sortByDocID {

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -1024,7 +1024,7 @@ NSString* CBLJoinSQLQuotedStrings(NSArray* strings) {
     [r close];
     
     if (options->sortBySequence) {
-        [changes sortBySequence];
+        [changes sortBySequenceAscending: !options->descending];
         [changes limit: options->limit];
     }
     return changes;

--- a/Source/CBL_StorageTypes.h
+++ b/Source/CBL_StorageTypes.h
@@ -68,6 +68,7 @@ typedef struct CBLChangesOptions {
     BOOL includeDocs;
     BOOL includeConflicts;
     BOOL sortBySequence;
+    BOOL descending;
 } CBLChangesOptions;
 
 extern const CBLChangesOptions kDefaultCBLChangesOptions;

--- a/Unit-Tests/Router_Tests.m
+++ b/Unit-Tests/Router_Tests.m
@@ -814,6 +814,62 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
 }
 
 
+- (void) test_ChangesDescending {
+    RequireTestCase(Changes);
+    NSArray* revIDs = [self populateDocs];
+
+    // _changes with descending = false
+    Send(self, @"GET", @"/db/_changes?descending=false", kCBLStatusOK,
+         $dict({@"last_seq", @5},
+               {@"results", $array($dict({@"id", @"doc3"},
+                                         {@"changes", $array($dict({@"rev", revIDs[2]}))},
+                                         {@"seq", @3}),
+                                   $dict({@"id", @"doc2"},
+                                         {@"changes", $array($dict({@"rev", revIDs[1]}))},
+                                         {@"seq", @4}),
+                                   $dict({@"id", @"doc1"},
+                                         {@"changes", $array($dict({@"rev", revIDs[0]}))},
+                                         {@"seq", @5},
+                                         {@"deleted", $true}))}));
+    if (self.isSQLiteDB ) {
+        // _changes with descending = true
+        Send(self, @"GET", @"/db/_changes?descending=true", kCBLStatusOK,
+             $dict({@"last_seq", @3},
+                   {@"results", $array($dict({@"id", @"doc1"},
+                                             {@"changes", $array($dict({@"rev", revIDs[0]}))},
+                                             {@"seq", @5},
+                                             {@"deleted", $true}),
+                                       $dict({@"id", @"doc2"},
+                                             {@"changes", $array($dict({@"rev", revIDs[1]}))},
+                                             {@"seq", @4}),
+                                       $dict({@"id", @"doc3"},
+                                             {@"changes", $array($dict({@"rev", revIDs[2]}))},
+                                             {@"seq", @3}))}));
+
+
+        // _changes with descending = true and limit = 2
+        Send(self, @"GET", @"/db/_changes?descending=true&limit=2", kCBLStatusOK,
+             $dict({@"last_seq", @4},
+                   {@"results", $array($dict({@"id", @"doc1"},
+                                             {@"changes", $array($dict({@"rev", revIDs[0]}))},
+                                             {@"seq", @5},
+                                             {@"deleted", $true}),
+                                       $dict({@"id", @"doc2"},
+                                             {@"changes", $array($dict({@"rev", revIDs[1]}))},
+                                             {@"seq", @4}))}));
+
+        Send(self, @"GET", @"/db/_changes?descending=true&feed=continuous", kCBLStatusBadParam, nil);
+        Send(self, @"GET", @"/db/_changes?descending=true&feed=longpoll", kCBLStatusBadParam, nil);
+    } else {
+        // https://github.com/couchbase/couchbase-lite-ios/issues/641
+        Send(self, @"GET", @"/db/_changes?descending=true", kCBLStatusNotImplemented, nil);
+        Send(self, @"GET", @"/db/_changes?descending=true&limit=2", kCBLStatusNotImplemented, nil);
+        Send(self, @"GET", @"/db/_changes?descending=true&feed=continuous", kCBLStatusBadParam, nil);
+        Send(self, @"GET", @"/db/_changes?descending=true&feed=longpoll", kCBLStatusBadParam, nil);
+    }
+}
+
+
 #pragma mark - ATTACHMENTS:
 
 


### PR DESCRIPTION
- Descending mode will be only working when the feed mode is normal mode. The bad param error will be returned when using the descending mode with continuous and long poll mode.

- Currently ForestDB storage doesn't support this option. The not implemented error will be returned. (https://github.com/couchbase/couchbase-lite-ios/issues/641).

#107