### PR TITLE
Fixed #875 Rename lowercase attachment files in CBLDatabaseUpgrade

### DIFF
--- a/Source/CBLDatabaseUpgrade.m
+++ b/Source/CBLDatabaseUpgrade.m
@@ -206,7 +206,7 @@ static int collateRevIDs(void *context,
         }
     }
     
-    if (success && [renDict count] > 0) {
+    if (!success && [renDict count] > 0) {
         // Backing out if there is an error found:
         for (NSString *oldFileName in [renDict allKeys]) {
             NSString* oldPath = [dir stringByAppendingPathComponent: oldFileName];


### PR DESCRIPTION
CBL Android 1.0.4 and .NET 1.1.0 have lowercase attachment file names. This method will detect that and uppercase the file names if needed. This makes the Database_Tests.test23_ReplaceOldVersionDatabase passed on the real device.

#875