### PR TITLE
Fix change tracker digest authentication

### DIFF
--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -294,8 +294,11 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust) {
             if (cred) {
                 LogTo(RemoteRequest, @"    challenge: useCredential: %@", cred);
                 [sender useCredential: cred forAuthenticationChallenge:challenge];
-                // Update my authorizer so my owner (the replicator) can pick it up when I'm done
-                _authorizer = [[CBLBasicAuthorizer alloc] initWithCredential: cred];
+
+                if ($equal(authMethod, NSURLAuthenticationMethodHTTPBasic)) {
+                    // Update my authorizer so my owner (the replicator) can pick it up when I'm done
+                    _authorizer = [[CBLBasicAuthorizer alloc] initWithCredential: cred];
+                }
                 return;
             }
         }

--- a/Source/CBL_Replicator.m
+++ b/Source/CBL_Replicator.m
@@ -341,13 +341,6 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
                  }
                 ];
 
-    // If client didn't set an authorizer, use basic auth if credential is available:
-    if (!_authorizer) {
-        _authorizer = [[CBLBasicAuthorizer alloc] initWithURL: _remote];
-        if (_authorizer)
-            LogTo(SyncVerbose, @"%@: Found credential, using %@", self, _authorizer);
-    }
-
     self.running = YES;
     _startTime = CFAbsoluteTimeGetCurrent();
     

--- a/Unit-Tests/ChangeTracker_Tests.m
+++ b/Unit-Tests/ChangeTracker_Tests.m
@@ -125,6 +125,29 @@
 }
 
 
+- (void) test_Auth_Url {
+    RequireTestCase(AuthFailure);
+    // This database requires authentication to access at all.
+    NSURL* url = [self remoteTestDBURL: @"cbl_auth_test"];
+    if (!url)
+        return;
+
+    NSURLComponents *comps = [NSURLComponents componentsWithURL: url resolvingAgainstBaseURL: nil];
+    comps.user = @"test";
+    comps.password = @"abc123";
+    url = comps.URL;
+
+    CBLChangeTracker* tracker = [[CBLChangeTracker alloc] initWithDatabaseURL: url mode: kOneShot conflicts: NO lastSequence: 0 client:  self];
+    NSArray* expected = $array($dict({@"seq", @1},
+                                     {@"id", @"_user/test"},
+                                     {@"revs", @[]}),
+                               $dict({@"seq", @2},
+                                     {@"id", @"something"},
+                                     {@"revs", $array(@"1-53b059eb633a9d58042318e478cc73dc")}) );
+    [self run: tracker expectingChanges: expected];
+}
+
+
 - (void) test_AuthFailure {
     NSURL* url = [self remoteTestDBURL: @"cbl_auth_test"];
     if (!url)
@@ -141,6 +164,31 @@
 
 
 - (void) test_CBLWebSocketChangeTracker_Auth {
+    // This Sync Gateway database requires authentication to access at all.
+    NSURL* url = [self remoteTestDBURL: @"cbl_auth_test"];
+    if (!url) {
+        Warn(@"Skipping test; no remote DB URL configured");
+        return;
+    }
+
+    NSURLComponents *comps = [NSURLComponents componentsWithURL: url resolvingAgainstBaseURL: nil];
+    comps.user = @"test";
+    comps.password = @"abc123";
+    url = comps.URL;
+
+    CBLChangeTracker* tracker = [[CBLChangeTracker alloc] initWithDatabaseURL: url mode: kWebSocket conflicts: NO lastSequence: 0 client:  self];
+
+    NSArray* expected = $array($dict({@"seq", @1},
+                                     {@"id", @"_user/test"},
+                                     {@"revs", $array()}) ,
+                               $dict({@"seq", @2},
+                                     {@"id", @"something"},
+                                     {@"revs", $array(@"1-53b059eb633a9d58042318e478cc73dc")}) );
+    [self run: tracker expectingChanges: expected];
+}
+
+
+- (void) test_CBLWebSocketChangeTracker_Auth_Url {
     // This Sync Gateway database requires authentication to access at all.
     NSURL* url = [self remoteTestDBURL: @"cbl_auth_test"];
     if (!url) {

--- a/Unit-Tests/ReplicatorInternal_Tests.m
+++ b/Unit-Tests/ReplicatorInternal_Tests.m
@@ -218,6 +218,25 @@
 }
 
 
+- (void) test_06_Puller_Auth_Url {
+    RequireTestCase(Puller);
+    NSURL* remoteURL = [self remoteTestDBURL: @"cbl_auth_test"];
+    if (!remoteURL)
+        return;
+
+    NSURLComponents *comps = [NSURLComponents componentsWithURL: remoteURL resolvingAgainstBaseURL: nil];
+    comps.user = @"test";
+    comps.password = @"abc123";
+    remoteURL = comps.URL;
+
+    id lastSeq = replic8(db, remoteURL, NO, nil, nil, nil);
+    AssertEqual(lastSeq, @2);
+
+    AssertEq(db.documentCount, 1u);
+    AssertEq(db.lastSequenceNumber, 1u);
+}
+
+
 - (void) test_06_Puller_AuthFailure {
     RequireTestCase(Puller);
     NSURL* remoteURL = [self remoteTestDBURL: @"cbl_auth_test"];


### PR DESCRIPTION
- In CBL_Replication.start method, not creating the basic authorizer from the credentials specified in the remote url. The credentails in the URL will be automatically picked up by the NSURLConnection in CBLRemoteRequest to do (basic or digest) authentication. This also allows CBLSocketChangeTracker to get the challenge response and apply credentials to the challenge approriately based on the authentication scheme.

- In CBLRemoteRequest's connection:willSendRequestForAuthenticationChallenge: delegate method, check if the auth method is basic before creating and saving a basic authorizer.

- In CBLScoketChangeTracker, handle the case of getting authentication challenge responses (401) correctly. When getting the challenge response, we will get a NSStreamEventEndEncountered event without getting any NSStreamEventHasBytesAvailable events. Therefore we also need to check the header when getting the NSStreamEventEndEncountered event.

- Fixed WebSocketHTTPLogic's CFHTTPMessageAddAuthentication  () call by passing NULL to the auth method parameter. This allows the auth method to be selected based on the auth failure response. (PR: https://github.com/couchbaselabs/WebSockets-Cocoa/pull/3)

#777