### PR TITLE
ForestDBViewStorage, filter out _design docs when indexing

### DIFF
--- a/Source/CBL_ForestDBViewStorage.mm
+++ b/Source/CBL_ForestDBViewStorage.mm
@@ -78,6 +78,8 @@ public:
             indexIt = false;
         } else if (flags & VersionedDocument::kDeleted) {
             indexIt = false;
+        } else if ([(NSString*)cppDoc.key() hasPrefix: @"_design/"]) {
+            indexIt = false; // design docs don't get indexed!
         } else if (_docTypes.size() > 0) {
             if (std::find(_docTypes.begin(), _docTypes.end(), docType) == _docTypes.end())
                 indexIt = false;

--- a/Unit-Tests/ViewInternal_Tests.m
+++ b/Unit-Tests/ViewInternal_Tests.m
@@ -110,6 +110,7 @@ static NSDictionary* mkGeoRect(double x0, double y0, double x1, double y1) {
         Assert(doc[@"_id"] != nil, @"Missing _id in %@", doc);
         Assert(doc[@"_rev"] != nil, @"Missing _rev in %@", doc);
         Assert([doc[@"_local_seq"] isKindOfClass: [NSNumber class]], @"Invalid _local_seq in %@", doc);
+        Assert(![doc[@"_id"] hasPrefix:@"_design/"], @"Shouldn't index the design doc: %@", doc);
         if (doc[@"key"])
             emit(doc[@"key"], nil);
         if (doc[@"geoJSON"])


### PR DESCRIPTION
- In CocoaIndexer, check to filter out a design doc.
- Update ViewInternal_Tests's -createViewNames to assert if there is a design doc get indexed.

#727