### PR TITLE
Fix #715 CBLIS fetch result via nested relationships

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.h
+++ b/Source/API/Extras/CBLIncrementalStore.h
@@ -11,8 +11,8 @@
 extern NSString* const kCBLISErrorDomain;
 extern NSString* const kCBLISObjectHasBeenChangedInStoreNotification;
 
-/** Maximum number of relationship search levels allowed in a fetch request. Default value is 3. */
-extern NSString* const kCBLISCustomPropertyMaxRelationshipSearchDepth;
+/** Maximum number of relationship loading allowed in a fetch request. Default value is 3. */
+extern NSString* const kCBLISCustomPropertyMaxRelationshipLoadDepth;
 
 /** Error codes for CBLIncrementalStore. */
 typedef enum

--- a/Source/API/Extras/CBLIncrementalStore.h
+++ b/Source/API/Extras/CBLIncrementalStore.h
@@ -11,6 +11,9 @@
 extern NSString* const kCBLISErrorDomain;
 extern NSString* const kCBLISObjectHasBeenChangedInStoreNotification;
 
+/** Maximum number of relationship search levels allowed in a fetch request. Default value is 3. */
+extern NSString* const kCBLISCustomPropertyMaxRelationshipSearchDepth;
+
 /** Error codes for CBLIncrementalStore. */
 typedef enum
 {
@@ -61,6 +64,9 @@ typedef void(^CBLISConflictHandler)(NSArray* conflictingRevisions);
 
 /** Conflict handling block that gets called when conflicts are to be handled. Initialied with a generic conflicts handler, can be set to NULL to not handle conflicts at all. */
 @property (nonatomic, copy) CBLISConflictHandler conflictHandler;
+
+/** An optional dictionary of extra properties for the incremental store.*/
+@property (nonatomic, copy) NSDictionary* customProperties;
 
 /** Returns the type of this store to use with addPersistentStore:... 
  *

--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -28,8 +28,11 @@
 #define WARN(FMT, ...) NSLog(@"[CBLIS] WARNING " FMT, ##__VA_ARGS__)
 #define ERROR(FMT, ...) NSLog(@"[CBLIS] ERROR " FMT, ##__VA_ARGS__)
 
+#define kDefaultMaxRelationshipSearchDepth 3;
+
 NSString* const kCBLISErrorDomain = @"CBLISErrorDomain";
-NSString* const kCBLISObjectHasBeenChangedInStoreNotification = @"kCBLISObjectHasBeenChangedInStoreNotification";
+NSString* const kCBLISObjectHasBeenChangedInStoreNotification = @"CBLISObjectHasBeenChangedInStoreNotification";
+NSString* const kCBLISCustomPropertyMaxRelationshipSearchDepth = @"CBLISCustomPropertyMaxRelationshipFetchDepth";
 
 static NSString* const kCBLISDefaultTypeKey = @"type";
 static NSString* const kCBLISOldDefaultTypeKey = @"CBLIS_type";
@@ -56,6 +59,7 @@ static NSError* CBLISError(NSInteger code, NSString* desc, NSError *parent);
 @property (nonatomic, strong) NSHashTable* observingManagedObjectContexts;
 @property (nonatomic, strong) CBLDatabase* database;
 @property (nonatomic, strong) id changeObserver;
+@property (nonatomic, readonly) NSUInteger maxRelationshipSearchDepth;
 
 @end
 
@@ -66,11 +70,13 @@ static NSError* CBLISError(NSInteger code, NSString* desc, NSError *parent);
     NSMutableDictionary* _fetchRequestResultCache;
     CBLLiveQuery* _conflictsQuery;
     NSString * _documentTypeKey;
+    NSUInteger _relationshipSearchDepth;
 }
 
 @synthesize database = _database;
 @synthesize changeObserver = _changeObserver;
 @synthesize conflictHandler = _conflictHandler;
+@synthesize customProperties = _customProperties;
 @synthesize observingManagedObjectContexts = _observingManagedObjectContexts;
 
 static CBLManager* sCBLManager;
@@ -243,8 +249,6 @@ static CBLManager* sCBLManager;
     
     return self;
 }
-
-#pragma mark - NSIncrementalStore
 
 -(BOOL) loadMetadata: (NSError**)outError {
     // Check data model if compatible with this store:
@@ -644,6 +648,14 @@ static CBLManager* sCBLManager;
         _documentTypeKey = kCBLISDefaultTypeKey;
 
     return _documentTypeKey;
+}
+
+#pragma mark - Custom properties
+
+- (NSUInteger) maxRelationshipSearchDepth {
+    id maxDepthValue = _customProperties[kCBLISCustomPropertyMaxRelationshipSearchDepth];
+    NSUInteger maxDepth = [maxDepthValue unsignedIntegerValue];
+    return maxDepth > 0 ? maxDepth : kDefaultMaxRelationshipSearchDepth;
 }
 
 #pragma mark - Views
@@ -1065,37 +1077,26 @@ static CBLManager* sCBLManager;
                            outError: (NSError**)outError {
     NSString* keyPath = expression.keyPath;
 
-    NSDictionary* properties = [entity propertiesByName];
-    id propertyDesc = [properties objectForKey: keyPath];
-
-    BOOL hasDotAccess = NO;
-    if (!propertyDesc && [keyPath rangeOfString:@"."].location != NSNotFound) {
-        hasDotAccess = YES;
-        NSArray* components = [keyPath componentsSeparatedByString: @"."];
-        NSArray* keyComponents = [components subarrayWithRange:
-                                  NSMakeRange(0, components.count - 1)];
-        keyPath = [keyComponents componentsJoinedByString: @"."];
-        propertyDesc = [properties objectForKey: keyPath];
-    }
-
-    if (propertyDesc) {
-        BOOL needJoins = NO;
-        if ([propertyDesc isKindOfClass:[NSRelationshipDescription class]]) {
-            NSRelationshipDescription* rel = (NSRelationshipDescription*)propertyDesc;
-            needJoins = hasDotAccess || rel.isToMany;
-        }
-        if (outNeedJoinsQuery)
-            *outNeedJoinsQuery = needJoins;
+    BOOL needJoin = NO;
+    if ([keyPath rangeOfString:@"."].location != NSNotFound) {
+        needJoin = YES;
     } else {
-        keyPath = nil;
-        if (outError) {
-            NSString* errDesc = [NSString stringWithFormat: @"Predicate Keypath '%@' "
-                                 "not found in the entity '%@'.", expression.keyPath, entity.name];
-            *outError = CBLISError(CBLIncrementalStoreErrorPredicateKeyPathNotFoundInEntity,
-                                   errDesc, nil);
+        NSDictionary* properties = [entity propertiesByName];
+        id propertyDesc = [properties objectForKey: keyPath];
+        if (!propertyDesc) {
+            keyPath = nil;
+            if (outError) {
+                NSString* errDesc = [NSString stringWithFormat: @"Predicate Keypath '%@' "
+                                     "not found in the entity '%@'.", expression.keyPath, entity.name];
+                *outError = CBLISError(CBLIncrementalStoreErrorPredicateKeyPathNotFoundInEntity,
+                                       errDesc, nil);
+            }
         }
     }
 
+    if (outNeedJoinsQuery)
+        *outNeedJoinsQuery = needJoin;
+    
     return keyPath;
 }
 
@@ -1178,6 +1179,7 @@ static CBLManager* sCBLManager;
     NSUInteger offset = 0;
     NSMutableArray* result = [NSMutableArray array];
     for (CBLQueryRow* row in rows) {
+        _relationshipSearchDepth = 0;
         if (!request.predicate ||
             [self evaluatePredicate: request.predicate
                          withEntity: request.entity
@@ -1294,7 +1296,7 @@ static CBLManager* sCBLManager;
 
     NSPropertyDescription* propertyDesc = [entity.propertiesByName objectForKey: expression.keyPath];
     if (!propertyDesc) {
-        NSArray* keyProp = [self parseKeyAndPropertyFromKeyPath: expression.keyPath];
+        NSArray* keyProp = [self parseKeyPathComponents: expression.keyPath];
         if ([keyProp count] == 2)
             propertyDesc = [entity.propertiesByName objectForKey: keyProp[0]];
     }
@@ -1304,18 +1306,13 @@ static CBLManager* sCBLManager;
            ((NSRelationshipDescription*)propertyDesc).isToMany;
 }
 
-- (NSArray*) parseKeyAndPropertyFromKeyPath: (NSString*)keyPath {
+- (NSArray*) parseKeyPathComponents: (NSString*)keyPath {
     if (!keyPath) return nil;
 
-    if ([keyPath rangeOfString:@"."].location != NSNotFound) {
-        NSArray* components = [keyPath componentsSeparatedByString: @"."];
-        NSString* key = [[components subarrayWithRange: NSMakeRange(0, components.count - 1)]
-                         componentsJoinedByString: @"."];
-        NSString* property = [components lastObject];
-        return @[key, property];
-    } else {
+    if ([keyPath rangeOfString:@"."].location != NSNotFound)
+        return [keyPath componentsSeparatedByString: @"."];
+    else
         return @[keyPath];
-    }
 }
 
 - (id) evaluateExpression: (NSExpression*)expression
@@ -1331,34 +1328,24 @@ static CBLManager* sCBLManager;
             value = properties;
             break;
         case NSKeyPathExpressionType: {
-            NSPropertyDescription* propertyDesc = [entity.propertiesByName objectForKey: expression.keyPath];
+            NSPropertyDescription* propertyDesc = [entity.propertiesByName
+                                                   objectForKey: expression.keyPath];
             if (propertyDesc) {
                 value = [properties objectForKey: expression.keyPath];
                 if ([propertyDesc isKindOfClass: [NSAttributeDescription class]]) {
                     if (!value) break;
                     NSAttributeDescription* attr = (NSAttributeDescription* )propertyDesc;
-                    value =  [self convertCoreDataValue: value toCouchbaseLiteValueOfType: attr.attributeType];
+                    value =  [self convertCoreDataValue: value
+                             toCouchbaseLiteValueOfType: attr.attributeType];
                 } else if ([propertyDesc isKindOfClass: [NSRelationshipDescription class]]) {
-                    // Compare whole relationship, return managed object or array of managed objects:
                     NSRelationshipDescription* relation = (NSRelationshipDescription*)propertyDesc;
                     if (!relation.isToMany) {
-                        if (!value) break;
-                        NSString* childDocId = value;
-                        NSManagedObjectID* objectID = [self newObjectIDForEntity: relation.destinationEntity
-                                                                 referenceObject: childDocId];
-                        value = objectID ? [context existingObjectWithID: objectID error: nil] : nil;
+                        // Use the current value which is a doc id:
+                        break;
                     } else {
                         if (relation.inverseRelationship.toMany) {
-                            // many-to-many
-                            NSMutableArray* objects = [NSMutableArray array];
-                            for (NSString* docId in value) {
-                                NSManagedObjectID* objectID = [self newObjectIDForEntity: relation.destinationEntity
-                                                                         referenceObject: docId];
-                                if (!objectID) continue;
-                                NSManagedObject* object = [context existingObjectWithID: objectID error: nil];
-                                if (object) [objects addObject: object];
-                            }
-                            value = objects;
+                            // Use the current value which an array of doc id:
+                            break;
                         } else {
                             // one-to-many
                             NSString* parentDocId = [properties objectForKey: @"_id"];
@@ -1368,26 +1355,22 @@ static CBLManager* sCBLManager;
                                                                             prefetch: NO
                                                                             outError: nil];
                                 if (rows) {
-                                    NSMutableArray* objects = [NSMutableArray array];
-                                    for (CBLQueryRow* row in rows) {
-                                        NSManagedObjectID* objectID = [self newObjectIDForEntity: relation.destinationEntity
-                                                                                 referenceObject: row.documentID];
-                                        if (!objectID) continue;
-                                        NSManagedObject* object = [context existingObjectWithID: objectID error: nil];
-                                        if (object) [objects addObject: object];
-                                    }
-                                    value = objects;
+                                    NSMutableArray* docIds = [NSMutableArray array];
+                                    for (CBLQueryRow* row in rows)
+                                        [docIds addObject: row.documentID];
+                                    value = docIds;
                                 }
                             }
                         }
                     }
                 }
             } else if ([expression.keyPath rangeOfString:@"."].location != NSNotFound) {
-                NSArray* keyProp = [self parseKeyAndPropertyFromKeyPath: expression.keyPath];
-                if ([keyProp count] < 2) break;
-
-                NSString* srcKeyPath = keyProp[0];
-                NSString* destKeyPath = keyProp[1];
+                NSArray* keyPathComponents = [self parseKeyPathComponents: expression.keyPath];
+                if ([keyPathComponents count] < 2) break;
+                NSString* srcKeyPath = keyPathComponents[0];
+                NSString* destKeyPath = [[keyPathComponents subarrayWithRange:
+                                          NSMakeRange(1, keyPathComponents.count - 1)]
+                                            componentsJoinedByString: @"."];
 
                 propertyDesc = [entity.propertiesByName objectForKey: srcKeyPath];
                 if (![propertyDesc isKindOfClass: [NSRelationshipDescription class]])
@@ -1395,13 +1378,29 @@ static CBLManager* sCBLManager;
 
                 NSRelationshipDescription* relation = (NSRelationshipDescription*)propertyDesc;
                 if (!relation.isToMany) {
-                    NSString* childDocId = [properties objectForKey: srcKeyPath];
-                    if (childDocId) {
-                        CBLDocument* document = [self.database existingDocumentWithID: childDocId];
-                        if (document)
-                            value = [document.properties objectForKey: destKeyPath];
+                    // one-to-one (multiple level fetching):
+                    NSString* subDocId = [properties objectForKey: srcKeyPath];
+                    if (subDocId) {
+                        _relationshipSearchDepth++;
+                        if (_relationshipSearchDepth > self.maxRelationshipSearchDepth) {
+                            WARN(@"Excess the maximum relationship search depth (current=%lu vs max=%lu)",
+                                 _relationshipSearchDepth, self.maxRelationshipSearchDepth);
+                            break;
+                        }
+
+                        CBLDocument* subDocument = [self.database existingDocumentWithID: subDocId];
+                        if (subDocument) {
+                            NSEntityDescription* subEntity = relation.destinationEntity;
+                            NSExpression *subExpression = [NSExpression expressionForKeyPath:destKeyPath];
+                            return [self evaluateExpression: subExpression
+                                                 withEntity: subEntity
+                                             withProperties: subDocument.properties
+                                                withContext:context];
+                        }
                     }
+                    break;
                 } else {
+                    // one(many)-to-many (1 level fetching):
                     if (relation.inverseRelationship.toMany) {
                         // many-to-many
                         value = [properties objectForKey: srcKeyPath];
@@ -1450,7 +1449,9 @@ static CBLManager* sCBLManager;
     //    NSIntersectSetExpressionType,
     //    NSMinusSetExpressionType,
     //    NSBlockExpressionType = 19
-    
+
+    if ([value isKindOfClass: [NSManagedObject class]])
+        value = [[value objectID] couchbaseLiteIDRepresentation];
     return value;
 }
 
@@ -1680,7 +1681,6 @@ static CBLManager* sCBLManager;
         
         if ([desc isKindOfClass: [NSAttributeDescription class]]) {
             NSAttributeDescription* attr = desc;
-            
             if ([attr isTransient]) {
                 continue;
             }
@@ -1704,7 +1704,7 @@ static CBLManager* sCBLManager;
             
             if (value) {
                 NSAttributeType attributeType = [attr attributeType];
-                
+
                 if (attr.valueTransformerName) {
                     NSValueTransformer* transformer = [NSValueTransformer valueTransformerForName: attr.valueTransformerName];
                     Class transformedClass = [[transformer class] transformedValueClass];

--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -28,11 +28,11 @@
 #define WARN(FMT, ...) NSLog(@"[CBLIS] WARNING " FMT, ##__VA_ARGS__)
 #define ERROR(FMT, ...) NSLog(@"[CBLIS] ERROR " FMT, ##__VA_ARGS__)
 
-#define kDefaultMaxRelationshipSearchDepth 3;
+#define kDefaultMaxRelationshipLoadDepth 3;
 
 NSString* const kCBLISErrorDomain = @"CBLISErrorDomain";
 NSString* const kCBLISObjectHasBeenChangedInStoreNotification = @"CBLISObjectHasBeenChangedInStoreNotification";
-NSString* const kCBLISCustomPropertyMaxRelationshipSearchDepth = @"CBLISCustomPropertyMaxRelationshipFetchDepth";
+NSString* const kCBLISCustomPropertyMaxRelationshipLoadDepth = @"CBLISCustomPropertyMaxRelationshipLoadDepth";
 
 static NSString* const kCBLISDefaultTypeKey = @"type";
 static NSString* const kCBLISOldDefaultTypeKey = @"CBLIS_type";
@@ -59,7 +59,7 @@ static NSError* CBLISError(NSInteger code, NSString* desc, NSError *parent);
 @property (nonatomic, strong) NSHashTable* observingManagedObjectContexts;
 @property (nonatomic, strong) CBLDatabase* database;
 @property (nonatomic, strong) id changeObserver;
-@property (nonatomic, readonly) NSUInteger maxRelationshipSearchDepth;
+@property (nonatomic, readonly) NSUInteger maxRelationshipLoadDepth;
 
 @end
 
@@ -652,10 +652,10 @@ static CBLManager* sCBLManager;
 
 #pragma mark - Custom properties
 
-- (NSUInteger) maxRelationshipSearchDepth {
-    id maxDepthValue = _customProperties[kCBLISCustomPropertyMaxRelationshipSearchDepth];
-    NSUInteger maxDepth = [maxDepthValue unsignedIntegerValue];
-    return maxDepth > 0 ? maxDepth : kDefaultMaxRelationshipSearchDepth;
+- (NSUInteger) maxRelationshipLoadDepth {
+    id maxDepth = _customProperties[kCBLISCustomPropertyMaxRelationshipLoadDepth];
+    NSUInteger maxDepthValue = [maxDepth unsignedIntegerValue];
+    return maxDepthValue > 0 ? maxDepthValue : kDefaultMaxRelationshipLoadDepth;
 }
 
 #pragma mark - Views
@@ -1382,9 +1382,9 @@ static CBLManager* sCBLManager;
                     NSString* subDocId = [properties objectForKey: srcKeyPath];
                     if (subDocId) {
                         _relationshipSearchDepth++;
-                        if (_relationshipSearchDepth > self.maxRelationshipSearchDepth) {
+                        if (_relationshipSearchDepth > self.maxRelationshipLoadDepth) {
                             WARN(@"Excess the maximum relationship search depth (current=%lu vs max=%lu)",
-                                 _relationshipSearchDepth, self.maxRelationshipSearchDepth);
+                                 _relationshipSearchDepth, self.maxRelationshipLoadDepth);
                             break;
                         }
 

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -1180,7 +1180,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     }];
 }
 
-- (void)test_FetchWithRelationshipDeep {
+- (void)test_FetchWithNestedRelationship {
     NSError *error;
     
     User *user1 = [NSEntityDescription insertNewObjectForEntityForName:@"User"
@@ -1231,7 +1231,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     [self reCreateCoreDataContext];
 
     // Set the max depth to 1:
-    store.customProperties = @{kCBLISCustomPropertyMaxRelationshipSearchDepth: @(1)};
+    store.customProperties = @{kCBLISCustomPropertyMaxRelationshipLoadDepth: @(1)};
 
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"entry == %@", entry1];
     [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -1180,6 +1180,51 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     }];
 }
 
+- (void)test_FetchWithRelationshipDeep {
+    NSError *error;
+    
+    User *user1 = [NSEntityDescription insertNewObjectForEntityForName:@"User"
+                                                inManagedObjectContext:context];
+    user1.name = @"User1";
+    
+    // Entry1:
+    Entry *entry1 = [NSEntityDescription insertNewObjectForEntityForName:@"Entry"
+                                                  inManagedObjectContext:context];
+    entry1.created_at = [NSDate new];
+    entry1.text = @"This is an entry 1.";
+    entry1.number = @(10);
+    entry1.user = user1;
+    
+    for (NSUInteger i = 0; i < 3; i++) {
+        Subentry *sub = [NSEntityDescription insertNewObjectForEntityForName:@"Subentry"
+                                                      inManagedObjectContext:context];
+        sub.text = [NSString stringWithFormat:@"Entry1-Sub%lu", (unsigned long)i];
+        sub.number = @(10 + i);
+        [entry1 addSubEntriesObject:sub];
+    }
+    
+    BOOL success = [context save:&error];
+    Assert(success, @"Could not save context: %@", error);
+    
+    // Tear down the database to refresh cache
+    context = [CBLIncrementalStore createManagedObjectContextWithModel:model
+                                                          databaseName:db.name error:&error];
+    
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Subentry"];
+    
+    // Simple Many
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"entry == %@", entry1];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 3);
+    }];
+    
+    // Deep Many
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"entry.user == %@", user1];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 3);
+    }];
+}
+
 - (void)test_FetchParentChildEntities {
     Parent *p1 = [NSEntityDescription insertNewObjectForEntityForName:@"Parent"
                                                inManagedObjectContext:context];


### PR DESCRIPTION
- Getting the relationship document as the document id instead of the NSManagedObject object.

- Support multiple level relationship search. The default max releationship search depth of 3. Users can customize the max depth by specifiying the custom properties called `kCBLISCustomPropertyMaxRelationshipSearchDepth `.