### PR TITLE
Fix #686 close database not closing background database

### DIFF
--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -196,7 +196,9 @@ static BOOL sAutoCompact = YES;
         return NO;
     }
 
+    [self willChangeValueForKey: @"isOpen"];
     _isOpen = YES;
+    [self didChangeValueForKey: @"isOpen"];
 
     // Listen for _any_ CBLDatabase changing, so I can detect changes made to my database
     // file by other instances (running on other threads presumably.)
@@ -241,7 +243,9 @@ static BOOL sAutoCompact = YES;
         _storage = nil;
         _attachments = nil;
 
+        [self willChangeValueForKey: @"isOpen"];
         _isOpen = NO;
+        [self didChangeValueForKey: @"isOpen"];
 
         [[NSNotificationCenter defaultCenter] removeObserver: self];
         [self _clearDocumentCache];

--- a/Source/CBLManager+Internal.h
+++ b/Source/CBLManager+Internal.h
@@ -28,6 +28,9 @@
 
 - (void) _forgetDatabase: (CBLDatabase*)db;
 
+- (BOOL) _closeDatabaseNamed: (NSString*)name
+                       error: (NSError**)outError;
+
 @property (readonly) NSArray* allOpenDatabases;
 
 @property (readonly) CBL_Shared* shared;


### PR DESCRIPTION
- Closed background database in CBLManager._forgetDatabase: method.
- Added CBLManager._closeDatabaseNamed: method to facilitate closing the opened database of the given name.
- Added Database_Tests.test24_CloseDatabase
- Made CBLDatabase.isOpen value change observable (used in the unit test)

#686