### PR TITLE
Fix CBLReplication.pendingDocumentIds when replication is not running

### DIFF
--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -403,7 +403,7 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
                                                 toDatabase: nil
                                                     status: &status];
         if (!settings) {
-            Warn(@"Error parsing replicatior settings : %@", CBLStatusToNSError(status));
+            Warn(@"Error parsing replicator settings : %@", CBLStatusToNSError(status));
             return nil;
         }
 

--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -390,18 +390,41 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 
 #pragma mark - PUSH REPLICATION ONLY:
 
-
 - (NSSet*) pendingDocumentIDs {
-    if (!_pendingDocIDs && _started && !_pull) {
-        _pendingDocIDs = [self tellReplicatorAndWait: ^NSSet*(id<CBL_Replicator> bgReplicator) {
-            if ([_bg_replicator respondsToSelector: @selector(pendingDocIDs)])
-                return _bg_replicator.pendingDocIDs;
-            else
-                return nil;
-        }];
-    }
+    if (_pull || (_started && _pendingDocIDs))
+        return _pendingDocIDs;
+
+    _pendingDocIDs = [_database.manager.backgroundServer
+                      waitForDatabaseNamed: _database.name to: ^id(CBLDatabase* bgDb)
+    {
+        CBLStatus status;
+        CBL_ReplicatorSettings* settings =
+            [bgDb.manager replicatorSettingsWithProperties: self.properties
+                                                toDatabase: nil
+                                                    status: &status];
+        if (!settings) {
+            Warn(@"Error parsing replicatior settings : %@", CBLStatusToNSError(status));
+            return nil;
+        }
+
+        NSString* lastSequence = _bg_replicator.lastSequence;
+        if (!lastSequence)
+            lastSequence = [bgDb lastSequenceForReplicator: settings];
+
+        NSError* error;
+        CBL_RevisionList* revs = [bgDb unpushedRevisionsSince: lastSequence
+                                                       filter: settings.filterBlock
+                                                       params: settings.filterParameters
+                                                        error: &error];
+        if (revs)
+            return [NSSet setWithArray: revs.allDocIDs];
+        else
+            Warn(@"Error getting unpushed revisions : %@", error);
+        return nil;
+    }];
     return _pendingDocIDs;
 }
+
 
 - (BOOL) isDocumentPending: (CBLDocument*)doc {
     return doc && [self.pendingDocumentIDs containsObject: doc.documentID];

--- a/Source/CBLBlipReplicator.m
+++ b/Source/CBLBlipReplicator.m
@@ -59,6 +59,7 @@
 @synthesize sync=_sync, status=_status;
 @synthesize changesProcessed=_changesProcessed, changesTotal=_changesTotal;
 @synthesize remoteCheckpointDocID=_remoteCheckpointDocID;
+@synthesize lastSequence=_lastSequence;
 
 
 + (BOOL) needsRunLoop {
@@ -149,7 +150,7 @@
 
 
 #if DEBUG
-@synthesize savingCheckpoint=_savingCheckpoint, active=_active, lastSequence=_lastSequence;
+@synthesize savingCheckpoint=_savingCheckpoint, active=_active;
 #endif
 
 

--- a/Source/CBLBlipReplicator.m
+++ b/Source/CBLBlipReplicator.m
@@ -321,7 +321,9 @@
             newStatus = kCBLReplicatorIdle;
             if (!_settings.continuous) {
                 LogTo(Sync, @"%@: SyncHandler went idle; closing connection...", self);
-                newStatus = kCBLReplicatorStopped;
+                // Keep the previous status. After the sync connection is closed,
+                // the status will be updated to kCBLReplicatorStopped:
+                newStatus = self.status;
                 [_sync close];
             }
             break;

--- a/Source/CBLBlipReplicator.m
+++ b/Source/CBLBlipReplicator.m
@@ -137,18 +137,6 @@
 }
 
 
-- (NSSet*) pendingDocIDs {
-    CBLQueryEnumerator* e = _sync.pendingDocuments;
-    if (!e)
-        return nil;
-    NSMutableSet* docIDs = [NSMutableSet new];
-    for (CBLQueryRow* row in e) {
-        [docIDs addObject: row.documentID];
-    }
-    return docIDs;
-}
-
-
 #if DEBUG
 @synthesize savingCheckpoint=_savingCheckpoint, active=_active;
 #endif

--- a/Source/CBLDatabase+Replication.h
+++ b/Source/CBLDatabase+Replication.h
@@ -9,6 +9,7 @@
 #import "CBL_Revision.h"
 #import "CBLStatus.h"
 @protocol CBL_Replicator;
+@class CBL_ReplicatorSettings;
 
 
 @interface CBLDatabase (Replication)
@@ -42,5 +43,14 @@
 - (void) stopAndForgetReplicator: (id<CBL_Replicator>)repl;
 - (NSString*) lastSequenceWithCheckpointID: (NSString*)checkpointID;
 - (BOOL) setLastSequence: (NSString*)lastSequence withCheckpointID: (NSString*)checkpointID;
+
+/** Get the current last sequence for a given replicator settings */
+- (NSString*) lastSequenceForReplicator: (CBL_ReplicatorSettings*)settings;
+
+/** Get unpushed revisions for a replicator since a given sequence */
+- (CBL_RevisionList*) unpushedRevisionsSince: (NSString*)sequence
+                                      filter: (CBLFilterBlock)filter
+                                      params: (NSDictionary*)filterParams
+                                       error: (NSError**)outError;
 
 @end

--- a/Source/CBLManager+Internal.h
+++ b/Source/CBLManager+Internal.h
@@ -8,7 +8,7 @@
 
 #import "CBLManager.h"
 #import "CBLStatus.h"
-@class CBLDatabase, CBL_Shared;
+@class CBLDatabase, CBL_Shared, CBL_ReplicatorSettings;
 @protocol CBL_Replicator;
 
 
@@ -37,5 +37,10 @@
 /** Creates a new CBL_Replicator, or returns an existing active one if it has the same properties. */
 - (id<CBL_Replicator>) replicatorWithProperties: (NSDictionary*)body
                                     status: (CBLStatus*)outStatus;
+
+/** Get a replicator settings from a given property. */
+- (CBL_ReplicatorSettings*) replicatorSettingsWithProperties: (NSDictionary*)body
+                                                  toDatabase: (CBLDatabase**)outDatabase // may be NULL
+                                                      status: (CBLStatus*)outStatus;
 
 @end

--- a/Source/CBLRestPusher.m
+++ b/Source/CBLRestPusher.m
@@ -75,36 +75,20 @@
 
 
 - (CBL_RevisionList*) unpushedRevisions {
-    CBLDatabase* db = _db;
-    CBLFilterBlock filter = _settings.filterBlock;
-
-    NSString* lastSequence = _lastSequence;
-    if (!lastSequence) {
-        // If replicator hasn't started yet (can happen if this method is being called from a
-        // CBLReplication), get local checkpoint from db:
-        NSString* checkpointID = self.remoteCheckpointDocID;
-        lastSequence = [db lastSequenceWithCheckpointID: checkpointID];
-    }
-
-    // Include conflicts so all conflicting revisions are replicated too
-    CBLChangesOptions options = kDefaultCBLChangesOptions;
-    options.includeConflicts = YES;
-
-    CBLStatus status;
-    CBL_RevisionList* revs = [db changesSinceSequence: [lastSequence longLongValue]
-                                              options: &options
-                                               filter: filter
-                                               params: _settings.filterParameters
-                                               status: &status];
+    NSError *error;
+    CBL_RevisionList* revs = [_db unpushedRevisionsSince: _lastSequence
+                                                  filter: _settings.filterBlock
+                                                  params: _settings.filterParameters
+                                                   error: &error];
     if (!revs)
-        self.error = CBLStatusToNSError(status);
+        self.error = error;
     return revs;
 }
+
 
 - (NSSet*) pendingDocIDs {
     CBL_RevisionList* revs = self.unpushedRevisions;
     return revs ? [NSSet setWithArray: revs.allDocIDs] : nil;
-
 }
 
 

--- a/Source/CBLRestPusher.m
+++ b/Source/CBLRestPusher.m
@@ -86,12 +86,6 @@
 }
 
 
-- (NSSet*) pendingDocIDs {
-    CBL_RevisionList* revs = self.unpushedRevisions;
-    return revs ? [NSSet setWithArray: revs.allDocIDs] : nil;
-}
-
-
 - (void) beginReplicating {
     // If we're still waiting to create the remote db, do nothing now. (This method will be
     // re-invoked after that request finishes; see -maybeCreateRemoteDB above.)

--- a/Source/CBL_Replicator.h
+++ b/Source/CBL_Replicator.h
@@ -77,8 +77,10 @@ extern NSString* CBL_ReplicatorStoppedNotification;
 /** Called by CBLDatabase to notify active replicators that it's about to close. */
 - (void) databaseClosing;
 
-#if DEBUG // for unit tests
+/** Current lastSequence tracked by the replicator. */
 @property (readonly) id lastSequence;
+
+#if DEBUG // for unit tests
 @property (readonly) BOOL active;
 @property (readonly) BOOL savingCheckpoint;
 #endif

--- a/Source/CBL_Replicator.h
+++ b/Source/CBL_Replicator.h
@@ -87,7 +87,6 @@ extern NSString* CBL_ReplicatorStoppedNotification;
 
 @optional
 @property (readonly) NSArray* activeTasksInfo;
-@property (readonly) NSSet* pendingDocIDs;
 
 @end
 


### PR DESCRIPTION
1. Query unpushed revisions from the last sequence. When the bg replicator and the bg replication's last sequence is not null, use the last sequence from the bg replicator. Otherwise use the last sequence from the database.

2. In CBLBlipReplicator, for non-continuous replication, update the status to kCBLReplicatorStopped after connection is closed. This will allow the current last sequence to be synced with the remote and saved into the database before kCBLReplicatorStopped status is notified. This means that for new replicator, we will see the (one-time) replication status like below when it replicates 10 docs:

 ```
Replication status=3; completedChangesCount=0; changesCount=0
Replication status=3; completedChangesCount=10; changesCount=10
Replication status=0; completedChangesCount=10;
```

3. I didn't refactor CBLRestReplicator to wait until the last sequence is saved before notifying kCBLReplicatorStopped status as the current code around that area is quite complex and we already did optimistic saving for the last sequence when the replicator is stopped.

4. I didn't refactored CBLSyncConnection+Push when it queries pending documents as I feel it looks good the way it is now. 

#807