### PR TITLE
Fix for replicators not getting distinct checkpoints

### DIFF
--- a/Source/CBL_Puller.m
+++ b/Source/CBL_Puller.m
@@ -120,7 +120,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     _changeTracker.filterParameters = _filterParameters;
     _changeTracker.docIDs = _docIDs;
     _changeTracker.authorizer = _authorizer;
-    _changeTracker.cookieStorage = _cookieStorage;
+    _changeTracker.cookieStorage = self.cookieStorage;
     _changeTracker.usePOST = [self serverIsSyncGatewayVersion: @"0.93"];
 
     unsigned heartbeat = $castIf(NSNumber, _options[kCBLReplicatorOption_Heartbeat]).unsignedIntValue;

--- a/Source/CBL_Replicator.h
+++ b/Source/CBL_Replicator.h
@@ -36,7 +36,6 @@ extern NSString* CBL_ReplicatorStoppedNotification;
     NSDictionary* _options;
     NSDictionary* _requestHeaders;
     NSString* _serverType;
-    CBLCookieStorage* _cookieStorage;
 #if TARGET_OS_IPHONE
     NSUInteger /*UIBackgroundTaskIdentifier*/ _bgTask;
 #endif

--- a/Unit-Tests/ReplicatorInternal_Tests.m
+++ b/Unit-Tests/ReplicatorInternal_Tests.m
@@ -543,6 +543,32 @@
 }
 
 
+- (void) test_DistinctCheckpointIDs {
+    NSMutableDictionary* props = [@{@"source": @"http://fake.fake/fakedb",
+                                    @"target": db.name,
+                                    @"continuous": @NO} mutableCopy];
+    CBLStatus status;
+    CBL_Replicator* r1 = [dbmgr replicatorWithProperties: props status: &status];
+    Assert(r1);
+    NSString* check1 = r1.remoteCheckpointDocID;
+
+    props[@"continuous"] = @YES;
+    CBL_Replicator* r2 = [dbmgr replicatorWithProperties: props status: &status];
+    Assert(r2);
+    NSString* check2 = r2.remoteCheckpointDocID;
+    Assert(![check1 isEqualToString: check2]);
+    Assert(![r1 hasSameSettingsAs: r2]);
+
+    props[@"filter"] = @"Melitta";
+    props[@"query_params"] = @{@"unbleached": @"true"};     // Test fix for #728
+    CBL_Replicator* r3 = [dbmgr replicatorWithProperties: props status: &status];
+    Assert(r3);
+    NSString* check3 = r3.remoteCheckpointDocID;
+    Assert(![check3 isEqualToString: check2]);
+    Assert(![r3 hasSameSettingsAs: r2]);
+}
+
+
 #pragma mark - UTILITY FUNCTIONS
 
 


### PR DESCRIPTION
Defer initialization of cookieStorage because this has the side effect
of setting the remoteCheckpointDocID, and we don't want to do that until
properties like the filter and filterParams are set up.
Fixes #728