### PR TITLE
Add _conflicts to the document in the map function

### DIFF
--- a/Source/CBL_ForestDBViewStorage.mm
+++ b/Source/CBL_ForestDBViewStorage.mm
@@ -92,10 +92,14 @@ public:
                 const Revision* node = vdoc.currentRevision();
                 NSMutableDictionary* body = [CBLForestBridge bodyOfNode: node];
                 body[@"_local_seq"] = @(node->sequence);
-                NSArray* conflicts = [CBLForestBridge getCurrentRevisionIDs: vdoc];
-                if (conflicts.count > 1)
-                    body[@"_conflicts"] = [conflicts subarrayWithRange:
-                                           NSMakeRange(1, conflicts.count - 1)];
+
+                if (vdoc.hasConflict()) {
+                    NSArray* conflicts = [CBLForestBridge getCurrentRevisionIDs: vdoc];
+                    if (conflicts.count > 1)
+                        body[@"_conflicts"] = [conflicts subarrayWithRange:
+                                               NSMakeRange(1, conflicts.count - 1)];
+                }
+
                 LogTo(ViewVerbose, @"Mapping %@ rev %@", body.cbl_id, body.cbl_rev);
                 CocoaMappable mappable(cppDoc, body);
                 addMappable(mappable);

--- a/Source/CBL_ForestDBViewStorage.mm
+++ b/Source/CBL_ForestDBViewStorage.mm
@@ -92,7 +92,10 @@ public:
                 const Revision* node = vdoc.currentRevision();
                 NSMutableDictionary* body = [CBLForestBridge bodyOfNode: node];
                 body[@"_local_seq"] = @(node->sequence);
-
+                NSArray* conflicts = [CBLForestBridge getCurrentRevisionIDs: vdoc];
+                if (conflicts.count > 1)
+                    body[@"_conflicts"] = [conflicts subarrayWithRange:
+                                           NSMakeRange(1, conflicts.count - 1)];
                 LogTo(ViewVerbose, @"Mapping %@ rev %@", body.cbl_id, body.cbl_rev);
                 CocoaMappable mappable(cppDoc, body);
                 addMappable(mappable);

--- a/Unit-Tests/View_Benchmarks.m
+++ b/Unit-Tests/View_Benchmarks.m
@@ -10,6 +10,8 @@
 #import "CBLView+Internal.h"
 
 
+#define TEST_DOCS_CONFLICTS 0
+
 @interface View_Benchmarks : CBLTestCaseWithDB
 @end
 
@@ -83,6 +85,8 @@
         [self benchmarkIndexingWithDocTypeOptimization: YES conflicts: NO];
 }
 
+#if TEST_DOCS_CONFLICTS
+
 - (void)testDocWithConflicts_SQLite {
     if (self.isSQLiteDB)
         [self benchmarkIndexingWithDocTypeOptimization: NO conflicts: YES];
@@ -92,5 +96,7 @@
     if (!self.isSQLiteDB)
         [self benchmarkIndexingWithDocTypeOptimization: NO conflicts: YES];
 }
+
+#endif
 
 @end


### PR DESCRIPTION
- When updating view index, gather a list of the conflict revisions if any.

- Add index conflict docs performance test to View_Benchmarks.

- Performance note when indexing 5000 documents, each has 0 conflict revisions (IP6 simulator):
```
SQLite:

Master branch:
[Time, seconds] average: 0.123, relative standard deviation: 4.698%, 
values: [0.137071, 0.118618, 0.122648, 0.118491, 0.119955, 0.130553, 0.125290, 0.121883, 0.118404, 0.120640]

_conflicts branch:
[Time, seconds] average: 0.127, relative standard deviation: 2.886%, 
values: [0.130026, 0.124279, 0.125534, 0.130044, 0.119877, 0.132092, 0.125637, 0.125442, 0.131264, 0.130175]

ForestDB:

Master branch:

[Time, seconds] average: 0.175, relative standard deviation: 0.806%, 
values: [0.173869, 0.176649, 0.173722, 0.175208, 0.176017, 0.172913, 0.175884, 0.172716, 0.174799, 0.176723]

_conflicts branch:
[Time, seconds] average: 0.172, relative standard deviation: 0.528%, 
values: [0.172850, 0.171485, 0.170446, 0.171153, 0.171059, 0.173832, 0.171988, 0.171561, 0.171765, 0.171921]
```

- Performance note when indexing 5000 documents, each has 100 conflict revisions (IP6 simulator):
```
SQLite:

Master branch:
[Time, seconds] average: 2.791, relative standard deviation: 0.972%, 
values: [2.838544, 2.784327, 2.784880, 2.747793, 2.820985, 2.789743, 2.765956, 2.775347, 2.824352, 2.774947],

_conflicts branch:
[Time, seconds] average: 3.039, relative standard deviation: 1.005%, 
values: [3.006172, 3.016779, 3.045371, 3.102432, 2.997188, 3.058586, 3.067990, 3.012772, 3.043481, 3.044008]

ForestDB:

Master branch:
[Time, seconds] average: 0.587, relative standard deviation: 0.885%, 
values: [0.580759, 0.590165, 0.585337, 0.583715, 0.588333, 0.588271, 0.585275, 0.585258, 0.583447, 0.600625], 

_conflicts branch:
[Time, seconds] average: 1.016, relative standard deviation: 8.155%, values: [1.261900, 0.983670, 0.984249, 0.984583, 0.984473, 0.980027, 0.984079, 1.019412, 0.988718, 0.984164]

```
** Update : Add Performance result for indexing 5000 docs without conflicts.