### PR TITLE
Encrypt attachment store if db encrypted, and fix existing unencrypted stores

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -1497,6 +1497,7 @@
 		27ED862E157D0FC600712B33 /* CBLDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLDocument.h; sourceTree = "<group>"; };
 		27ED862F157D0FC600712B33 /* CBLDocument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLDocument.m; sourceTree = "<group>"; };
 		27ED9A961639D8D2000C844A /* LiteServ.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LiteServ.m; path = ../Listener/LiteServ.m; sourceTree = "<group>"; };
+		27EF111F1B8BAD190039A138 /* CBL_BlobStore+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBL_BlobStore+Internal.h"; sourceTree = "<group>"; };
 		27EF7F991912EB5200A327B9 /* CBLForestBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLForestBridge.h; sourceTree = "<group>"; };
 		27EF7F9A1912EB5200A327B9 /* CBLForestBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLForestBridge.mm; sourceTree = "<group>"; };
 		27F0744611CD4B6D00E9A2AB /* CBLDatabase+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CBLDatabase+Internal.h"; sourceTree = "<group>"; };
@@ -1918,6 +1919,7 @@
 				27C706411486BBD500F0F099 /* CBL_Server.m */,
 				27731EFD1493FA3100815D67 /* CBL_BlobStore.h */,
 				27731EFE1493FA3100815D67 /* CBL_BlobStore.m */,
+				27EF111F1B8BAD190039A138 /* CBL_BlobStore+Internal.h */,
 				27D8C347195A28100073A51C /* CBLDatabaseUpgrade.h */,
 				27D8C348195A28100073A51C /* CBLDatabaseUpgrade.m */,
 			);

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -201,7 +201,9 @@ static BOOL sAutoCompact = YES;
 
     // Open attachment store:
     NSString* attachmentsPath = self.attachmentStorePath;
-    _attachments = [[CBL_BlobStore alloc] initWithPath: attachmentsPath error: outError];
+    _attachments = [[CBL_BlobStore alloc] initWithPath: attachmentsPath
+                                         encryptionKey: self.encryptionKey
+                                                 error: outError];
     if (!_attachments) {
         Warn(@"%@: Couldn't open attachment store at %@", self, attachmentsPath);
         [_storage close];

--- a/Source/CBLMisc.h
+++ b/Source/CBLMisc.h
@@ -95,6 +95,12 @@ BOOL CBLRemoveFileIfExistsAsync(NSString* path, NSError** outError);
 
 BOOL CBLCopyFileIfExists(NSString*atPath, NSString* toPath, NSError** outError) __attribute__((nonnull(1, 2)));
 
+/** Replaces the directory at dstPath with the one at srcPath. (Both must already exist.)
+    Afterwards, on success, there will be a dir at dstPath but not at srcPath.
+    For safety's sake, the old directory is moved aside, then the new directory is moved in,
+    and only then is the old directory deleted. */
+BOOL CBLSafeReplaceDir(NSString* srcPath, NSString* dstPath, NSError** outError);
+
 /** Returns the hostname of this computer/device (will be of the form "___.local") */
 NSString* CBLGetHostName(void);
 

--- a/Source/CBLMisc.m
+++ b/Source/CBLMisc.m
@@ -322,7 +322,8 @@ BOOL CBLIsFileNotFoundError( NSError* error ) {
     NSInteger code = error.code;
     return ($equal(domain, NSPOSIXErrorDomain) && code == ENOENT)
 #ifndef GNUSTEP
-        || ($equal(domain, NSCocoaErrorDomain) && code == NSFileNoSuchFileError)
+        || ($equal(domain, NSCocoaErrorDomain) && (code == NSFileNoSuchFileError ||
+                                                   code == NSFileReadNoSuchFileError))
 #endif
     ;
 }
@@ -416,6 +417,24 @@ BOOL CBLCopyFileIfExists(NSString* atPath, NSString* toPath, NSError** outError)
     } else
         return YES;
 }
+
+
+BOOL CBLSafeReplaceDir(NSString* srcPath, NSString* dstPath, NSError** outError) {
+    NSFileManager* fmgr = [NSFileManager defaultManager];
+    // Define an interim location to move dstPath to, and make sure it's available:
+    NSString* interimPath = [dstPath stringByAppendingString: @"~"];
+    [fmgr removeItemAtPath: interimPath error: NULL];
+
+    if ([fmgr moveItemAtPath: dstPath toPath: interimPath error: outError]) {
+        if ([fmgr moveItemAtPath: srcPath toPath: dstPath error: outError]) {
+            [fmgr removeItemAtPath: interimPath error: NULL];
+            return YES; // success!
+        }
+        [fmgr moveItemAtPath: interimPath toPath: dstPath error: NULL]; // back out
+    }
+    return NO;
+}
+
 
 NSString* CBLGetHostName() {
     // From <http://stackoverflow.com/a/16902907/98077>

--- a/Source/CBL_BlobStore+Internal.h
+++ b/Source/CBL_BlobStore+Internal.h
@@ -1,0 +1,25 @@
+//
+//  CBL_BlobStore+Internal.h
+//  CouchbaseLite
+//
+//  Created by Jens Alfke on 8/23/15.
+//  Copyright © 2015 Couchbase, Inc. All rights reserved.
+//
+
+#import "CBL_BlobStore.h"
+
+
+// Name of file in blob-store dir that records encryption type used (currently "AES")
+#define kEncryptionMarkerFilename @"_encryption"
+
+
+@interface CBL_BlobStore ()
+
+- (NSString*) rawPathForKey: (CBLBlobKey)key;
+@property (readonly, nonatomic) NSString* tempDir;
+@property (readonly) CBLSymmetricKey* encryptionKey;
+
+#if DEBUG
+- (BOOL) markEncrypted: (BOOL)encrypted error: (NSError**)outError; // exposed for testing ONLY
+#endif
+@end

--- a/Source/CBL_BlobStore.h
+++ b/Source/CBL_BlobStore.h
@@ -29,7 +29,9 @@ typedef struct CBLBlobKey {
     Each blob is stored as a file named by its SHA-1 digest. */
 @interface CBL_BlobStore : NSObject
 
-- (instancetype) initWithPath: (NSString*)dir error: (NSError**)outError;
+- (instancetype) initWithPath: (NSString*)dir
+                encryptionKey: (CBLSymmetricKey*)encryptionKey
+                        error: (NSError**)outError;
 
 @property (nonatomic) CBLSymmetricKey* encryptionKey;
 

--- a/Source/CBL_BlobStore.h
+++ b/Source/CBL_BlobStore.h
@@ -33,7 +33,10 @@ typedef struct CBLBlobKey {
                 encryptionKey: (CBLSymmetricKey*)encryptionKey
                         error: (NSError**)outError;
 
-@property (nonatomic) CBLSymmetricKey* encryptionKey;
+/** Changes the encryption key. This will rewrite every blob to a new directory
+    and then replace the current directory with it. */
+- (BOOL) changeEncryptionKey: (CBLSymmetricKey*)newKey
+                       error: (NSError**)outError;
 
 - (BOOL) hasBlobForKey: (CBLBlobKey)key;
 - (NSData*) blobForKey: (CBLBlobKey)key;
@@ -73,6 +76,9 @@ typedef struct {
 
 /** Appends data to the blob. Call this when new data is available. */
 - (void) appendData: (NSData*)data;
+
+- (BOOL) appendInputStream: (NSInputStream*)readStream
+                     error: (NSError**)outError;
 
 /** Call this after all the data has been added. */
 - (void) finish;

--- a/Source/CBL_BlobStore.m
+++ b/Source/CBL_BlobStore.m
@@ -38,11 +38,15 @@
 @synthesize path=_path, encryptionKey=_encryptionKey;
 
 
-- (instancetype) initWithPath: (NSString*)dir error: (NSError**)outError {
+- (instancetype) initWithPath: (NSString*)dir
+                encryptionKey: (CBLSymmetricKey*)encryptionKey
+                        error: (NSError**)outError
+{
     Assert(dir);
     self = [super init];
     if (self) {
         _path = [dir copy];
+        _encryptionKey = encryptionKey;
         BOOL isDir;
         if (![[NSFileManager defaultManager] fileExistsAtPath: dir isDirectory: &isDir] || !isDir) {
             if (![[NSFileManager defaultManager] createDirectoryAtPath: dir

--- a/Unit-Tests/BlobStore_Tests.m
+++ b/Unit-Tests/BlobStore_Tests.m
@@ -7,7 +7,7 @@
 //
 
 #import "CBLTestCase.h"
-#import "CBL_BlobStore.h"
+#import "CBL_BlobStore+Internal.h"
 #import "CBLSymmetricKey.h"
 
 
@@ -35,24 +35,43 @@
     [super setUp];
     storePath = [NSTemporaryDirectory() stringByAppendingPathComponent: @"CBL_BlobStoreTest"];
     [[NSFileManager defaultManager] removeItemAtPath: storePath error: NULL];
+    if (encrypt)
+        Log(@"---- Now enabling attachment encryption ----");
     NSError* error;
     store = [[CBL_BlobStore alloc] initWithPath: storePath
-                                  encryptionKey: nil
+                                  encryptionKey: (encrypt ? [[CBLSymmetricKey alloc] init] : nil)
                                           error: &error];
     Assert(store, @"Couldn't create CBL_BlobStore: %@", error);
-    if (encrypt) {
-        Log(@"---- Now enabling attachment encryption ----");
-        store.encryptionKey = [[CBLSymmetricKey alloc] init];
-    }
+
+    NSString* encMarkerPath = [storePath stringByAppendingPathComponent: kEncryptionMarkerFilename];
+    BOOL markerExists = [[NSFileManager defaultManager] fileExistsAtPath: encMarkerPath
+                                                             isDirectory: NULL];
+    AssertEq(markerExists, encrypt);
 }
 
 - (void)tearDown {
+    store = nil;
     [[NSFileManager defaultManager] removeItemAtPath: storePath error: NULL];
     [super tearDown];
 }
 
 
-- (void) test_CBL_BlobStoreBasic {
+// Asserts that the raw blob file is cleartext IFF the store is unencrypted.
+- (void) verifyRawBlob: (CBLBlobKey)attKey
+         withCleartext: (NSData*)cleartext
+{
+    NSString* path = [store rawPathForKey: attKey];
+    NSData* raw = [NSData dataWithContentsOfFile: path];
+    Assert(raw != nil);
+    if (store.encryptionKey == nil) {
+        AssertEqual(raw, cleartext);
+    } else {
+        AssertEq(memmem(raw.bytes, raw.length, cleartext.bytes, cleartext.length), NULL);
+    }
+}
+
+
+- (void) test01_Basic {
     NSData* item = [@"this is an item" dataUsingEncoding: NSUTF8StringEncoding];
     CBLBlobKey key, key2;
     Assert([store storeBlob: item creatingKey: &key]);
@@ -61,13 +80,34 @@
 
     NSData* readItem = [store blobForKey: key];
     AssertEqual(readItem, item);
+    [self verifyRawBlob: key withCleartext: item];
 
     NSString* path = [store blobPathForKey: key];
-    AssertEq((path == nil), encrypt);  // path exists IFF not encrypted
+    AssertEq((path == nil), encrypt);  // path is returned IFF not encrypted
 }
 
 
-- (void) test_CBL_BlobStoreWriter {
+- (void) test02_Reopen {
+    NSData* item = [@"this is an item" dataUsingEncoding: NSUTF8StringEncoding];
+    CBLBlobKey key;
+    Assert([store storeBlob: item creatingKey: &key]);
+
+    NSError* error;
+    CBL_BlobStore* store2 = [[CBL_BlobStore alloc] initWithPath: store.path
+                                                  encryptionKey: store.encryptionKey
+                                                          error: &error];
+    Assert(store2, @"Couldn't re-open store: %@", error);
+
+    NSData* readItem = [store2 blobForKey: key];
+    AssertEqual(readItem, item);
+
+    readItem = [store blobForKey: key];
+    AssertEqual(readItem, item);
+    [self verifyRawBlob: key withCleartext: item];
+}
+
+
+- (void) test03_BlobStoreWriter {
     CBL_BlobStoreWriter* writer = [[CBL_BlobStoreWriter alloc] initWithStore: store];
     Assert(writer);
 
@@ -77,8 +117,70 @@
     [writer finish];
     Assert([writer install]);
 
+    NSData* expectedData = [@"part 1, part 2, part 3" dataUsingEncoding: NSUTF8StringEncoding];
     NSData* readItem = [store blobForKey: writer.blobKey];
-    AssertEqual(readItem, [@"part 1, part 2, part 3" dataUsingEncoding: NSUTF8StringEncoding]);
+    AssertEqual(readItem, expectedData);
+    [self verifyRawBlob: writer.blobKey withCleartext: expectedData];
+}
+
+
+- (void) test04_Rekey {
+    NSData* item = [@"this is an item" dataUsingEncoding: NSUTF8StringEncoding];
+    CBLBlobKey blobKey;
+    Assert([store storeBlob: item creatingKey: &blobKey]);
+
+    CBLSymmetricKey* newEncryptionKey = [CBLSymmetricKey new];
+    NSError* error;
+
+    Log(@"---- %@ key", (encrypt ? @"Changing" : @"Adding"));
+    Assert([store changeEncryptionKey: newEncryptionKey error: &error],
+           @"%@ key failed: %@", (encrypt ? @"Changing" : @"Adding"), error);
+    AssertEqual(store.encryptionKey, newEncryptionKey);
+    AssertEqual([store blobForKey: blobKey], item);
+
+    [self test02_Reopen];
+
+    if (encrypt) {
+        Log(@"---- Removing key");
+        Assert([store changeEncryptionKey: nil error: &error], @"Removing key failed: %@", error);
+        AssertEqual(store.encryptionKey, nil);
+        AssertEqual([store blobForKey: blobKey], item);
+        [self test02_Reopen];
+    }
+}
+
+
+- (void) test05_FixMissingEncryption {
+    // Tests the recovery from the 1.1 bug where the attachment store isn't encrypted:
+    if (encrypt)
+        return;
+
+    // Set up the 1.1-style store: no encryption
+    NSData* item = [@"this is an item" dataUsingEncoding: NSUTF8StringEncoding];
+    CBLBlobKey blobKey;
+    Assert([store storeBlob: item creatingKey: &blobKey]);
+
+    // Open a new instance on the store directory, but with a key -- this triggers the fix:
+    CBLSymmetricKey* encryptionKey = [CBLSymmetricKey new];
+    NSError* error;
+    store = [[CBL_BlobStore alloc] initWithPath: store.path
+                                                  encryptionKey: encryptionKey
+                                                          error: &error];
+    Assert(store, @"Couldn't re-open store: %@", error);
+    AssertEqual(store.encryptionKey, encryptionKey);
+
+    // Verify that the store got the "_encrypted" marker file:
+    NSString* encMarkerPath = [storePath stringByAppendingPathComponent: kEncryptionMarkerFilename];
+    BOOL markerExists = [[NSFileManager defaultManager] fileExistsAtPath: encMarkerPath
+                                                             isDirectory: NULL];
+    Assert(markerExists);
+
+    // Verify that the attachment is readable:
+    NSData* readItem = [store blobForKey: blobKey];
+    AssertEqual(readItem, item);
+
+    // ...and encrypted on disk:
+    [self verifyRawBlob: blobKey withCleartext: item];
 }
 
 

--- a/Unit-Tests/BlobStore_Tests.m
+++ b/Unit-Tests/BlobStore_Tests.m
@@ -36,7 +36,9 @@
     storePath = [NSTemporaryDirectory() stringByAppendingPathComponent: @"CBL_BlobStoreTest"];
     [[NSFileManager defaultManager] removeItemAtPath: storePath error: NULL];
     NSError* error;
-    store = [[CBL_BlobStore alloc] initWithPath: storePath error: &error];
+    store = [[CBL_BlobStore alloc] initWithPath: storePath
+                                  encryptionKey: nil
+                                          error: &error];
     Assert(store, @"Couldn't create CBL_BlobStore: %@", error);
     if (encrypt) {
         Log(@"---- Now enabling attachment encryption ----");

--- a/Unit-Tests/CBLTestCase.m
+++ b/Unit-Tests/CBLTestCase.m
@@ -11,7 +11,7 @@
 #import "CBLManager+Internal.h"
 #import "MYURLUtils.h"
 #import "CBLRemoteRequest.h"
-#import "CBL_BlobStore.h"
+#import "CBL_BlobStore+Internal.h"
 #import "CBLSymmetricKey.h"
 
 
@@ -148,10 +148,12 @@ extern NSString* WhyUnequalObjects(id a, id b); // from Test.m
 }
 
 - (void) setEncryptedAttachmentStore: (BOOL)encrypted {
-    if (!encrypted)
-        db.attachmentStore.encryptionKey = nil;
-    else if (db.attachmentStore.encryptionKey == nil)
-        db.attachmentStore.encryptionKey = [[CBLSymmetricKey alloc] init];
+    if (encrypted != self.encryptedAttachmentStore) {
+        CBLSymmetricKey* key = encrypted ? [[CBLSymmetricKey alloc] init] : nil;
+        NSError* error;
+        Assert([db.attachmentStore changeEncryptionKey: key error: &error],
+               @"Failed to add/remove encryption: %@", error);
+    }
 }
 
 

--- a/Unit-Tests/DatabaseEncryption_Tests.m
+++ b/Unit-Tests/DatabaseEncryption_Tests.m
@@ -8,6 +8,14 @@
 
 #import "CBLTestCase.h"
 #import "CBL_SQLiteStorage.h"
+#import "CBL_Attachment.h"
+#import "CBL_BlobStore.h"
+
+
+@interface CBL_BlobStore ()
+- (NSString*) rawPathForKey: (CBLBlobKey)key;
+@end
+
 
 
 @interface DatabaseEncryption_Tests : CBLTestCaseWithDB
@@ -124,5 +132,35 @@
     AssertNil(seekrit, @"Password opened unencrypted db!");
     AssertEq(error.code, 401);
 }
+
+
+- (void) test07_EncryptedAttachments {
+    if (!self.isSQLiteDB)
+        return;
+    CBLEnableMockEncryption = YES;
+    [dbmgr registerEncryptionKey: @"letmein" forDatabaseNamed: @"seekrit"];
+    CBLDatabase* seekrit = [dbmgr databaseNamed: @"seekrit" error: NULL];
+    Assert(seekrit);
+
+    // Save a doc with an attachment:
+    CBLDocument* doc = [seekrit documentWithID: @"att"];
+    NSData* body = [@"This is a test attachment!" dataUsingEncoding: NSUTF8StringEncoding];
+    CBLUnsavedRevision *rev = [doc newRevision];
+    [rev setAttachmentNamed: @"att.txt" withContentType: @"text/plain; charset=utf-8" content:body];
+    NSError* error;
+    CBLSavedRevision* savedRev = [rev save: &error];
+    Assert(savedRev, @"Saving doc failed: %@", error);
+
+    // Read the raw attachment file and make sure it's not cleartext:
+    NSString* digest = savedRev[@"_attachments"][@"att.txt"][@"digest"];
+    Assert(digest);
+    CBLBlobKey attKey;
+    Assert([CBL_Attachment digest: digest toBlobKey: &attKey]);
+    NSString* path = [seekrit.attachmentStore rawPathForKey: attKey];
+    NSData* raw = [NSData dataWithContentsOfFile: path];
+    Assert(raw != nil);
+    Assert(![raw isEqual: body], @"Oops, attachment was not encrypted");
+}
+
 
 @end


### PR DESCRIPTION
Fixes a serious security problem: Attachments in an encrypted database didn't get encrypted. :(

The bug was simply that when CBLDatabase instantiated its CBL_BlobStore, it didn't set the blob-store's
encryption key. The first commit fixes that, and has a unit test to verify that when an encrypted database is created, the raw attachment blob files are encrypted on disk.

The harder part is fixing existing databases. We have to (a) detect an existing encrypted database with
an unencrypted attachment store that hasn't been fixed yet, and (b) rewrite all the blob files with encryption.

Part (a) is done by adding a file called `_encryption` to the BlobStore directory when encryption is being used. The contents of the file name the encryption algorithm, currently always `AES`. Existing databases won't have this file, which indicates that their attachments aren't encrypted. So when opening an existing BlobStore, if an encryption key is given but the `_encryption` file doesn't exist, we've encountered this bug and need to encrypt the files.

Part (b) is done by the new `-changeEncryptionKey:error:` method I started working on last Friday. This is a general purpose method to add/remove/change the encryption key. It creates a new BlobStore in a new directory with the new key, writes all the blobs into it, then replaces the old directory with the new one. This uses more disk space during the operation, but makes it possible to recover safely if there's an error or crash partway through.

There are new unit tests that test upgrading the buggy BlobStore, as well as all three modes of changing the encryption key.