### PR TITLE
Fixed #925 CBLIS crash due to missing type property

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -2109,7 +2109,6 @@ static CBLManager* sCBLManager;
 }
 
 - (void) processCouchbaseLiteChanges: (NSArray*)changes {
-    NSMutableSet* changedEntitites = [NSMutableSet setWithCapacity: changes.count];
     NSMutableArray* deletedObjectIDs = [NSMutableArray array];
     NSMutableArray* updatedObjectIDs = [NSMutableArray array];
 
@@ -2125,6 +2124,12 @@ static CBLManager* sCBLManager;
         NSDictionary* properties = [rev properties];
 
         NSString* type = [properties objectForKey: [self documentTypeKey]];
+        if (!type) {
+            WARN(@"Couldn't find type property on changed document : %@ (source = %@)",
+                 properties, change.source);
+            continue;
+        }
+
         NSString* reference = change.documentID;
 
         NSDictionary *entitiesByName = self.persistentStoreCoordinator.managedObjectModel.entitiesByName;
@@ -2136,8 +2141,6 @@ static CBLManager* sCBLManager;
         } else {
             [updatedObjectIDs addObject: objectID];
         }
-
-        [changedEntitites addObject: type];
     }
 
     [self informObservingManagedObjectContextsAboutUpdatedIDs: updatedObjectIDs


### PR DESCRIPTION
When processing CBL databas change, the changed document doesn't have type property. It's possible that the document was deleted without preserving the type property outside the CBLIS app. Now skipping the document without type property and print out a warning message.

#925