### PR TITLE
Fix CBLIS cannot nullify NSData property

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -419,12 +419,15 @@ static CBLManager* sCBLManager;
         if ([attr isTransient]) continue;
         if ([attr attributeType] != NSBinaryDataAttributeType) continue;
 
-        NSData* data = [object valueForKey: attr.name];
-        if (!data) continue;
-
-        [revision setAttachmentNamed: attr.name
-                     withContentType: @"application/binary"
-                             content: data];
+        if ([[object changedValues] objectForKey: attr.name]) {
+            NSData* data = [object valueForKey: attr.name];
+            if (data)
+                [revision setAttachmentNamed: attr.name
+                             withContentType: @"application/binary"
+                                     content: data];
+            else if ([doc.currentRevision attachmentNamed: attr.name])
+                [revision removeAttachmentNamed: attr.name];
+        }
     }
 
     BOOL result = [revision save: outError] != nil;

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -810,6 +810,29 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
 
     NSString *stringFromContent = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
     Assert([stringFromContent hasPrefix:@"Updated."], @"Not updated");
+
+    // nullify attachment
+
+    data = nil;
+    file.data = data;
+
+    success = [context save:&error];
+    Assert(success, @"Could not save context: %@", error);
+
+    doc = [database documentWithID:[file.objectID couchbaseLiteIDRepresentation]];
+    Assert(doc != nil, @"Document should not be nil");
+    AssertEqual(file.filename, [doc propertyForKey:@"filename"]);
+
+    att = [doc.currentRevision attachmentNamed:@"data"];
+    Assert(att != nil, @"Attachmant should be created");
+
+    content = att.content;
+    Assert(content != nil, @"Content should be loaded");
+    AssertEq(content.length, data.length);
+    AssertEqual(content, data);
+
+    NSString *stringFromContentNil = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
+    Assert(0 == stringFromContentNil.length, @"Not nil, size:%lu", stringFromContentNil.length);
 }
 
 - (void) test_FetchWithPredicates {

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -824,15 +824,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     AssertEqual(file.filename, [doc propertyForKey:@"filename"]);
 
     att = [doc.currentRevision attachmentNamed:@"data"];
-    Assert(att != nil, @"Attachmant should be created");
-
-    content = att.content;
-    Assert(content != nil, @"Content should be loaded");
-    AssertEq(content.length, data.length);
-    AssertEqual(content, data);
-
-    NSString *stringFromContentNil = [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
-    Assert(0 == stringFromContentNil.length, @"Not nil, size:%lu", stringFromContentNil.length);
+    AssertNil(att);
 }
 
 - (void) test_FetchWithPredicates {


### PR DESCRIPTION
- Remove the attachment when nullifying the NSData property

- Optimize storing the attachment by checking if the NSData property value was changed or not

#763