### PR TITLE
Fixed: insert of already-existing rev was posting a change notification (#717)

### DIFF
--- a/Source/CBLDatabaseChange.m
+++ b/Source/CBLDatabaseChange.m
@@ -31,6 +31,7 @@
                                 source: (NSURL*)source
 {
     Assert(addedRevision);
+    Assert(addedRevision.sequence);
     self = [super init];
     if (self) {
         // Input CBL_Revisions need to be copied in case they are mutable:

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -1625,10 +1625,12 @@ NSString* CBLJoinSQLQuotedStrings(NSArray* strings) {
     }
     
     //// EPILOGUE: A change notification is sent...
-    [_delegate databaseStorageChanged: [[CBLDatabaseChange alloc] initWithAddedRevision: newRev
-                                                              winningRevisionID: winningRevID
-                                                                     inConflict: inConflict
-                                                                         source: nil]];
+    if (newRev.sequenceIfKnown != 0) {
+        [_delegate databaseStorageChanged: [[CBLDatabaseChange alloc] initWithAddedRevision: newRev
+                                                                  winningRevisionID: winningRevID
+                                                                         inConflict: inConflict
+                                                                             source: nil]];
+    }
     return newRev;
 }
 
@@ -1760,12 +1762,12 @@ NSString* CBLJoinSQLQuotedStrings(NSArray* strings) {
         return kCBLStatusCreated;
     }];
 
-    if (!CBLStatusIsError(status)) {
+    if (status == kCBLStatusCreated) {
         [_delegate databaseStorageChanged: [[CBLDatabaseChange alloc] initWithAddedRevision: rev
                                                               winningRevisionID: winningRevID
                                                                      inConflict: inConflict
                                                                          source: source]];
-    } else {
+    } else if (CBLStatusIsError(status)) {
         if (outError && !*outError)
             CBLStatusToOutNSError(status, outError);
     }


### PR DESCRIPTION
* -[CBL_SQLiteStorage forceInsert:...] was posting a change notification
  even if the revision already existed in the db.
* The CBL_Revision in the CBLDocumentChange would have no sequence since
  it hadn't been added to the db.
* This would cause an assertion failure when CBLRouter's changes feed
  processed the notification.
* Fixed this and added unit-test coverage of this situation.
Fixes #717