### PR TITLE
Fix replicator restart issue

### DIFF
--- a/Unit-Tests/Replication_Tests.m
+++ b/Unit-Tests/Replication_Tests.m
@@ -904,4 +904,69 @@ static UInt8 sEncryptionIV[kCCBlockSizeAES128];
     AssertEq(revpos, 2);
 }
 
+- (void) test16_Restart {
+    NSURL* remoteDbURL = [self remoteTestDBURL: kPushThenPullDBName];
+    if (!remoteDbURL)
+        return;
+    [self eraseRemoteDB: remoteDbURL];
+
+    // Pusher:
+    CBLReplication* pusher = [db createPushReplication: remoteDbURL];
+    pusher.continuous = YES;
+    [pusher start];
+    [pusher restart];
+
+    // Wait to get a notification after the replication is stopped:
+    NSDate* timeout = [NSDate dateWithTimeIntervalSinceNow: 2.0];
+    while (pusher.status != kCBLReplicationIdle && timeout.timeIntervalSinceNow > 0.0) {
+        if (![[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
+                                      beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]])
+            break;
+    }
+
+    // Make sure the replication is now idle:
+    AssertEq(pusher.status, kCBLReplicationIdle);
+
+    // Stop the replicator now:
+    [pusher stop];
+    timeout = [NSDate dateWithTimeIntervalSinceNow: 2.0];
+    while (pusher.status != kCBLReplicationStopped && timeout.timeIntervalSinceNow > 0.0) {
+        if (![[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
+                                      beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]])
+            break;
+    }
+
+    // Make sure the replication is stopped:
+    AssertEq(pusher.status, kCBLReplicationStopped);
+
+    // Puller:
+    CBLReplication* puller = [db createPullReplication: remoteDbURL];
+    puller.continuous = YES;
+    [puller start];
+    [puller restart];
+
+    // Wait to get a notification after the replication is stopped:
+    timeout = [NSDate dateWithTimeIntervalSinceNow: 2.0];
+    while (puller.status != kCBLReplicationIdle && timeout.timeIntervalSinceNow > 0.0) {
+        if (![[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
+                                      beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]])
+            break;
+    }
+
+    // Make sure the replication is now idle:
+    AssertEq(puller.status, kCBLReplicationIdle);
+
+    // Stop the replicator now:
+    [puller stop];
+    timeout = [NSDate dateWithTimeIntervalSinceNow: 2.0];
+    while (puller.status != kCBLReplicationStopped && timeout.timeIntervalSinceNow > 0.0) {
+        if (![[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
+                                      beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]])
+            break;
+    }
+
+    // Make sure the replication is stopped:
+    AssertEq(puller.status, kCBLReplicationStopped);
+}
+
 @end


### PR DESCRIPTION
- In CBLReplication -stop method, before returning, wait until the background stop notification comes.

- In CBLReplication -restart method, spin the -start method call into the next runloop or the next dispatching if the dispatch queue is used.

#696