### PR TITLE
helpful error message when storage classes are missing

### DIFF
--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -155,7 +155,7 @@ static BOOL sAutoCompact = YES;
     NSString* storageType = _manager.storageType ?: @"SQLite";
     NSString* storageClassName = $sprintf(@"CBL_%@Storage", storageType);
     Class primaryStorage = NSClassFromString(storageClassName);
-    Assert(primaryStorage, @"CBLManager.storageType is '%@' but no %@ class found",
+    Assert(primaryStorage, @"CBLManager.storageType is '%@' but no %@ class found, maybe add the -ObjC flag to Other Linker Flags in Build Settings",
            _manager.storageType, storageClassName);
     Assert([primaryStorage conformsToProtocol: @protocol(CBL_Storage)],
             @"CBLManager.storageType is '%@' but %@ is not a CBL_Storage implementation",


### PR DESCRIPTION
I ran into this issue on a new app, and had to google the error to figure out how to fix it. Now the fix will be in the logs. (Use the `-ObjC` flag).