### PR TITLE
Fixed 401 status not being propagated to CBLReplication.lastError

### DIFF
--- a/Source/CBLStatus.h
+++ b/Source/CBLStatus.h
@@ -22,6 +22,7 @@ typedef enum {
     kCBLStatusMethodNotAllowed = 405,
     kCBLStatusNotAcceptable  = 406,
     kCBLStatusConflict       = 409,
+    kCBLStatusGone           = 410,
     kCBLStatusDuplicate      = 412,      // Formally known as "Precondition Failed"
     kCBLStatusUnsupportedType= 415,
     


### PR DESCRIPTION
-[CBLRestPuller pullRemoteRevision:] was treating all errors as applying
only to the revision being pulled, i.e. it would just skip that rev and
continue. That should only be done for specific errors like a 403, 404
or 410 status. Others should set the replicator's error property.

This is actually a regression introduced a year ago in 87f3261 as part
of the fix for #377. That fix made document-level errors from this HTTP
call work correctly, but it broke connection-level errors like this one.

Fixes #900