### PR TITLE
Added some way to add information to a document on the fly

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.h
+++ b/Source/API/Extras/CBLIncrementalStore.h
@@ -53,6 +53,11 @@ typedef enum
  */
 typedef void(^CBLISConflictHandler)(NSArray* conflictingRevisions);
 
+@protocol CBLIncrementalStoreDelegate <NSObject>
+@optional
+- (NSDictionary *)keyValuesToAddToManagedObject:(NSManagedObject *)managedObject;
+@end
+
 
 /** NSIncrementalStore implementation that persists the data in a CouchbaseLite database. Before using this store you need to call #updateManagedObjectModel:
  * to prepare the Core Data model. To be informed about changes, you need to call #addObservingManagedObjectContext: with every NSManagedObjectContext.
@@ -70,6 +75,9 @@ typedef void(^CBLISConflictHandler)(NSArray* conflictingRevisions);
 
 /** Conflict handling block that gets called when conflicts are to be handled. Initialied with a generic conflicts handler, can be set to NULL to not handle conflicts at all. */
 @property (nonatomic, copy) CBLISConflictHandler conflictHandler;
+
+/** Delegate allowing some more customization to the developer's implementation */
+@property (nonatomic, weak) id<CBLIncrementalStoreDelegate> delegate;
 
 /** An optional dictionary of extra properties for the incremental store.*/
 @property (nonatomic, copy) NSDictionary* customProperties;

--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -2197,13 +2197,22 @@ static CBLManager* sCBLManager;
  * Can be overridden if you need more for filtered syncing.
  */
 - (NSDictionary*) propertiesForDeletingDocument: (CBLDocument*)doc {
+    NSMutableDictionary *contents = [NSMutableDictionary dictionary];
     NSString *typeKey = [self documentTypeKey];
-    NSDictionary* contents = @{
-                               @"_deleted": @YES,
-                               @"_rev": [doc propertyForKey:@"_rev"],
-                               typeKey: [doc propertyForKey: typeKey]
-                               };
-    return contents;
+    
+    [contents addEntriesFromDictionary:@{
+                                         @"_deleted": @YES,
+                                         @"_rev": [doc propertyForKey:@"_rev"],
+                                         typeKey: [doc propertyForKey: typeKey]
+                                         }];
+    
+    
+    if (_flags.respondsToKeyValuesToAddToManagedObject) {
+        [contents addEntriesFromDictionary:[_delegate keyValuesToAddToManagedObject:nil]];
+    }
+    
+    
+    return [NSDictionary dictionaryWithDictionary:contents];
 }
 
 @end


### PR DESCRIPTION
In my use case I want users to only see THEIR data, not other's.
So I need to add a "owner" property on each document. But I don't want to add property to all tables in my Core Data model, since I think it is more a metadata than a data, since on the device I don't need that information since, as a user, all I have on my device is my data anyway. But Couchbase needs this information to do a proper rooting.
So I want to add a "owner" property on every documents. created from NSManagedObjects.
But to make it usable by any developer I added a delegate methods that is called when the Document is created to give the opportunity for developer to add any properties they want.

I therefore don't have to touch my datamodel. What do you think ?