### PR TITLE
Check for currentRevision.isDeletion state in CBLDocument -isDeleted

### DIFF
--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -96,7 +96,8 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
 
 
 - (BOOL) isDeleted {
-    return self.currentRevision.isDeletion || (self.currentRevision == nil && [self getLeafRevisions: NULL].count > 0);
+    CBLRevision *currentRev = self.currentRevision;
+    return currentRev.isDeletion || ((currentRev == nil) && ([self getLeafRevisions: NULL].count > 0));
 }
 
 

--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -96,7 +96,7 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
 
 
 - (BOOL) isDeleted {
-    return self.currentRevision == nil && [self getLeafRevisions: NULL].count > 0;
+    return self.currentRevision.isDeletion || (self.currentRevision == nil && [self getLeafRevisions: NULL].count > 0);
 }
 
 


### PR DESCRIPTION
I noticed a curious case of a deleted document responding to `-isDeleted` with `NO`. Digging deeper into its properties I can see that the current revision indeed has `_deleted = 1`:

```
(lldb) po [document isDeleted]
NO

(lldb) po [document properties]
{
    "_deleted" = 1;
    "_id" = "MPBibliographyItem:10D49A6A-4822-400C-97A2-3A41429B118A";
    "_rev" = "2-29edc04926e670a8e3df99e5b8122175";
}
```

The current definition of `isDeleted` in CBLDocument indeed does not check for the presence of `_deleted`:

```
- (BOOL) isDeleted {
    return self.currentRevision == nil && [self getLeafRevisions: NULL].count > 0;
}
```

This PR is an attempt at addressing the above issue by checking for self.currentRevision.isDeletion as well as the pre-existing conditions. 

This case happens at least when fetching a document with a `CBLQuery` with `kCBLIncludeDeleted` passed in as the `allDocsMode`.