### PR TITLE
CBLIS do not inform contexts just refresh registered objects

### DIFF
--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -56,10 +56,6 @@ static NSError* CBLISError(NSInteger code, NSString* desc, NSError *parent);
 - (NSString*) couchbaseLiteIDRepresentation;
 @end
 
-@interface CBLView (CBLIncrementalStore)
-@property (readonly) SInt64 lastSequenceChangedAt;
-@end
-
 
 @interface CBLIncrementalStore ()
 
@@ -1628,7 +1624,7 @@ static CBLManager* sCBLManager;
     if (view) {
         NSString* cacheKey = [NSString stringWithFormat:@"%@/%@", view, parentKey];
         CBLQueryEnumerator* result = [_relationshipCache objectForKey: cacheKey];
-        if (result && (SInt64)result.sequenceNumber == view.lastSequenceChangedAt)
+        if (result && (SInt64)result.sequenceNumber == view.database.lastSequenceNumber)
             return [result allObjects];
 
         CBLQuery* query = [view createQuery];

--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -2200,9 +2200,9 @@ static CBLManager* sCBLManager;
                                     userInfo: userInfo];
     [strongRootContext mergeChangesFromContextDidSaveNotification: notification];
 
-    for (NSManagedObjectContext *context in self.observingManagedObjectContexts) {
+    for (NSManagedObjectContext* context in self.observingManagedObjectContexts) {
         if (context != strongRootContext) {
-            [context performBlockAndWait:^{
+            [context performBlock: ^{
                 [context mergeChangesFromContextDidSaveNotification: notification];
             }];
         }

--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -56,6 +56,10 @@ static NSError* CBLISError(NSInteger code, NSString* desc, NSError *parent);
 - (NSString*) couchbaseLiteIDRepresentation;
 @end
 
+@interface CBLView (CBLIncrementalStore)
+@property (readonly) SInt64 lastSequenceChangedAt;
+@end
+
 
 @interface CBLIncrementalStore ()
 
@@ -1624,7 +1628,7 @@ static CBLManager* sCBLManager;
     if (view) {
         NSString* cacheKey = [NSString stringWithFormat:@"%@/%@", view, parentKey];
         CBLQueryEnumerator* result = [_relationshipCache objectForKey: cacheKey];
-        if (result && (SInt64)result.sequenceNumber == view.database.lastSequenceNumber)
+        if (result && (SInt64)result.sequenceNumber == view.lastSequenceChangedAt)
             return [result allObjects];
 
         CBLQuery* query = [view createQuery];

--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -2054,7 +2054,6 @@ static CBLManager* sCBLManager;
     
     CFAbsoluteTime start = CFAbsoluteTimeGetCurrent();
 
-    NSMutableSet* insertedIDs = [NSMutableSet set];
     NSMutableSet* updatedIDs = [NSMutableSet set];
     NSMutableSet* deletedIDs = [NSMutableSet set];
     NSMutableSet *localChangedEntities = [NSMutableSet set];
@@ -2099,17 +2098,13 @@ static CBLManager* sCBLManager;
 
     }
 
-    if (insertedIDs.count > 0 || updatedIDs.count > 0 || deletedIDs.count > 0) {
+    if (updatedIDs.count > 0 || deletedIDs.count > 0) {
         [self refreshContextsWithUpdatedIDs:updatedIDs deletedIDs: deletedIDs];
-
-        NSMutableSet *allUpdatedIDs = [NSMutableSet set];
-        [allUpdatedIDs addObjectsFromArray:insertedIDs.allObjects];
-        [allUpdatedIDs addObjectsFromArray:updatedIDs.allObjects];
 
         [[NSNotificationCenter defaultCenter]
          postNotificationName: kCBLISObjectHasBeenChangedInStoreNotification
          object: self
-         userInfo: @{ NSUpdatedObjectsKey: allUpdatedIDs,
+         userInfo: @{ NSUpdatedObjectsKey: updatedIDs,
                       NSDeletedObjectsKey: deletedIDs }];
     } else {
         INFO(@"processCouchbaseLiteChanges : no changes from remote");

--- a/Source/API/Extras/CBLIncrementalStore.m
+++ b/Source/API/Extras/CBLIncrementalStore.m
@@ -2192,10 +2192,6 @@ static CBLManager* sCBLManager;
             for (NSManagedObjectID *objID in objectsToRefresh) {
                 NSManagedObject *obj = [context objectRegisteredForID:objID];
 
-                if (!obj) {
-                    obj = [context objectWithID: objID];
-                }
-
                 if (obj) {
                     [context refreshObject:obj mergeChanges:YES];
                 }
@@ -2206,6 +2202,8 @@ static CBLManager* sCBLManager;
             for (NSString* entity in updatedEntities) {
                 [self purgeCachedObjectsForEntityName: entity];
             }
+            
+            [context processPendingChanges];
             
             INFO(@"finish refresh context : %@", context.parentContext ? @"MAIN" : @"ROOT");
         }];


### PR DESCRIPTION
related to https://github.com/couchbase/couchbase-lite-ios/issues/938

- No need to merge contexts with notification.
- Separate inserted and updated objects to refresh relationships only for inserted objects
- refresh objects only if object is registered