### PR TITLE
Fix error re-adding a document after it's been purged.

### DIFF
--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -1121,5 +1121,7 @@ static void convertRevIDs(NSArray* revIDs,
     }];
 }
 
+-(void) removeKeyFromDocIDCache:(NSString*)docID {
+}
 
 @end

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -677,9 +677,16 @@ static void CBLComputeFTSRank(sqlite3_context *pCtx, int nVal, sqlite3_value **a
 - (SInt64) _createDocNumericID: (NSString*)docID {
     if (![_fmdb executeUpdate: @"INSERT OR IGNORE INTO docs (docid) VALUES (?)", docID])
         return -1;
-    if (_fmdb.changes == 0)
-        return -1;
+    if (_fmdb.changes == 0) {
+      SInt64 result = [self _getDocNumericID:docID];
+      if(result > 0) return result; 
+      return -1;
+    }
     return _fmdb.lastInsertRowId;
+}
+
+-(void) removeKeyFromDocIDCache:(NSString*)docID {
+  [_docIDs removeObjectForKey:docID];
 }
 
 // Registers a docID and returns its numeric row ID in the 'docs' table.

--- a/Source/CBL_Storage.h
+++ b/Source/CBL_Storage.h
@@ -253,6 +253,10 @@
                           obeyMVCC: (BOOL)obeyMVCC
                             status: (CBLStatus*)outStatus;
 
+
+/** For use by unit tests to clear the docID cache. */
+-(void) removeKeyFromDocIDCache: (NSString*)docID;
+
 @end
 
 

--- a/Unit-Tests/DatabaseInternal_Tests.m
+++ b/Unit-Tests/DatabaseInternal_Tests.m
@@ -847,4 +847,28 @@ static CBL_Revision* mkrev(NSString* revID) {
 #endif
 #endif
 
+-(void) test26_ReAddAfterPurge {
+   
+    NSString* docId = @"test26-ReAddAfterPurge";
+  
+    CBL_MutableRevision* rev = [[CBL_MutableRevision alloc] initWithDocID:docId revID:@"1-1111" deleted: NO];
+    rev.properties = $dict({@"_id", rev.docID}, {@"_rev", rev.revID}, {@"testName", @"test26_ReAddAfterPurge"});
+    CBLStatus status = [db forceInsert: rev revisionHistory: nil source: nil];
+    AssertEq(status, kCBLStatusCreated);
+    
+    CBLDocument* redoc = [db existingDocumentWithID:docId];
+    Assert(redoc);
+    
+    NSError* error;
+    Assert([redoc purgeDocument: &error]);
+  
+    [db.storage removeKeyFromDocIDCache:docId];
+    
+    CBL_MutableRevision* revAfterPurge = [[CBL_MutableRevision alloc] initWithDocID:docId revID:@"1-1111" deleted: NO];
+    revAfterPurge.properties = $dict({@"_id", revAfterPurge.docID}, {@"_rev", revAfterPurge.revID}, {@"testName", @"test26_ReAddAfterPurge"});
+    CBLStatus status2 = [db forceInsert: revAfterPurge revisionHistory: nil source: nil];
+    AssertEq(status2, kCBLStatusCreated);
+ 
+}
+
 @end


### PR DESCRIPTION
Fixed a bug in SQLLiteStorage/_createDocNumericID that should insert or ignore that was returning -1 when it really should return the documents row id. For a unit test to call _createDocNumericID twice and fail correctly I had to add a function to clear the document from the key cache _docIDs.