### PR TITLE
Fix #74 CBLRouter's processRequestRanges to return 416 when the range is invalid

### DIFF
--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -553,9 +553,11 @@ static NSArray* splitPath( NSURL* url ) {
     NSUInteger from, to;
     if (fromStr.length > 0) {
         from = (NSUInteger)fromStr.integerValue;
-        if (toStr.length > 0)
+        if (toStr.length > 0) {
             to = MIN((NSUInteger)toStr.integerValue, bodyLength - 1);
-        else
+            if (to < from)
+                return;  // invalid range
+        } else
             to = bodyLength - 1;
     } else if (toStr.length > 0) {
         to = bodyLength - 1;
@@ -571,9 +573,6 @@ static NSArray* splitPath( NSURL* url ) {
         _response.body = nil;
         return;
     }
-
-    if (to < from)
-        return;  // invalid range
 
     if (from == 0 && to == bodyLength - 1)
         return; // No-op; entire body still causes a 200 response

--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -554,9 +554,10 @@ static NSArray* splitPath( NSURL* url ) {
     if (fromStr.length > 0) {
         from = (NSUInteger)fromStr.integerValue;
         if (toStr.length > 0) {
-            to = MIN((NSUInteger)toStr.integerValue, bodyLength - 1);
+            to = (NSUInteger)toStr.integerValue;
             if (to < from)
                 return;  // invalid range
+            to = MIN(to, bodyLength - 1);
         } else
             to = bodyLength - 1;
     } else if (toStr.length > 0) {

--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -550,6 +550,7 @@ static NSArray* splitPath( NSURL* url ) {
         toStr = [rangeHeader substringWithRange: r];
 
     // Now convert those into the integer offsets (remember that 'to' is inclusive):
+    BOOL missingRange = NO;
     NSUInteger from, to;
     if (fromStr.length > 0) {
         from = (NSUInteger)fromStr.integerValue;
@@ -557,16 +558,14 @@ static NSArray* splitPath( NSURL* url ) {
             to = MIN((NSUInteger)toStr.integerValue, bodyLength - 1);
         else
             to = bodyLength - 1;
-        if (to < from)
-            return;  // invalid range
     } else if (toStr.length > 0) {
         to = bodyLength - 1;
         from = bodyLength - MIN((NSUInteger)toStr.integerValue, bodyLength);
     } else {
-        return;  // "-" is an invalid range
+        missingRange = YES;
     }
 
-    if (from >= bodyLength || to < from) {
+    if (missingRange || from >= bodyLength || to < from) {
         _response.status = 416; // Requested Range Not Satisfiable
         NSString* contentRangeStr = $sprintf(@"bytes */%llu", (uint64_t)bodyLength);
         _response[@"Content-Range"] = contentRangeStr;

--- a/Unit-Tests/Listener_Tests.m
+++ b/Unit-Tests/Listener_Tests.m
@@ -323,6 +323,53 @@ static NSString* addressToString(NSData* addrData) {
 - (void)test02_SSL_ClientCert      {[super test02_SSL_ClientCert];}
 - (void)test03_ReadOnly			   {[super test03_ReadOnly];}
 
+- (void)testGetRange {
+    // Create a document with an attachment:
+    CBLDocument* doc = [db createDocument];
+    CBLUnsavedRevision* newRev = [doc newRevision];
+    NSData* attach = [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding];
+    [newRev setAttachmentNamed: @"attach" withContentType: @"text/plain" content: attach];
+    Assert([newRev save: nil]);
+
+    // Wait for listener to start:
+    if (listener.port == 0) {
+        [self keyValueObservingExpectationForObject: listener keyPath: @"port" expectedValue: @(sPort)];
+        [listener start: NULL];
+        [self waitForExpectationsWithTimeout: kTimeout handler: nil];
+    }
+
+    // URL to the attachment:
+    NSString* path = [NSString stringWithFormat:@"%@/%@/attach", db.name, doc.documentID];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=5-15"} body: nil
+       expectedStatus: 206 expectedHeaders: @{@"Content-Range": @"bytes 5-15/27"}
+       expectedResult: [@"is the body" dataUsingEncoding: NSUTF8StringEncoding]];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=12-"} body: nil
+       expectedStatus: 206 expectedHeaders: @{@"Content-Range": @"bytes 12-26/27"}
+       expectedResult: [@"body of attach1" dataUsingEncoding: NSUTF8StringEncoding]];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=12-100"} body: nil
+       expectedStatus: 206 expectedHeaders: @{@"Content-Range": @"bytes 12-26/27"}
+       expectedResult: [@"body of attach1" dataUsingEncoding: NSUTF8StringEncoding]];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=-7"} body: nil
+       expectedStatus: 206 expectedHeaders: @{@"Content-Range": @"bytes 20-26/27"}
+       expectedResult: [@"attach1" dataUsingEncoding: NSUTF8StringEncoding]];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=5-3"} body: nil
+       expectedStatus: 416 expectedHeaders: @{@"Content-Range": @"bytes */27"}
+       expectedResult: nil];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=100-"} body: nil
+       expectedStatus: 416 expectedHeaders: @{@"Content-Range": @"bytes */27"}
+       expectedResult: nil];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=-100"} body: nil
+       expectedStatus: 200 expectedHeaders: nil
+       expectedResult: [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]];
+}
+
 
 - (void) connect {
     Log(@"Connecting to <%@>", listener.URL);
@@ -355,6 +402,68 @@ static NSString* addressToString(NSData* addrData) {
     CFRelease(realServerCert);
     Assert(CBLForceTrusted(protectionSpace.serverTrust));
     return YES;
+}
+
+
+- (void) sendRequest: (NSString*)method
+                path: (NSString*)path
+             headers: (NSDictionary*)headers
+                body: (id)bodyObj
+          onComplete: (void (^)(NSData *data, NSURLResponse *response, NSError *error))onComplete {
+    NSURL* url = [NSURL URLWithString: path relativeToURL: listener.URL];
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL: url];
+    request.HTTPMethod = method;
+
+    for (NSString* header in headers)
+        [request setValue: headers[header] forHTTPHeaderField: header];
+
+    if (bodyObj) {
+        if ([bodyObj isKindOfClass: [NSData class]])
+            request.HTTPBody = bodyObj;
+        else {
+            NSError* error = nil;
+            request.HTTPBody = [CBLJSON dataWithJSONObject: bodyObj options:0 error:&error];
+            AssertNil(error);
+        }
+    }
+
+    NSURLSessionConfiguration* config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    config.requestCachePolicy = NSURLRequestReloadIgnoringCacheData;
+    NSURLSession *session = [NSURLSession sessionWithConfiguration: config];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest: request
+                                            completionHandler:
+                                  ^(NSData *data, NSURLResponse *response, NSError *error) {
+                                      onComplete(data, response, error);
+                                  }];
+    [task resume];
+}
+
+
+- (void) sendRequest: (NSString*)method
+                path: (NSString*)path
+             headers: (NSDictionary*)headers
+                body: (id)bodyObj
+      expectedStatus: (NSInteger)expectedStatus
+     expectedHeaders: (NSDictionary*)expectedHeader
+      expectedResult: (NSData*)expectedResult {
+    NSString* description = [NSString stringWithFormat:@"%@ %@", method, path];
+    XCTestExpectation* exp = [self expectationWithDescription: description];
+
+    [self sendRequest: method path: path headers: headers body: bodyObj
+           onComplete: ^(NSData *data, NSURLResponse *response, NSError *error) {
+               NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+               AssertEq(httpResponse.statusCode, expectedStatus);
+
+               for (NSString* key in [expectedHeader allKeys])
+                   AssertEqual(httpResponse.allHeaderFields[key], expectedHeader[key]);
+
+               if (expectedResult)
+                   AssertEqual(data, expectedResult);
+
+               [exp fulfill];
+           }];
+
+    [self waitForExpectationsWithTimeout: kTimeout handler: nil];
 }
 
 @end

--- a/Unit-Tests/Listener_Tests.m
+++ b/Unit-Tests/Listener_Tests.m
@@ -323,7 +323,7 @@ static NSString* addressToString(NSData* addrData) {
 - (void)test02_SSL_ClientCert      {[super test02_SSL_ClientCert];}
 - (void)test03_ReadOnly			   {[super test03_ReadOnly];}
 
-- (void)testGetRange {
+- (void)test04_GetRange {
     // Create a document with an attachment:
     CBLDocument* doc = [db createDocument];
     CBLUnsavedRevision* newRev = [doc newRevision];

--- a/Unit-Tests/Listener_Tests.m
+++ b/Unit-Tests/Listener_Tests.m
@@ -368,6 +368,10 @@ static NSString* addressToString(NSData* addrData) {
     [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=-100"} body: nil
        expectedStatus: 200 expectedHeaders: nil
        expectedResult: [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]];
+
+    [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=500-100"} body: nil
+       expectedStatus: 200 expectedHeaders: nil
+       expectedResult: [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]];
 }
 
 

--- a/Unit-Tests/Listener_Tests.m
+++ b/Unit-Tests/Listener_Tests.m
@@ -358,8 +358,8 @@ static NSString* addressToString(NSData* addrData) {
        expectedResult: [@"attach1" dataUsingEncoding: NSUTF8StringEncoding]];
 
     [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=5-3"} body: nil
-       expectedStatus: 416 expectedHeaders: @{@"Content-Range": @"bytes */27"}
-       expectedResult: nil];
+       expectedStatus: 200 expectedHeaders: nil
+       expectedResult: [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]];
 
     [self sendRequest: @"GET" path: path headers: @{@"Range": @"bytes=100-"} body: nil
        expectedStatus: 416 expectedHeaders: @{@"Content-Range": @"bytes */27"}

--- a/Unit-Tests/Router_Tests.m
+++ b/Unit-Tests/Router_Tests.m
@@ -1066,9 +1066,9 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
     response = SendRequest(self, @"GET", @"/db/doc1/attach",
                            $dict({@"Range", @"bytes=5-3"}),
                            nil);
-    AssertEq(response.status, 416);
-    AssertEqual((response.headers)[@"Content-Range"], @"bytes */27");
-    AssertNil(response.body);
+    AssertEq(response.status, 200);
+    AssertNil((response.headers)[@"Content-Range"]);
+    AssertEqual(response.body.asJSON, [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]);
 
     // -100:
     response = SendRequest(self, @"GET", @"/db/doc1/attach",

--- a/Unit-Tests/Router_Tests.m
+++ b/Unit-Tests/Router_Tests.m
@@ -1085,6 +1085,14 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
     AssertEq(response.status, 416);
     AssertEqual((response.headers)[@"Content-Range"], @"bytes */27");
     AssertNil(response.body);
+
+    // 500-100:
+    response = SendRequest(self, @"GET", @"/db/doc1/attach",
+                           $dict({@"Range", @"bytes=500-100"}),
+                           nil);
+    AssertEq(response.status, 200); // full range
+    AssertNil((response.headers)[@"Content-Range"]);
+    AssertEqual(response.body.asJSON, [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]);
 }
 
 

--- a/Unit-Tests/Router_Tests.m
+++ b/Unit-Tests/Router_Tests.m
@@ -1066,7 +1066,7 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
     response = SendRequest(self, @"GET", @"/db/doc1/attach",
                            $dict({@"Range", @"bytes=5-3"}),
                            nil);
-    AssertEq(response.status, 200);
+    AssertEq(response.status, 200); // full range
     AssertNil((response.headers)[@"Content-Range"]);
     AssertEqual(response.body.asJSON, [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]);
 
@@ -1093,6 +1093,22 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
     AssertEq(response.status, 200); // full range
     AssertNil((response.headers)[@"Content-Range"]);
     AssertEqual(response.body.asJSON, [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]);
+    
+    // 0-27:
+    response = SendRequest(self, @"GET", @"/db/doc1/attach",
+                           $dict({@"Range", @"bytes=500-100"}),
+                           nil);
+    AssertEq(response.status, 200); // full range
+    AssertNil((response.headers)[@"Content-Range"]);
+    AssertEqual(response.body.asJSON, [@"This is the body of attach1" dataUsingEncoding: NSUTF8StringEncoding]);
+    
+    // 27-28:
+    response = SendRequest(self, @"GET", @"/db/doc1/attach",
+                           $dict({@"Range", @"bytes=27-28"}),
+                           nil);
+    AssertEq(response.status, 416);
+    AssertEqual((response.headers)[@"Content-Range"], @"bytes */27");
+    AssertNil(response.body);
 }
 
 


### PR DESCRIPTION
- Aligned with the fix in CocoaHTTPServer (d44cf160dd72fa5a1df9924e33ad367c3e37b798), return 416 when the range is invalid.

- Added unit test cases

#74