### PR TITLE
cannot nullify NSData property with CBLIncrementalStore

### DIFF
--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -810,6 +810,29 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
 
     NSString *stringFromContent = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
     Assert([stringFromContent hasPrefix:@"Updated."], @"Not updated");
+
+    // nullify attachment
+
+    data = nil;
+    file.data = data;
+
+    success = [context save:&error];
+    Assert(success, @"Could not save context: %@", error);
+
+    doc = [database documentWithID:[file.objectID couchbaseLiteIDRepresentation]];
+    Assert(doc != nil, @"Document should not be nil");
+    AssertEqual(file.filename, [doc propertyForKey:@"filename"]);
+
+    att = [doc.currentRevision attachmentNamed:@"data"];
+    Assert(att != nil, @"Attachmant should be created");
+
+    content = att.content;
+    Assert(content != nil, @"Content should be loaded");
+    AssertEq(content.length, data.length);
+    AssertEqual(content, data);
+
+    NSString *stringFromContentNil = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
+    Assert(0 == stringFromContentNil.length, @"Not nil, size:%lu", stringFromContentNil.length);
 }
 
 - (void) test_FetchWithPredicates {


### PR DESCRIPTION
I just added a simple test that shows when we set to nil a NSData property, the old value is kept.