### PR TITLE
Fix issue 765: dateWithJSONObject: method cannot parse ISO 8601 dates with a time zone designator "+hhmm" or "-hhmm"

### DIFF
--- a/Source/CBLParseDate.c
+++ b/Source/CBLParseDate.c
@@ -142,7 +142,7 @@ end_getDigits:
  ** Parse a timezone extension on the end of a date-time.
  ** The extension is of the form:
  **
- **        (+/-)HH:MM
+ **        (+/-)HH:MM or (+/-)HHMM
  **
  ** Or the "zulu" notation:
  **
@@ -172,9 +172,19 @@ static int parseTimezone(const char *zDate, DateTime *p){
         return c!=0;
     }
     zDate++;
-    if( getDigits(zDate, 2, 0, 14, ':', &nHr, 2, 0, 59, 0, &nMn)!=2 ){
+    
+    if( getDigits(zDate, 2, 0, 14, 0, &nHr) != 1 ) {
         return 1;
     }
+    
+    if (*zDate == ':') {
+        zDate++;
+    }
+    
+    if( getDigits(zDate, 2, 0, 59, 0, &nMn) != 1 ) {
+        return 1;
+    }
+    
     zDate += 5;
     p->tz = sgn*(nMn + nHr*60);
 zulu_time:

--- a/Unit-Tests/JSON_Tests.m
+++ b/Unit-Tests/JSON_Tests.m
@@ -29,6 +29,10 @@
     XCTAssertEqualWithAccuracy([CBLJSON absoluteTimeWithJSONObject: @"2013-04-01T20:42:33Z"], 386541753.000, 1e-6);
     NSDate* date = [CBLJSON dateWithJSONObject: @"2013-04-01T20:42:33Z"];
     AssertEq(date.timeIntervalSinceReferenceDate, 386541753.000);
+    date = [CBLJSON dateWithJSONObject: @"2013-04-01T20:42:33+0000"];
+    AssertEq(date.timeIntervalSinceReferenceDate, 386541753.000);
+    date = [CBLJSON dateWithJSONObject: @"2013-04-01T20:42:33+00:00"];
+    AssertEq(date.timeIntervalSinceReferenceDate, 386541753.000);
     date = [CBLJSON dateWithJSONObject: @"2013-04-01T20:42:33.388Z"];
     XCTAssertEqualWithAccuracy(date.timeIntervalSinceReferenceDate, 386541753.388, 1e-6);
     AssertNil([CBLJSON dateWithJSONObject: @""]);


### PR DESCRIPTION
Fix for the issue: https://github.com/couchbase/couchbase-lite-ios/issues/765