### PR TITLE
Add prefixMatchLevel logic to allDocuments query

### DIFF
--- a/Source/CBLMisc.h
+++ b/Source/CBLMisc.h
@@ -105,6 +105,8 @@ NSURL* CBLURLWithoutQuery( NSURL* url ) __attribute__((nonnull));
 /** Appends path components to a URL. These will NOT be URL-escaped, so you can include queries. */
 NSURL* CBLAppendToURL(NSURL* baseURL, NSString* toAppend) __attribute__((nonnull));
 
+/** Changes a given query max key into one that also extends to any key it matches as a prefix. */
+id CBLKeyForPrefixMatch(id key, unsigned depth);
 
 #if DEBUG
 NSString* CBLPathToTestFile(NSString* name);

--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -474,3 +474,24 @@ NSURL* CBLAppendToURL(NSURL* baseURL, NSString* toAppend) {
     [urlStr appendString: toAppend];
     return [NSURL URLWithString: urlStr];
 }
+
+
+id CBLKeyForPrefixMatch(id key, unsigned depth) {
+    if (depth < 1)
+        return key;
+    if ([key isKindOfClass: [NSString class]]) {
+        // Kludge: prefix match a string by appending max possible character value to it
+        return [key stringByAppendingString: @"\uffffffff"];
+    } else if ([key isKindOfClass: [NSArray class]]) {
+        NSMutableArray* nuKey = [key mutableCopy];
+        if (depth == 1) {
+            [nuKey addObject: @{}];
+        } else {
+            id lastObject = CBLKeyForPrefixMatch(nuKey.lastObject, depth-1);
+            [nuKey replaceObjectAtIndex: nuKey.count-1 withObject: lastObject];
+        }
+        return nuKey;
+    } else {
+        return key;
+    }
+}

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -505,9 +505,17 @@ static void FDBLogCallback(forestdb::logLevel level, const char *message) {
             docIDs.push_back(docID.UTF8String);
         e = DocEnumerator(*_forest, docIDs, forestOpts);
     } else {
+        id startKey, endKey;
+        if (options->descending) {
+            startKey = CBLKeyForPrefixMatch(options.startKey, options->prefixMatchLevel);
+            endKey = options.endKey;
+        } else {
+            startKey = options.startKey;
+            endKey = CBLKeyForPrefixMatch(options.endKey, options->prefixMatchLevel);
+        }
         e = DocEnumerator(*_forest,
-                          nsstring_slice(options.startKey),
-                          nsstring_slice(options.endKey),
+                          nsstring_slice(startKey),
+                          nsstring_slice(endKey),
                           forestOpts);
     }
 

--- a/Source/CBL_ForestDBViewStorage.mm
+++ b/Source/CBL_ForestDBViewStorage.mm
@@ -495,7 +495,7 @@ static NSString* viewNames(NSArray* views) {
                                collatableKeys,
                                forestOpts);
     } else {
-        id endKey = keyForPrefixMatch(options.endKey, options->prefixMatchLevel);
+        id endKey = CBLKeyForPrefixMatch(options.endKey, options->prefixMatchLevel);
         return IndexEnumerator(_index,
                                Collatable(options.startKey),
                                nsstring_slice(options.startKeyDocID),
@@ -590,28 +590,6 @@ static NSString* viewNames(NSArray* views) {
         }
         return nil;
     };
-}
-
-
-// Changes a maxKey into one that also extends to any key it matches as a prefix.
-static id keyForPrefixMatch(id key, unsigned depth) {
-    if (depth < 1)
-        return key;
-    if ([key isKindOfClass: [NSString class]]) {
-        // Kludge: prefix match a string by appending max possible character value to it
-        return [key stringByAppendingString: @"\uffffffff"];
-    } else if ([key isKindOfClass: [NSArray class]]) {
-        NSMutableArray* nuKey = [key mutableCopy];
-        if (depth == 1) {
-            [nuKey addObject: @{}];
-        } else {
-            id lastObject = keyForPrefixMatch(nuKey.lastObject, depth-1);
-            [nuKey replaceObjectAtIndex: nuKey.count-1 withObject: lastObject];
-        }
-        return nuKey;
-    } else {
-        return key;
-    }
 }
 
 

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -1112,6 +1112,7 @@ NSString* CBLJoinSQLQuotedStrings(NSArray* strings) {
     }
     if (maxKey) {
         Assert([maxKey isKindOfClass: [NSString class]]);
+        maxKey = CBLKeyForPrefixMatch(maxKey, options->prefixMatchLevel);
         [sql appendString: (inclusiveMax ? @" AND docid <= ?" :  @" AND docid < ?")];
         [args addObject: maxKey];
     }

--- a/Source/CBL_SQLiteViewStorage.m
+++ b/Source/CBL_SQLiteViewStorage.m
@@ -21,6 +21,7 @@
 #import "CBLCollateJSON.h"
 #import "CouchbaseLitePrivate.h"
 #import "CBLInternal.h"
+#import "CBLMisc.h"
 #import "ExceptionUtils.h"
 
 #import "FMDatabase.h"
@@ -642,7 +643,7 @@ typedef CBLStatus (^QueryRowBlock)(NSData* keyData, NSData* valueData, NSString*
         }
     }
     if (maxKey) {
-        maxKey = keyForPrefixMatch(maxKey, options->prefixMatchLevel);
+        maxKey = CBLKeyForPrefixMatch(maxKey, options->prefixMatchLevel);
         NSData* maxKeyData = toJSONData(maxKey);
         [sql appendString: (inclusiveMax ? @" AND key <= ?" :  @" AND key < ?")];
         [sql appendString: collationStr];
@@ -890,28 +891,6 @@ typedef CBLStatus (^QueryRowBlock)(NSData* keyData, NSData* valueData, NSString*
 
     //OPT: Return objects from enum as they're found, without collecting them in an array first
     return queryIteratorBlockFromArray(rows);
-}
-
-
-// Changes a maxKey into one that also extends to any key it matches as a prefix.
-static id keyForPrefixMatch(id key, unsigned depth) {
-    if (depth < 1)
-        return key;
-    if ([key isKindOfClass: [NSString class]]) {
-        // Kludge: prefix match a string by appending max possible character value to it
-        return [key stringByAppendingString: @"\uffffffff"];
-    } else if ([key isKindOfClass: [NSArray class]]) {
-        NSMutableArray* nuKey = [key mutableCopy];
-        if (depth == 1) {
-            [nuKey addObject: @{}];
-        } else {
-            id lastObject = keyForPrefixMatch(nuKey.lastObject, depth-1);
-            [nuKey replaceObjectAtIndex: nuKey.count-1 withObject: lastObject];
-        }
-        return nuKey;
-    } else {
-        return key;
-    }
 }
 
 

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -454,6 +454,63 @@
     AssertEq(n, kNDocs);
 }
 
+- (void) test12_AllDocumentsPrefixMatchLevel {
+    [self createDocumentWithProperties:@{@"_id": @"three"}];
+    [self createDocumentWithProperties:@{@"_id": @"four"}];
+    [self createDocumentWithProperties:@{@"_id": @"five"}];
+    [self createDocumentWithProperties:@{@"_id": @"eight"}];
+    [self createDocumentWithProperties:@{@"_id": @"fifteen"}];
+
+    // clear the cache so all documents/revisions will be re-fetched:
+    [db _clearDocumentCache];
+
+    CBLQuery* query = [db createAllDocumentsQuery];
+    CBLQueryEnumerator* rows = nil;
+
+    // Set prefixMatchLevel = 1, no startKey, ascending:
+    query.descending = NO;
+    query.endKey = @"f";
+    query.prefixMatchLevel = 1;
+    rows = [query run: NULL];
+    AssertEq(rows.count, 4u);
+    AssertEqual(rows.nextRow.key, @"eight");
+    AssertEqual(rows.nextRow.key, @"fifteen");
+    AssertEqual(rows.nextRow.key, @"five");
+    AssertEqual(rows.nextRow.key, @"four");
+
+    // Set prefixMatchLevel = 1, ascending:
+    query.descending = NO;
+    query.startKey = @"f";
+    query.endKey = @"f";
+    query.prefixMatchLevel = 1;
+    rows = [query run: NULL];
+    AssertEq(rows.count, 3u);
+    AssertEqual(rows.nextRow.key, @"fifteen");
+    AssertEqual(rows.nextRow.key, @"five");
+    AssertEqual(rows.nextRow.key, @"four");
+
+    // Set prefixMatchLevel = 1, descending:
+    query.descending = YES;
+    query.startKey = @"f";
+    query.endKey = @"f";
+    query.prefixMatchLevel = 1;
+    rows = [query run: NULL];
+    AssertEq(rows.count, 3u);
+    AssertEqual(rows.nextRow.key, @"four");
+    AssertEqual(rows.nextRow.key, @"five");
+    AssertEqual(rows.nextRow.key, @"fifteen");
+
+    // Set prefixMatchLevel = 1, ascending, prefix = fi:
+    query.descending = NO;
+    query.startKey = @"fi";
+    query.endKey = @"fi";
+    query.prefixMatchLevel = 1;
+    rows = [query run: NULL];
+    AssertEq(rows.count, 2u);
+    AssertEqual(rows.nextRow.key, @"fifteen");
+    AssertEqual(rows.nextRow.key, @"five");
+}
+
 
 - (void) test12_AllDocumentsBySequence {
     static const NSUInteger kNDocs = 10;


### PR DESCRIPTION
- Extracted keyForPrefixMatch(key, depth) from CBL_SQLiteViewStorage and CBL_ForestDBViewStorage to CBLMisc as CBLKeyForPrefixMatch(key, depth) so same implementation can be reused.

- Added prefixMatchLevel logic to the -getAllDocs:status: method of CBL_SQLiteStorage and CBL_ForestDBStorage.

- Added Database_Tests.test12_AllDocumentsPrefixMatchLevel.

#683