### PR TITLE
Fix attachment revpos not being set when follows=true

### DIFF
--- a/Source/CBL_Attachment.m
+++ b/Source/CBL_Attachment.m
@@ -115,6 +115,16 @@ static NSString* blobKeyToDigest(CBLBlobKey key) {
                 *outStatus = kCBLStatusBadAttachment;
                 return nil;
             }
+            // #817: There could be a revpos set to a parent revision:
+            id revPosObj = attachInfo[@"revpos"];
+            if (revPosObj) {
+                int revPos = [$castIf(NSNumber, revPosObj) intValue];
+                if (revPos <= 0) {
+                    *outStatus = kCBLStatusBadAttachment;
+                    return nil;
+                }
+                self->revpos = (unsigned)revPos;
+            }
         } else {
             *outStatus = kCBLStatusBadAttachment;
             return nil;

--- a/Unit-Tests/DatabaseAttachment_Tests.m
+++ b/Unit-Tests/DatabaseAttachment_Tests.m
@@ -526,6 +526,27 @@
 }
 
 
+- (void) test16_FollowWithRevpos {
+    NSDictionary* attachInfo = $dict({@"content_type", @"text/plain"},
+                                     {@"digest", @"md5-DaUdFsLh8FKLbcBIDlU57g=="},
+                                     {@"follows", @YES},
+                                     {@"length", @51200},
+                                     {@"revpos", @2});
+    CBLStatus status;
+    CBL_Attachment *attachment = [[CBL_Attachment alloc] initWithName: @"attachment"
+                                                                 info: attachInfo
+                                                               status: &status];
+    Assert(attachment);
+    Assert(status != kCBLStatusBadAttachment);
+    NSDictionary* stub = [attachment asStubDictionary];
+    AssertEqualish(stub, $dict({@"content_type", @"text/plain"},
+                               {@"digest", @"sha1-AAAAAAAAAAAAAAAAAAAAAAAAAAA="},
+                               {@"length", @51200},
+                               {@"revpos", @2},
+                               {@"stub", @YES}));
+}
+
+
 static NSDictionary* attachmentsDict(NSData* data, NSString* name, NSString* type, BOOL gzipped) {
     if (gzipped)
         data = [NSData gtm_dataByGzippingData: data];


### PR DESCRIPTION
During the pull replication, the revpos of an attachment could be set to a parent revision while the follows=true. If the revpos value doesn't get preserved, the revpos will be set to the current generation.

Later, when pushing an updated document again, the attachment info will contain a wrong revpos and result to the missing_stub error on CouchDB. SyncGateway currently ignores the issue and doesn't overwrite the revpos value on the server side.

#817