### PR TITLE
Fix CBLIS storing and querying boolean value

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.h
+++ b/Source/API/Extras/CBLIncrementalStore.h
@@ -14,6 +14,12 @@ extern NSString* const kCBLISObjectHasBeenChangedInStoreNotification;
 /** Maximum number of relationship loading allowed in a fetch request. Default value is 3. */
 extern NSString* const kCBLISCustomPropertyMaxRelationshipLoadDepth;
 
+/** Enable query boolean value with number. After CBL 1.1.0, CBLIS stores a boolean value as
+ * a JSON boolean value instead of a number value of 1 or 0. If the application
+ * uses CBLIS and has stored boolean values since CBL 1.1.0 or below, setting this option to
+ * YES is required for quering data with boolean value predicates. Default value is NO. */
+extern NSString* const kCBLISCustomPropertyQueryBooleanWithNumber;
+
 /** Error codes for CBLIncrementalStore. */
 typedef enum
 {

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -851,18 +851,6 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Entry"];
 
     //// ==
-    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == YES"];
-    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
-        AssertEq((int)result.count, 2);
-    }];
-
-    //// ==
-    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == NO"];
-    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
-        AssertEq((int)result.count, 1);
-    }];
-
-    //// ==
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"text == %@", entry1[@"text"]];
     [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
         AssertEq((int)result.count, 1);
@@ -1093,6 +1081,71 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     }];
 }
 
+- (void)test_FetchBooleanValue {
+    NSError *error;
+
+    NSDictionary *entry1 = @{
+                             @"created_at": [NSDate new],
+                             @"check": @YES,
+                             @"text": @"This is a test for predicates. Möhre.",
+                             @"text2": @"This is text2.",
+                             @"number": [NSNumber numberWithInt:10],
+                             @"decimalNumber": [NSDecimalNumber decimalNumberWithString:@"10.10"],
+                             @"doubleNumber": [NSNumber numberWithDouble:42.23]
+                             };
+    NSDictionary *entry2 = @{
+                             @"created_at": [[NSDate new] dateByAddingTimeInterval:-60],
+                             @"check": @YES,
+                             @"text": @"Entry number 2. touché.",
+                             @"text2": @"Text 2 by Entry number 2",
+                             @"number": [NSNumber numberWithInt:20],
+                             @"decimalNumber": [NSDecimalNumber decimalNumberWithString:@"20.20"],
+                             @"doubleNumber": [NSNumber numberWithDouble:12.45]
+                             };
+    NSDictionary *entry3 = @{
+                             @"created_at": [[NSDate new] dateByAddingTimeInterval:60],
+                             @"check": @NO,
+                             @"text": @"Entry number 3",
+                             @"text2": @"Text 2 by Entry number 3",
+                             @"number": [NSNumber numberWithInt:30],
+                             @"decimalNumber": [NSDecimalNumber decimalNumberWithString:@"30.30"],
+                             @"doubleNumber": [NSNumber numberWithDouble:98.76]
+                             };
+
+    CBLISTestInsertEntriesWithProperties(context, @[entry1, entry2, entry3]);
+
+    BOOL success = [context save:&error];
+    Assert(success, @"Could not save context: %@", error);
+
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Entry"];
+
+    //// ==
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == YES"];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 2);
+    }];
+
+    //// ==
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == NO"];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 1);
+    }];
+    
+    [store setCustomProperties:@{kCBLISCustomPropertyQueryBooleanWithNumber: @(YES)}];
+
+    //// ==
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == YES"];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 2);
+    }];
+
+    //// ==
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == NO"];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 1);
+    }];
+}
+
 - (void)test_FetchWithRelationship {
     NSError *error;
 
@@ -1164,7 +1217,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     BOOL success = [context save:&error];
     Assert(success, @"Could not save context: %@", error);
 
-    // Tear down the database to refresh cache
+    // Reset context and cache:
     [self reCreateCoreDataContext];
 
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Entry"];
@@ -1300,7 +1353,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     BOOL success = [context save:&error];
     Assert(success, @"Could not save context: %@", error);
     
-    // Tear down the database to refresh cache
+    // Reset context and cache:
     [self reCreateCoreDataContext];
     
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Subentry"];
@@ -1393,7 +1446,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     BOOL success = [context save:&error];
     Assert(success, @"Could not save context: %@", error);
 
-    // Tear down the database to refresh cache
+    // Reset context and cache:
     [self reCreateCoreDataContext];
 
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Subentry"];
@@ -1479,9 +1532,8 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     BOOL success = [context save:&error];
     Assert(success, @"Could not save context: %@", error);
 
-    // Tear down the database to refresh cache
-    context = [CBLIncrementalStore createManagedObjectContextWithModel:model
-                                                          databaseName:db.name error:&error];
+    // Reset context and cache:
+    [self reCreateCoreDataContext];
 
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Subentry"];
 

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -817,6 +817,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     
     NSDictionary *entry1 = @{
                              @"created_at": [NSDate new],
+                             @"check": @YES,
                              @"text": @"This is a test for predicates. Möhre.",
                              @"text2": @"This is text2.",
                              @"number": [NSNumber numberWithInt:10],
@@ -825,6 +826,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
                              };
     NSDictionary *entry2 = @{
                              @"created_at": [[NSDate new] dateByAddingTimeInterval:-60],
+                             @"check": @YES,
                              @"text": @"Entry number 2. touché.",
                              @"text2": @"Text 2 by Entry number 2",
                              @"number": [NSNumber numberWithInt:20],
@@ -833,6 +835,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
                              };
     NSDictionary *entry3 = @{
                              @"created_at": [[NSDate new] dateByAddingTimeInterval:60],
+                             @"check": @NO,
                              @"text": @"Entry number 3",
                              @"text2": @"Text 2 by Entry number 3",
                              @"number": [NSNumber numberWithInt:30],
@@ -846,6 +849,18 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     Assert(success, @"Could not save context: %@", error);
     
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Entry"];
+
+    //// ==
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == YES"];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 2);
+    }];
+
+    //// ==
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"check == NO"];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 1);
+    }];
 
     //// ==
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"text == %@", entry1[@"text"]];
@@ -1300,6 +1315,11 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"entry.user == %@", user1];
     [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
         AssertEq((int)result.count, 3);
+    }];
+
+    fetchRequest.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[[NSPredicate predicateWithFormat:@"entry == %@", entry1], [NSPredicate predicateWithFormat:@"number == 10"]]];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 1);
     }];
 
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"entry.user.name like %@", user1.name];


### PR DESCRIPTION
- Store boolean value in CBL database as JSON boolean value instead of number boolean value

- Provide kCBLISCustomPropertyQueryBooleanWithNumber (Default is NO) to support querying the existing boolean number value.

- If setting the kCBLISCustomPropertyQueryBooleanWithNumber property value to YES, when scanning the predicate for CBLQueryBuilder, CBLIS will replcate the original boolean predicate with an OR-compound predicate of the original predicate and the improvised number boolean predicate without parameterizing. For example, if the predicate is 'checked == YES', CBLIS will replace the predicate with 'checked == YES or checked == 1.

#756