### PR TITLE
Always callback couchTableSource:self willUseCell:cell forRow:row

### DIFF
--- a/Source/API/CBLUITableSource.m
+++ b/Source/API/CBLUITableSource.m
@@ -170,22 +170,22 @@
                                           indexPath);
     if (!cell) {
         // ...if it doesn't, create a cell for it:
-        cell = [tableView dequeueReusableCellWithIdentifier: @"CBLUITableDelegate"];
+        cell = [tableView dequeueReusableCellWithIdentifier: @"CBUITableDelegate"];
         if (!cell)
             cell = [[UITableViewCell alloc] initWithStyle: UITableViewCellStyleDefault
-                                          reuseIdentifier: @"CBLUITableDelegate"];
-        
-        CBLQueryRow* row = [self rowAtIndex: indexPath.row];
-        cell.textLabel.text = [self labelForRow: row];
-        
-        // Allow the delegate to customize the cell:
-        id delegate = _tableView.delegate;
-        if ([delegate respondsToSelector: @selector(couchTableSource:willUseCell:forRow:)])
-            [(id<CBLUITableDelegate>)delegate couchTableSource: self willUseCell: cell forRow: row];
+                                          reuseIdentifier: @"CBUITableDelegate"];
     }
+    
+    CBLQueryRow* row = [self rowAtIndex: indexPath.row];
+    cell.textLabel.text = [self labelForRow: row];
+    
+    // Allow the delegate to customize the cell:
+    id delegate = _tableView.delegate;
+    if ([delegate respondsToSelector: @selector(couchTableSource:willUseCell:forRow:)])
+        [(id<CBUITableDelegate>)delegate couchTableSource: self willUseCell: cell forRow: row];
+    
     return cell;
 }
-
 
 #pragma mark -
 #pragma mark EDITING:


### PR DESCRIPTION
I had to make this change locally in my project when using CBLUiTableSource because when I added:

```
    func couchTableSource(source: CBUITableSource, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
        let cell = tableView.dequeueReusableCellWithIdentifier("GalleryTableViewCell", forIndexPath: indexPath) as! GalleryTableViewCell
        return cell
    }
```

this method:

```
    func couchTableSource(source: CBUITableSource, willUseCell cell: UITableViewCell, forRow row: CBLQueryRow) {
      ...
    }
```

was no longer being called back.  Making the above change fixed it, and I can't see how it would cause any side effects.