### PR TITLE
Fix UnsavedRevision.properties synthesizing

### DIFF
--- a/Source/API/CBLRevision.m
+++ b/Source/API/CBLRevision.m
@@ -288,7 +288,7 @@
     NSMutableDictionary* _properties;
 }
 
-@synthesize parentRevisionID=_parentRevID, properties=_properties;
+@synthesize parentRevisionID=_parentRevID;
 @dynamic isDeletion, userProperties;     // Necessary because this class redeclares them
 
 - (instancetype) initWithDocument: (CBLDocument*)doc parent: (CBLSavedRevision*)parent {
@@ -306,6 +306,20 @@
 
 - (CBLSavedRevision*) parentRevision {
     return _parentRevID ? [_document revisionWithID: _parentRevID] : nil;
+}
+
+- (void) setProperties: (NSMutableDictionary*)properties {
+    @synchronized(self) { // Atomic property
+        if (_properties != properties) {
+            _properties = [properties mutableCopy];
+        }
+    }
+}
+
+- (NSMutableDictionary*)properties {
+    @synchronized(self) { // Atomic property
+        return _properties;
+    }
 }
 
 - (NSArray*) getRevisionHistory: (NSError**)outError {

--- a/Source/API/CBLRevision.m
+++ b/Source/API/CBLRevision.m
@@ -309,17 +309,13 @@
 }
 
 - (void) setProperties: (NSMutableDictionary*)properties {
-    @synchronized(self) { // Atomic property
-        if (_properties != properties) {
-            _properties = [properties mutableCopy];
-        }
+    if (_properties != properties) {
+        _properties = [properties mutableCopy];
     }
 }
 
 - (NSMutableDictionary*)properties {
-    @synchronized(self) { // Atomic property
-        return _properties;
-    }
+    return _properties;
 }
 
 - (NSArray*) getRevisionHistory: (NSError**)outError {

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -922,4 +922,32 @@
 }
 
 
+- (void) test22_CreateDocWithAttachmentInSingleRevision {
+    // Set properties:
+    CBLDocument* doc1 = [db createDocument];
+    CBLUnsavedRevision* newRev1 = [doc1 newRevision];
+    NSMutableDictionary* props = [NSMutableDictionary dictionaryWithDictionary:newRev1.properties];
+    props[@"foo"] = @"bar";
+    newRev1.properties = props;
+
+    NSData* attach1 = [@"attach1" dataUsingEncoding:NSUTF8StringEncoding];
+    [newRev1 setAttachmentNamed: @"attach1"
+               withContentType: @"text/plain; charset=utf-8"
+                       content: attach1];
+    NSError* error;
+    Assert([newRev1 save: &error], @"Cannot save the document: %@", error);
+
+    // Set userProperties:
+    CBLDocument* doc2 = [db createDocument];
+    CBLUnsavedRevision* newRev2 = [doc2 newRevision];
+    newRev2.userProperties = @{@"foo":@"bar"};
+    
+    NSData* attach2 = [@"attach2" dataUsingEncoding:NSUTF8StringEncoding];
+    [newRev2 setAttachmentNamed: @"attach2"
+                withContentType: @"text/plain; charset=utf-8"
+                        content: attach2];
+    Assert([newRev2 save: &error], @"Cannot save the document: %@", error);
+}
+
+
 @end


### PR DESCRIPTION
The UnsavedRevision.properties propery is declared as copy and that causes an issue that the new NSMutableDictionary object set to the property is changed to an immutable one at runtime by the SDK. Instead of synthesizing, implementing a pair get/set method with doing mutableCopy instead.

#718