### PR TITLE
Fixed #942 crash due to firing fault on faulted parent relationship object

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -2038,13 +2038,14 @@ static CBLManager* sCBLManager;
 
                     for (NSString *relationshipName in moc.entity.relationshipsByName) {
                         NSRelationshipDescription *relationshipDescription = moc.entity.relationshipsByName[relationshipName];
-
-                        if (NO == relationshipDescription.toMany) {
-                            NSManagedObject *destinationObject = [moc valueForKey:relationshipName];
-                            if (nil != destinationObject) {
-                                // Ensure that a fault has been fired:
-                                [destinationObject willAccessValueForKey: nil];
-                                [context refreshObject: destinationObject mergeChanges: YES];
+                        if (!relationshipDescription.toMany) {
+                            if (![moc hasFaultForRelationshipNamed:relationshipName]) {
+                                NSManagedObject *destinationObject = [moc valueForKey:relationshipName];
+                                if (destinationObject) {
+                                    // Ensure that a fault has been fired:
+                                    [destinationObject willAccessValueForKey: nil];
+                                    [context refreshObject: destinationObject mergeChanges: YES];
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Not firing fault when parent object is in faulted state.

#942