### PR TITLE
Make CBLView.totalRows public

### DIFF
--- a/Source/API/CBLView.h
+++ b/Source/API/CBLView.h
@@ -105,6 +105,10 @@ FOUNDATION_EXTERN id CBLTextKey(NSString* text);
 /** The last sequence number indexed so far. */
 @property (readonly) SInt64 lastSequenceIndexed;
 
+/** Total number of rows in the view. The view's index will be updated if needed before returning
+    the totalRows value. */
+@property (readonly) NSUInteger totalRows;
+
 /** Deletes the view's persistent index. It will be regenerated on the next query. */
 - (void) deleteIndex;
 

--- a/Source/API/CBLView.m
+++ b/Source/API/CBLView.m
@@ -324,6 +324,7 @@ static id<CBLViewCompiler> sCompiler;
 
 
 - (NSUInteger) totalRows {
+    [self updateIndex];
     return _storage.totalRows;
 }
 

--- a/Source/CBLView+Internal.h
+++ b/Source/CBLView+Internal.h
@@ -39,8 +39,6 @@ BOOL CBLRowPassesFilter(CBLDatabase* db, CBLQueryRow* row, const CBLQueryOptions
 
 - (void) close;
 
-@property (readonly) NSUInteger totalRows;
-
 /** The map block alredy registered with the view. Unlike the public .mapBlock property, this
     will not look for a design document or compile a function therein. */
 @property (readonly) CBLMapBlock registeredMapBlock;

--- a/Unit-Tests/View_Tests.m
+++ b/Unit-Tests/View_Tests.m
@@ -1048,4 +1048,28 @@ static NSDictionary* mkGeoRect(double x0, double y0, double x1, double y1) {
 }
 
 
+- (void) test21_TotalRows {
+    CBLView* view = [db viewNamed: @"vu"];
+    Assert(view);
+    [view setMapBlock: MAPBLOCK({
+        emit(doc[@"sequence"], nil);
+    }) version: @"1"];
+    Assert(view.mapBlock != nil);
+    AssertEq(view.totalRows, 0u);
+
+    // Add 20 documents:
+    [self createDocuments: 20];
+    Assert(view.stale);
+    AssertEq(view.totalRows, 20u);
+    Assert(!view.stale);
+
+    // Add another 20 documents, query, and check totalRows:
+    [self createDocuments: 20];
+    CBLQuery* query = [view createQuery];
+    CBLQueryEnumerator* rows = [query run: NULL];
+    AssertEq(rows.count, 40u);
+    AssertEq(view.totalRows, 40u);
+}
+
+
 @end


### PR DESCRIPTION
- Moved totalRows property from CBLView+Internal.h to CBLView.h

- When accessing the totalRows, update the index first.

#808