### PR TITLE
Check if CBL_Storage's lowMemoryWarning method is implemented before calling

### DIFF
--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -491,7 +491,8 @@ static BOOL sAutoCompact = YES;
 - (void) lowMemory: (NSNotification*)n {
     [self doAsync: ^{
         [self _pruneDocumentCache];
-        [_storage lowMemoryWarning];
+        if ([_storage respondsToSelector:@selector(lowMemoryWarning)])
+            [_storage lowMemoryWarning];
     }];
 }
 #endif


### PR DESCRIPTION
CBL_SQLiteStorage is not implmenting the lowMemoryWarning method so check if the method is implemented before calling.

#1079