### PR TITLE
Restore deleted CBLQuery fullTextSnippets/Ranking API

### DIFF
--- a/Source/API/CBLQuery+FullTextSearch.h
+++ b/Source/API/CBLQuery+FullTextSearch.h
@@ -37,6 +37,18 @@
     They also can't be reduced or grouped, so those properties are ignored too. */
 @property (copy, nullable) NSString* fullTextQuery;
 
+/** If set to YES, the query will collect snippets of the text surrounding each match, available
+    via the CBLFullTextQueryRow's -snippetWithWordStart:wordEnd: method.
+    (NOTE: ForestDB currently does not support snippets.) */
+@property BOOL fullTextSnippets;
+
+/** If YES (the default) the full-text query result rows will be sorted by (approximate) relevance.
+    If set to NO, the rows will be returned in the order the documents were added to the database,
+    i.e. essentially unordered; this is somewhat faster, so it can be useful if you don't care
+    about the ordering of the rows.
+    (NOTE: ForestDB currently does not support ranking.) */
+@property BOOL fullTextRanking;
+
 @end
 
 
@@ -48,6 +60,15 @@
 /** The text emitted when the view was indexed (the argument to CBLTextKey()) which contains the
     match(es). */
 @property (readonly, nullable) NSString* fullText;
+
+/** Returns a short substring of the full text containing at least some of the matched words.
+    This is useful to display in search results, and is faster than fetching the .fullText.
+    NOTE: The "fullTextSnippets" property of the CBLQuery must be set to YES to enable this;
+    otherwise the result will be nil.
+    @param wordStart  A delimiter that will be inserted before every instance of a match.
+    @param wordEnd  A delimiter that will be inserted after every instance of a match. */
+- (NSString*) snippetWithWordStart: (NSString*)wordStart
+                           wordEnd: (NSString*)wordEnd;
 
 /** The number of query words that were found in the fullText.
     (If a query word appears more than once, only the first instance is counted.) */

--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -160,6 +160,7 @@
                     fullTextID: (UInt64)fullTextID
                          value: (id)value
                        storage: (id<CBL_QueryRowStorage>)storage;
+@property (copy) NSString* snippet;
 - (void) addTerm: (NSUInteger)term atRange: (NSRange)range;
 @end
 

--- a/Source/CBL_SQLiteViewStorage.m
+++ b/Source/CBL_SQLiteViewStorage.m
@@ -881,8 +881,8 @@ typedef CBLStatus (^QueryRowBlock)(NSData* keyData, NSData* valueData, NSString*
                 [row addTerm: term atRange: NSMakeRange(location, length)];
             }
 
-//            if (options->fullTextSnippets)
-//                row.snippet = [r stringForColumnIndex: 5];
+            if (options->fullTextSnippets)
+                row.snippet = [r stringForColumnIndex: 5];
             if (!options.filter || options.filter(row))
                 [rows addObject: row];
         }

--- a/Unit-Tests/ViewInternal_Tests.m
+++ b/Unit-Tests/ViewInternal_Tests.m
@@ -1199,10 +1199,12 @@ static NSArray* rowsToDictsSettingDB(CBLDatabase* db, CBLQueryIteratorBlock iter
     AssertEq(rows.count, 0u);
 }
 
-#if 0 // Boolean operators and snippets are not available (yet) with ForestDB
+
 - (void) test24_FullTextQuery_Advanced {
+    if (!self.isSQLiteDB)
+        return; // Boolean operators and snippets are not available (yet) with ForestDB
+
     RequireTestCase(CBL_View_FullTextQuery);
-    CBLDatabase *db = createDB();
     CBLStatus status;
 
     NSMutableArray* docs = $marray();
@@ -1213,10 +1215,9 @@ static NSArray* rowsToDictsSettingDB(CBLDatabase* db, CBLQueryIteratorBlock iter
     [docs addObject: [self putDoc: $dict({@"_id", @"55555"}, {@"text", @"was barking."})]];
 
     CBLView* view = [db viewNamed: @"fts"];
-    view.indexType = kCBLFullTextIndex;
     [view setMapBlock: MAPBLOCK({
         if (doc[@"text"])
-            emit(doc[@"text"], doc[@"_id"]);
+            emit(CBLTextKey(doc[@"text"]), doc[@"_id"]);
     }) reduceBlock: NULL version: @"1"];
 
     AssertEq([view updateIndex], kCBLStatusOK);
@@ -1229,21 +1230,21 @@ static NSArray* rowsToDictsSettingDB(CBLDatabase* db, CBLQueryIteratorBlock iter
     Assert(rowIter, @"_queryFullText failed: %d", status);
     Log(@"rows = %@", rowIter);
     NSArray* expectedRows = $array($dict({@"id",  @"44444"},
-                                         {@"matches", @[@{@"range": @[@4, @7], @"term": @0}]},
+                                         {@"matches", @[@{@"range": @[@4, @6], @"term": @0}]},
                                          {@"snippet", @"and [STöRMy] night."},
                                          {@"value", @"44444"}),
                                    $dict({@"id",  @"33333"},
                                          {@"matches", @[@{@"range": @[@2,  @3], @"term": @1},
-                                                        @{@"range": @[@26, @3], @"term": @1}]},
+                                                        @{@"range": @[@22, @3], @"term": @1}]},
                                          {@"snippet", @"a [dog] whøse ñame was “[Dog]”"},
                                          {@"value", @"33333"}));
-    AssertEqual(rowsToDicts(rowIter), expectedRows);
+    AssertEqualish(rowsToDicts(rowIter), expectedRows);
 
     // Try a query with snippets:
     CBLQuery* query = [view createQuery];
     query.fullTextQuery = @"(was NOT barking) OR dog";
     query.fullTextSnippets = YES;
-    rows = [[query run: NULL] allObjects];
+    NSArray* rows = [[query run: NULL] allObjects];
     AssertEq(rows.count, 2u);
 
     CBLFullTextQueryRow* row = rows[0];
@@ -1287,12 +1288,11 @@ static NSArray* rowsToDictsSettingDB(CBLDatabase* db, CBLQueryIteratorBlock iter
     Log(@"after deletion, rows = %@", rowIter);
 
     expectedRows = $array($dict({@"id",  @"44444"},
-                                {@"matches", @[@{@"range": @[@4, @7], @"term": @0}]},
+                                {@"matches", @[@{@"range": @[@4, @6], @"term": @0}]},
                                 {@"snippet", @"and [STöRMy] night."},
                                 {@"value", @"44444"}));
-    AssertEqual(rowsToDicts(rowIter), expectedRows);
+    AssertEqualish(rowsToDicts(rowIter), expectedRows);
 }
-#endif
 
 
 - (void) test25_TotalDocs {


### PR DESCRIPTION
Was accidentally removed during ForestDB storage development.
These aren't supported yet with ForestDB but are with SQLite.

(Most of the diffs are just restoring code from release/1.0.4.)

Fixes #709