### PR TITLE
Feature/issue 874 test environment

### DIFF
--- a/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/CBL Mac Test App.xcscheme
+++ b/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/CBL Mac Test App.xcscheme
@@ -76,12 +76,12 @@
          <EnvironmentVariable
             key = "CBL_TEST_SERVER"
             value = "http://localhost:4984/"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "CBL_SSL_TEST_SERVER"
             value = "http://localhost:4994/"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </TestAction>
@@ -94,7 +94,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "27C70693148864BA00F0F099"
@@ -112,7 +113,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "27C70693148864BA00F0F099"

--- a/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/CBL iOS Test App.xcscheme
+++ b/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/CBL iOS Test App.xcscheme
@@ -76,12 +76,12 @@
          <EnvironmentVariable
             key = "CBL_TEST_SERVER"
             value = "http://localhost:4984/"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "CBL_SSL_TEST_SERVER"
             value = "https://localhost:4994/"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </TestAction>


### PR DESCRIPTION
- Enabled environment variables in iOS and Mac test schemes, so that tests can be run against any SyncGateway URL. 