### PR TITLE
Fixed queries that have custom sortDescriptors and skips or limits

### DIFF
--- a/Source/API/CBLQuery.m
+++ b/Source/API/CBLQuery.m
@@ -179,8 +179,6 @@
     options->fullTextSnippets = _fullTextSnippets;
     options->fullTextRanking = _fullTextRanking;
     options->bbox = (_isGeoQuery ? &_boundingBox : NULL);
-    options->skip = (unsigned)_skip;
-    options->limit = (unsigned)_limit;
     options->reduce = !_mapOnly;
     options->reduceSpecified = YES;
     options->groupLevel = (unsigned)_groupLevel;
@@ -190,6 +188,12 @@
     options->allDocsMode = _allDocsMode;
     options->indexUpdateMode = _indexUpdateMode;
     options->indexUpdateMode = _indexUpdateMode;
+
+    if (_sortDescriptors.count == 0) {
+        options->skip = (unsigned)_skip;
+        options->limit = (unsigned)_limit;
+        // If using sortDescriptors, have to apply skip+limit later, after sorting
+    }
 
     if (_filterBlock) {
         options.filter = _filterBlock;
@@ -224,8 +228,10 @@
                                                                          view: _view
                                                                sequenceNumber: lastSequence
                                                                      iterator: iterator];
-    if (_sortDescriptors)
-        [result sortUsingDescriptors: _sortDescriptors];
+    if (_sortDescriptors.count > 0)
+        [result sortUsingDescriptors: _sortDescriptors
+                                skip: _skip
+                               limit: _limit];
     return result;
 }
 
@@ -277,8 +283,10 @@
                                                             view: _view
                                                   sequenceNumber: lastSequence
                                                             rows: rows];
-                if (_sortDescriptors)
-                    [e sortUsingDescriptors: _sortDescriptors];
+                if (_sortDescriptors.count > 0)
+                    [e sortUsingDescriptors: _sortDescriptors
+                                       skip: _skip
+                                      limit: _limit];
             } else if (CBLStatusIsError(status)) {
                 error = CBLStatusToNSError(status);
             }

--- a/Source/API/CBLQueryEnumerator.m
+++ b/Source/API/CBLQueryEnumerator.m
@@ -126,6 +126,20 @@
     _rows = [self.allObjects sortedArrayUsingDescriptors: sortDescriptors];
 }
 
+- (void) sortUsingDescriptors: (NSArray*)sortDescriptors
+                         skip: (NSUInteger)skip
+                        limit: (NSUInteger)limit
+{
+    [self sortUsingDescriptors: sortDescriptors];
+    NSUInteger n = _rows.count;
+    if (skip >= n) {
+        _rows = @[];
+    } else if (skip > 0 || limit < n) {
+        limit = MIN(limit, n - skip);
+        _rows = [_rows subarrayWithRange: NSMakeRange(skip, limit)];
+    }
+}
+
 
 - (CBLQueryRow*) nextRow {
     if (_rows) {

--- a/Source/CBLView+Internal.h
+++ b/Source/CBLView+Internal.h
@@ -97,6 +97,9 @@ BOOL CBLRowPassesFilter(CBLDatabase* db, CBLQueryRow* row, const CBLQueryOptions
                              view: (CBLView*)view
                    sequenceNumber: (SequenceNumber)sequenceNumber
                              rows: (NSArray*)rows;
+- (void) sortUsingDescriptors: (NSArray*)sortDescriptors
+                         skip: (NSUInteger)skip
+                        limit: (NSUInteger)limit;
 @end
 
 

--- a/Unit-Tests/IncrementalStore_Tests.m
+++ b/Unit-Tests/IncrementalStore_Tests.m
@@ -675,7 +675,7 @@ static NSArray *CBLISTestInsertEntriesWithProperties(NSManagedObjectContext *con
     fetchRequest.fetchLimit = 20;
     result = [context executeFetchRequest:fetchRequest error:&error];
     AssertEq(result.count, 20u);
-    number = 40;
+    number = 99;
     for (NSManagedObject *obj in result) {
         AssertEqual([obj valueForKey:@"number"], @(number--));
     }

--- a/Unit-Tests/View_Tests.m
+++ b/Unit-Tests/View_Tests.m
@@ -248,6 +248,29 @@
     AssertEqual(rows.nextRow.value, @[@"none"]);
     AssertEqual(rows.nextRow.value, @[@"furry"]);
     AssertNil(rows.nextRow);
+
+    // Now combine with a limit (#892):
+    query.limit = 2;
+    rows = [query run: NULL];
+
+    AssertEqual(rows.nextRow.value, @[@"scaly"]);
+    AssertEqual(rows.nextRow.value, @[@"none"]);
+    AssertNil(rows.nextRow);
+
+    // ...and a skip
+    query.skip = 1;
+    query.limit = 9;
+    rows = [query run: NULL];
+
+    AssertEqual(rows.nextRow.value, @[@"none"]);
+    AssertEqual(rows.nextRow.value, @[@"furry"]);
+    AssertNil(rows.nextRow);
+
+    // ...and skipping everything:
+    query.skip = 3;
+    rows = [query run: NULL];
+
+    AssertNil(rows.nextRow);
 }
 
 


### PR DESCRIPTION
Don't apply the skip and limit during the actual query. Instead do them after the in-memory sorting.
Fixes #892

Note: I had to change the expected results for an IncrementalStore test. I am pretty sure the prior expected results were wrong, but I haven't looked at this test before so I might have missed something.