### PR TITLE
Fixed #726 CBLListener readOnly mode cannot save checkpoint doc

### DIFF
--- a/Listener/CBLHTTPResponse.m
+++ b/Listener/CBLHTTPResponse.m
@@ -60,7 +60,9 @@
             router.onAccessCheck = ^CBLStatus(CBLDatabase* db, NSString* docID, SEL action) {
                 if ([method isEqualToString: @"GET"] || [method isEqualToString: @"HEAD"])
                     return kCBLStatusOK;
-                if ([method isEqualToString: @"POST"]) {
+                else if ([method isEqualToString: @"PUT"] && [docID hasPrefix: @"_local/"])
+                    return kCBLStatusOK;
+                else if ([method isEqualToString: @"POST"]) {
                     NSString* actionStr = NSStringFromSelector(action);
                     if ([actionStr isEqualToString: @"do_POST_all_docs:"]
                             || [actionStr isEqualToString: @"do_POST_revs_diff:"])

--- a/Source/CBLSyncConnection+Checkpoints.m
+++ b/Source/CBLSyncConnection+Checkpoints.m
@@ -168,7 +168,7 @@ static NSString* localDocIDForCheckpointRequest(BLIPRequest* request) {
         [request respondWithErrorCode: 400 message: @"Bad Request"];
         return;
     }
-    if (![self accessCheckForRequest: request docID: [@"_local/" stringByAppendingString: docID]])
+    if (![self accessCheckForRequest: request])
         return;
     [request deferResponse];
     
@@ -203,7 +203,7 @@ static NSString* localDocIDForCheckpointRequest(BLIPRequest* request) {
         [request respondWithErrorCode: 400 message: @"Bad Request"];
         return;
     }
-    if (![self accessCheckForRequest: request docID: [@"_local/" stringByAppendingString: docID]])
+    if (![self accessCheckForRequest: request])
         return;
     NSString* revID = request[@"rev"];
     if (revID)

--- a/Source/CBLSyncConnection+Push.m
+++ b/Source/CBLSyncConnection+Push.m
@@ -21,7 +21,7 @@
 
 // Starting point of a passive push (called by peer when it starts pulling.)
 - (void) handleSubscribeToChanges: (BLIPRequest*)request {
-    if (![self accessCheckForRequest: request docID: nil])
+    if (![self accessCheckForRequest: request])
         return;
     
     uint64_t since = MAX(0, [request[@"since"] longLongValue]);
@@ -295,7 +295,7 @@ static NSArray* encodeChange(uint64_t sequence, NSString* docID, NSString* revID
 
 
 - (void) handleGetAttachment: (BLIPRequest*)request {
-    if (![self accessCheckForRequest: request docID: nil])
+    if (![self accessCheckForRequest: request])
         return;
     
     NSString* digest = request[@"digest"];
@@ -338,7 +338,7 @@ static NSArray* encodeChange(uint64_t sequence, NSString* docID, NSString* revID
 
 
 - (void) handleProveAttachment: (BLIPRequest*)request {
-    if (![self accessCheckForRequest: request docID: nil])
+    if (![self accessCheckForRequest: request])
         return;
     
     NSString* digest = request[@"digest"];

--- a/Source/CBLSyncConnection.h
+++ b/Source/CBLSyncConnection.h
@@ -19,7 +19,7 @@ typedef NS_ENUM(unsigned, SyncState) {
     kSyncActive,
 };
 
-typedef CBLStatus (^OnSyncAccessCheckBlock)(BLIPRequest* req, NSString* docID);
+typedef CBLStatus (^OnSyncAccessCheckBlock)(BLIPRequest* req);
 
 @interface CBLSyncConnection : NSObject <BLIPConnectionDelegate>
 

--- a/Source/CBLSyncConnection.m
+++ b/Source/CBLSyncConnection.m
@@ -266,11 +266,9 @@ NSString* const kSyncNestedProgressKey = @"CBLChildren";
 }
 
 
-- (BOOL) accessCheckForRequest: (BLIPRequest*)request
-                         docID: (NSString*)docID
-{
+- (BOOL) accessCheckForRequest: (BLIPRequest*)request {
     if (self.onSyncAccessCheck) {
-        CBLStatus status = self.onSyncAccessCheck(request, docID);
+        CBLStatus status = self.onSyncAccessCheck(request);
         if (CBLStatusIsError(status)) {
             NSString* message;
             int code = CBLStatusToHTTPStatus(status, &message);

--- a/Source/CBLSyncConnection_Internal.h
+++ b/Source/CBLSyncConnection_Internal.h
@@ -111,7 +111,7 @@
 - (void) removeAttachmentProgress: (NSProgress*)attProgress
                           pulling: (BOOL)pulling;
 
-- (BOOL) accessCheckForRequest: (BLIPRequest*)request docID: (NSString*)docID;
+- (BOOL) accessCheckForRequest: (BLIPRequest*)request;
 
 @end
 

--- a/Source/CBLSyncListener.m
+++ b/Source/CBLSyncListener.m
@@ -91,11 +91,9 @@
                                                                       connection: connection
                                                                            queue: queue];
         if (_facade.readOnly) {
-            handler.onSyncAccessCheck = ^CBLStatus(BLIPRequest* request, NSString* docID) {
+            handler.onSyncAccessCheck = ^CBLStatus(BLIPRequest* request) {
                 NSString* profile = request.profile;
-                if ([profile isEqualToString:@"setCheckpoint"] ||
-                    [profile isEqualToString:@"changes"] ||
-                    [profile isEqualToString:@"rev"])
+                if ([profile isEqualToString:@"changes"] || [profile isEqualToString:@"rev"])
                     return kCBLStatusForbidden;
                 return kCBLStatusOK;
             };


### PR DESCRIPTION
- Allowed access to PUT /_local/docid (Http Sync) setCheckpoint (Blip Sync).

- Removed docID from CBLSyncConnection's OnSyncAccessCheckBlock as there is currently no usage of the docID.

- Fixed unit tests.

#726