### PR TITLE
API: Add CBLManager -closeDatabaseName:error

### DIFF
--- a/Source/API/CBLManager.h
+++ b/Source/API/CBLManager.h
@@ -100,6 +100,12 @@ typedef struct CBLManagerOptions {
 - (BOOL) encryptDatabaseNamed: (NSString*)name;
 #endif
 
+/** Closes the database with the given name. Same as CBLDatabase's -close: method, this method stops 
+    the replicators, closes the views, and saves all of the models associated with the database. 
+    In addition, the shared background database used in the background thread with the given name 
+    will be closed as well. The method returns NO when an error occurs, otherwise returns YES. */
+- (BOOL) closeDatabaseNamed: (NSString*)name error: (NSError**)error;
+
 /** Same as -existingDatabaseNamed:. Enables "[]" access in Xcode 4.4+ */
 - (nullable CBLDatabase*) objectForKeyedSubscript: (NSString*)key;
 

--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -576,6 +576,24 @@ static CBLManager* sInstance;
 #endif
 
 
+- (BOOL) closeDatabaseNamed: (NSString*)name error: (NSError**)error {
+    CBLDatabase* db = _databases[name];
+    if (db) {
+        if (![db close: error])
+            return NO;
+    }
+    
+    CBL_Shared* shared = _shared;
+    if (shared.backgroundServer) {
+        return [[shared.backgroundServer waitForDatabaseNamed: name to: ^id(CBLDatabase* bgdb) {
+            BOOL result = [bgdb close: error];
+            return @(result);
+        }] boolValue];
+    }
+    return YES;
+}
+
+
 #if DEBUG
 - (CBLDatabase*) createEmptyDatabaseNamed: (NSString*)name error: (NSError**)outError {
     CBLDatabase* db = _databases[name];


### PR DESCRIPTION
Added CBLManager -closeDatabaseName:error method for closing the database with the given name.

By calling this method, both the foreground and the shared background database of the given name will be closed. This method provides a way to completely close the database without closing the manager object, given that the shared manager object cannot be closed.

#686