### PR TITLE
Fixed #1041 importing local docs when upgrading the database

### DIFF
--- a/Source/CBLDatabaseUpgrade.m
+++ b/Source/CBLDatabaseUpgrade.m
@@ -431,6 +431,9 @@ static int collateRevIDs(void *context,
     while (SQLITE_ROW == (err = sqlite3_step(localQuery))) {
         @autoreleasepool {
             NSString* docID = columnString(localQuery, 0);
+            // Remove "_local/" prefix:
+            if ([docID hasPrefix:@"_local/"])
+                docID = [docID substringFromIndex:7];
             NSData* json = columnData(localQuery, 1);
             NSDictionary* props = [CBLJSON JSONObjectWithData: json options: 0 error: NULL];
             LogTo(Upgrade, @"Upgrading local doc '%@'", docID);

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -1324,7 +1324,7 @@
 
     // Test db contents:
     [self checkReplacedDatabaseNamed: @"replacedb"
-                         onComplete: ^(CBLDatabase* replaceDb, CBLQueryEnumerator* rows) {
+                         onComplete: ^(CBLDatabase* targetDb, CBLQueryEnumerator* rows) {
                              AssertEq(rows.count, 2u);
                              CBLDocument* doc = [rows rowAtIndex:0].document;
                              AssertEqual(doc.documentID, @"doc1");
@@ -1334,8 +1334,8 @@
                              AssertEq(att.length, att.content.length);
                              
                              // https://github.com/couchbase/couchbase-lite-ios/issues/1041:
-                             // NSDictionary* localDoc = [replaceDb existingLocalDocumentWithID: @"local1"];
-                             //Assert(localDoc);
+                             NSDictionary* localDoc = [targetDb existingLocalDocumentWithID: @"local1"];
+                             Assert(localDoc);
                           }];
 
     // Close and re-open the db using SQLite storage type. Should fail if it used to be ForestDB:


### PR DESCRIPTION
putLoalDocument:withID: doesn't expect the docID with `_local/` prefix so it added another `_local/` prefix to the ID. Need to remove `_local/` prefix from the ID.

#1041