### PR TITLE
Fix #838 Implement readOnly to CBLSyncListener

### DIFF
--- a/Source/CBLSyncConnection+Checkpoints.m
+++ b/Source/CBLSyncConnection+Checkpoints.m
@@ -168,6 +168,8 @@ static NSString* localDocIDForCheckpointRequest(BLIPRequest* request) {
         [request respondWithErrorCode: 400 message: @"Bad Request"];
         return;
     }
+    if (![self accessCheckForRequest: request docID: [@"_local/" stringByAppendingString: docID]])
+        return;
     [request deferResponse];
     
     [self onDatabaseQueue:^{
@@ -201,6 +203,8 @@ static NSString* localDocIDForCheckpointRequest(BLIPRequest* request) {
         [request respondWithErrorCode: 400 message: @"Bad Request"];
         return;
     }
+    if (![self accessCheckForRequest: request docID: [@"_local/" stringByAppendingString: docID]])
+        return;
     NSString* revID = request[@"rev"];
     if (revID)
         checkpoint[@"_rev"] = revID;

--- a/Source/CBLSyncConnection+Pull.m
+++ b/Source/CBLSyncConnection+Pull.m
@@ -164,7 +164,7 @@
     NSDictionary* attachments = nil;
     NSString* docID;
     NSData* json = request.body;
-    if (self.onSyncAccessCheck && memmem(json.bytes, json.length, "\"_attachments\":", 15) != NULL) {
+    if (self.onSyncAccessCheck || memmem(json.bytes, json.length, "\"_attachments\":", 15) != NULL) {
         NSDictionary* props = [NSJSONSerialization JSONObjectWithData: json options: 0 error: NULL];
         attachments = $castIf(NSDictionary, props[@"_attachments"]);
         docID = props[@"_id"];

--- a/Source/CBLSyncConnection+Pull.m
+++ b/Source/CBLSyncConnection+Pull.m
@@ -72,6 +72,8 @@
     // (Note: even if we got 0 changes (i.e. caught up) we still need to go through the db queue
     // before announcing it, so previously queued change processing blocks get to run first.)
     LogTo(Sync, @"Received %u changes", (unsigned)changes.count);
+    if (![self accessCheckForRequest: request docID: nil])
+        return;
     [request deferResponse];
     [self onDatabaseQueue: ^{
         CFAbsoluteTime time = CFAbsoluteTimeGetCurrent();
@@ -162,11 +164,17 @@
     NSDictionary* attachments = nil;
     NSString* docID;
     NSData* json = request.body;
-    if (memmem(json.bytes, json.length, "\"_attachments\":", 15) != NULL) {
+    if (self.onSyncAccessCheck && memmem(json.bytes, json.length, "\"_attachments\":", 15) != NULL) {
         NSDictionary* props = [NSJSONSerialization JSONObjectWithData: json options: 0 error: NULL];
         attachments = $castIf(NSDictionary, props[@"_attachments"]);
         docID = props[@"_id"];
     }
+    
+    if (![self accessCheckForRequest: request docID: docID]) {
+        --_insertingRevs;
+        return;
+    }
+    
     if (attachments.count == 0) {
         [self queueRevisionToInsert: request withAttachments: nil];
         return;

--- a/Source/CBLSyncConnection+Push.m
+++ b/Source/CBLSyncConnection+Push.m
@@ -21,6 +21,9 @@
 
 // Starting point of a passive push (called by peer when it starts pulling.)
 - (void) handleSubscribeToChanges: (BLIPRequest*)request {
+    if (![self accessCheckForRequest: request docID: nil])
+        return;
+    
     uint64_t since = MAX(0, [request[@"since"] longLongValue]);
     if (request[@"batch"])
         _changesBatchSize = MAX(0, [request[@"batch"] integerValue]);
@@ -292,6 +295,9 @@ static NSArray* encodeChange(uint64_t sequence, NSString* docID, NSString* revID
 
 
 - (void) handleGetAttachment: (BLIPRequest*)request {
+    if (![self accessCheckForRequest: request docID: nil])
+        return;
+    
     NSString* digest = request[@"digest"];
     [request deferResponse];
     [self onDatabaseQueue: ^{
@@ -332,6 +338,9 @@ static NSArray* encodeChange(uint64_t sequence, NSString* docID, NSString* revID
 
 
 - (void) handleProveAttachment: (BLIPRequest*)request {
+    if (![self accessCheckForRequest: request docID: nil])
+        return;
+    
     NSString* digest = request[@"digest"];
     NSData* nonce = request.body;
     if (!digest || nonce.length == 0 || nonce.length > 255)

--- a/Source/CBLSyncConnection.h
+++ b/Source/CBLSyncConnection.h
@@ -8,6 +8,7 @@
 
 #import "BLIPConnection.h"
 #import <CouchbaseLite/CBLDatabase.h>
+#import <CouchbaseLite/CBLStatus.h>
 @class CBLQueryEnumerator, CBLBlipReplicator;
 
 
@@ -18,6 +19,7 @@ typedef NS_ENUM(unsigned, SyncState) {
     kSyncActive,
 };
 
+typedef CBLStatus (^OnSyncAccessCheckBlock)(BLIPRequest* req, NSString* docID);
 
 @interface CBLSyncConnection : NSObject <BLIPConnectionDelegate>
 
@@ -38,6 +40,8 @@ typedef NS_ENUM(unsigned, SyncState) {
 
 @property (readonly) dispatch_queue_t syncQueue;
 @property (readonly) NSURL* peerURL;
+
+@property (copy) OnSyncAccessCheckBlock onSyncAccessCheck;
 
 // The below properties are observable, but the changes happen on the syncQueue
 

--- a/Source/CBLSyncConnection.m
+++ b/Source/CBLSyncConnection.m
@@ -21,6 +21,7 @@ NSString* const kSyncNestedProgressKey = @"CBLChildren";
 @synthesize pullProgress=_pullProgress, nestedPullProgress=_nestedPullProgress;
 @synthesize pushProgress=_pushProgress, nestedPushProgress=_nestedPushProgress;
 @synthesize remoteCheckpointDocID=_remoteCheckpointDocID, replicator=_replicator;
+@synthesize onSyncAccessCheck=_onSyncAccessCheck;
 #if DEBUG
 @synthesize savingCheckpoint=_savingCheckpoint;  // for unit tests
 #endif
@@ -262,6 +263,22 @@ NSString* const kSyncNestedProgressKey = @"CBLChildren";
     else
         self.nestedPushProgress = children;
     [parent setUserInfoObject: children forKey: kSyncNestedProgressKey];
+}
+
+
+- (BOOL) accessCheckForRequest: (BLIPRequest*)request
+                         docID: (NSString*)docID
+{
+    if (self.onSyncAccessCheck) {
+        CBLStatus status = self.onSyncAccessCheck(request, docID);
+        if (CBLStatusIsError(status)) {
+            NSString* message;
+            [request respondWithErrorCode: CBLStatusToHTTPStatus(status, &message)
+                                  message: message];
+            return NO;
+        }
+    }
+    return YES;
 }
 
 

--- a/Source/CBLSyncConnection.m
+++ b/Source/CBLSyncConnection.m
@@ -273,8 +273,8 @@ NSString* const kSyncNestedProgressKey = @"CBLChildren";
         CBLStatus status = self.onSyncAccessCheck(request, docID);
         if (CBLStatusIsError(status)) {
             NSString* message;
-            [request respondWithErrorCode: CBLStatusToHTTPStatus(status, &message)
-                                  message: message];
+            int code = CBLStatusToHTTPStatus(status, &message);
+            [request respondWithErrorCode: code message: message];
             return NO;
         }
     }

--- a/Source/CBLSyncConnection_Internal.h
+++ b/Source/CBLSyncConnection_Internal.h
@@ -111,6 +111,8 @@
 - (void) removeAttachmentProgress: (NSProgress*)attProgress
                           pulling: (BOOL)pulling;
 
+- (BOOL) accessCheckForRequest: (BLIPRequest*)request docID: (NSString*)docID;
+
 @end
 
 

--- a/Source/CBLSyncListener.m
+++ b/Source/CBLSyncListener.m
@@ -9,6 +9,7 @@
 #import "CBLSyncListener.h"
 #import "CBLListener+Internal.h"
 #import "CBLSyncConnection.h"
+#import "BLIPRequest.h"
 #import "CouchbaseLite.h"
 #import "CBLInternal.h"
 #import "BLIPPocketSocketListener.h"
@@ -89,6 +90,16 @@
         CBLSyncConnection* handler = [[CBLSyncConnection alloc] initWithDatabase: db
                                                                       connection: connection
                                                                            queue: queue];
+        if (_facade.readOnly) {
+            handler.onSyncAccessCheck = ^CBLStatus(BLIPRequest* request, NSString* docID) {
+                NSString* profile = request.profile;
+                if ([profile isEqualToString:@"setCheckpoint"] ||
+                    [profile isEqualToString:@"changes"] ||
+                    [profile isEqualToString:@"rev"])
+                    return kCBLStatusForbidden;
+                return kCBLStatusOK;
+            };
+        }
         [handler addObserver: self forKeyPath: @"state" options: 0 context: (void*)1];
         dispatch_sync(_queue, ^{
             [_handlers addObject: handler];


### PR DESCRIPTION
- Added OnSyncAccessCheckBlock property to CBLSyncConnection similarly to CBL_Router.OnAccessCheckBlock property. OnSyncAccessCheckBlock (if specified) will be called to check the access for each sync request coming to the CBLSyncConnection's handlers. The handlers will then return the corresponding error responses depending on the result of the OnSyncAccessCheckBlock call.

- In read only mode, CBLSyncListener will block access to setCheckpoint, changes, and rev requests.

#838