### PR TITLE
CBLIS evaluates relationship with nsmanagedobjectid

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -1448,6 +1448,8 @@ static CBLManager* sCBLManager;
             value = [expression constantValue];
             if ([value isKindOfClass: [NSManagedObject class]])
                 value = [[value objectID] couchbaseLiteIDRepresentation];
+            if ([value isKindOfClass: [NSManagedObjectID class]])
+                value = [value couchbaseLiteIDRepresentation];
             else if ([value isKindOfClass:[NSDate class]])
                 value = [CBLJSON JSONObjectWithDate: value];
             break;

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -1437,6 +1437,12 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
         AssertEq((int)result.count, 3);
     }];
 
+    // Deep Many with an object id
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"entry.user == %@", [user1 objectID]];
+    [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
+        AssertEq((int)result.count, 3);
+    }];
+
     fetchRequest.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[[NSPredicate predicateWithFormat:@"entry == %@", entry1], [NSPredicate predicateWithFormat:@"number == 10"]]];
     [self assertFetchRequest: fetchRequest block: ^(NSArray *result, NSFetchRequestResultType resultType) {
         AssertEq((int)result.count, 1);
@@ -1576,7 +1582,6 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
         AssertEqual (texts, expected);
     }];
 }
-
 
 - (void)test_FetchWithRelationshipNil {
     NSError *error;


### PR DESCRIPTION
Manually merged https://github.com/couchbase/couchbase-lite-ios/pull/795 and added a minor fix to use scanContantValue: method to extract a constant value.