### PR TITLE
Fix CBLIS cannot nullify attributes and relationships (#782)

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -405,8 +405,8 @@ static CBLManager* sCBLManager;
     CBLDocument* doc = [self.database documentWithID:
                         [object.objectID couchbaseLiteIDRepresentation]];
     CBLUnsavedRevision* revision = [doc newRevision];
-    [revision.properties setValuesForKeysWithDictionary: contents];
-
+    revision.userProperties = contents;
+    
     // add attachments
     NSDictionary* propertyDesc = [object.entity propertiesByName];
 


### PR DESCRIPTION
Instead of using setValuesForKeysWithDictionary:, just set userProperties.

#782 