### PR TITLE
Filter out _removed revision from push replication

### DIFF
--- a/Source/CBL_Pusher.m
+++ b/Source/CBL_Pusher.m
@@ -279,8 +279,8 @@
                             [self revisionFailed];
                             continue;
                         }
-                        
-                        if ([loadedRev[@"_removed"] boolValue]) {
+
+                        if ($castIf(NSNumber, loadedRev[@"_removed"]).boolValue) {
                             // Filter out _removed revision:
                             [self removePending: rev];
                             continue;

--- a/Source/CBL_Pusher.m
+++ b/Source/CBL_Pusher.m
@@ -279,6 +279,12 @@
                             [self revisionFailed];
                             continue;
                         }
+                        
+                        if ([loadedRev[@"_removed"] boolValue]) {
+                            // Filter out _removed revision:
+                            [self removePending: rev];
+                            continue;
+                        }
 
                         CBL_MutableRevision* populatedRev = [[self transformRevision: loadedRev] mutableCopy];
 

--- a/Unit-Tests/Server/cbl_unit_tests.json
+++ b/Unit-Tests/Server/cbl_unit_tests.json
@@ -54,6 +54,13 @@
 				"GUEST": {"disabled": false, "admin_channels":["*"]}
 			},
             "sync": `function(doc) {throw({forbidden: "Immutable test db"});}`
-		}
+        },
+        "cbl_replicator_removed_rev": {
+            "server": "walrus:walrus_data",
+            "users": {
+                "test": {"admin_channels":["private"],"password":"abc123"}
+            },
+            "sync": `function(doc) {if (doc.grant) {channel("private");}}`
+        }
 	}
 }

--- a/Unit-Tests/Server/cbl_unit_tests.json
+++ b/Unit-Tests/Server/cbl_unit_tests.json
@@ -54,13 +54,6 @@
 				"GUEST": {"disabled": false, "admin_channels":["*"]}
 			},
             "sync": `function(doc) {throw({forbidden: "Immutable test db"});}`
-        },
-        "cbl_replicator_removed_rev": {
-            "server": "walrus:walrus_data",
-            "users": {
-                "test": {"admin_channels":["private"],"password":"abc123"}
-            },
-            "sync": `function(doc) {if (doc.grant) {channel("private");}}`
         }
 	}
 }


### PR DESCRIPTION
- Filter out _removed revision in CBL_Pusher's processInbox when preparing revisions to send to the remote server.

- No changes in CBL_Pusher.unpushedRevisions properties. Therefore unpushedRevisions could contained _removed revisions. The same for getting _changes feed from the CBLRouter.

- Added a unit test

- Added cbl_replicator_removed_rev remote database config to Unit-Tests/Server/cbl_unit_tests.json

#671