### PR TITLE
Support for upgrading SQLite databases to ForestDB (#870)

### DIFF
--- a/Source/API/CBLManager.h
+++ b/Source/API/CBLManager.h
@@ -53,6 +53,10 @@ typedef struct CBLManagerOptions {
 /** Storage engine type. There are two options, "SQLite" (default) or "ForestDB". */
 @property (copy, nonatomic) NSString* storageType;
 
+/** Should existing databases be upgraded to the preferred storage engine type when opened?
+    (Defaults to NO.) */
+@property (nonatomic) BOOL upgradeStorage;
+
 /** The root directory of this manager (as specified at initialization time.) */
 @property (readonly) NSString* directory;
 

--- a/Source/CBLDatabaseUpgrade.h
+++ b/Source/CBLDatabaseUpgrade.h
@@ -25,6 +25,8 @@
 
 - (void) backOut;
 
+- (void) deleteSQLiteFiles;
+
 @property (readonly) NSUInteger numDocs, numRevs;
 
 @end

--- a/Source/CBLDatabaseUpgrade.m
+++ b/Source/CBLDatabaseUpgrade.m
@@ -138,6 +138,14 @@ static int collateRevIDs(void *context,
 }
 
 
+- (void) deleteSQLiteFiles {
+    for (NSString* suffix in @[@"", @"-wal", @"-shm"]) {
+        NSString* oldFile = [_path stringByAppendingString: suffix];
+        [[NSFileManager defaultManager] removeItemAtPath: oldFile error: NULL];
+    }
+}
+
+
 - (CBLStatus) moveAttachmentsDir {
     NSFileManager* fmgr = [NSFileManager defaultManager];
     NSString* oldAttachmentsPath = [[_path stringByDeletingPathExtension]

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -1043,6 +1043,10 @@
     NSError* error;
     CBLDatabase* replaceDb = [dbmgr existingDatabaseNamed: name error: &error];
     Assert(replaceDb, @"Couldn't find the replaced database named %@ : %@", name, error);
+
+    NSString* storageType = NSStringFromClass(replaceDb.storage.class);
+    AssertEqual(storageType, (self.isSQLiteDB ? @"CBL_SQLiteStorage" : @"CBL_ForestDBStorage"));
+
     CBLView* view = [replaceDb viewNamed: @"myview"];
     Assert(view);
     [view setMapBlock: MAPBLOCK({
@@ -1053,7 +1057,7 @@
     query.prefetch = YES;
     Assert(query);
     CBLQueryEnumerator* rows = [query run: &error];
-    Assert(rows, @"Could query the replaced database named %@ : %@", name, error);
+    Assert(rows, @"Couldn't query the replaced database named %@ : %@", name, error);
 
     onComplete(rows);
 }
@@ -1069,9 +1073,9 @@
 }
 
 - (void) test23_ReplaceOldVersionDatabase {
-    // Test only SQLite:
-    if (!self.isSQLiteDB)
-        return;
+    // During the SQLite phase, this just tests copying the db and upgrading to 1.1 format.
+    // During the ForestDB phase, the databases will also be upgraded to ForestDB.
+    dbmgr.upgradeStorage = YES;
 
     // iOS 1.0.4
     NSString* dbFile = [self pathToReplaceDbFile: @"iosdb.cblite" inDirectory: @"ios104"];


### PR DESCRIPTION
If you set the new property CBLManager.upgradeStorage to YES, and the
existing property storageType to @"ForestDB", then existing SQLite
databases will be upgraded to ForestDB when first opened.
Fixes #870