### PR TITLE
Include CBLRegisterJSViewCompiler.h for Mac only

### DIFF
--- a/Source/API/CouchbaseLite.h
+++ b/Source/API/CouchbaseLite.h
@@ -35,4 +35,6 @@
 
 #if TARGET_OS_IPHONE
 #import "CBLUITableSource.h"
+#else
+#import "CBLRegisterJSViewCompiler.h"
 #endif


### PR DESCRIPTION
This is a regression bug after e97746843befc7987db35420bfbcddad435c9968 commit.

OSX includes CBLRegisterJSViewCompiler into the framework but iOS doesn't so we need to add CBLRegisterJSViewCompiler.h back to CouchbaesLite.h for Mac only.

#1054