### PR TITLE
tvOS: App Support dir is r/o, so CBLManager should use Caches dir

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -138,8 +138,11 @@ static NSCharacterSet* kIllegalNameChars;
 
 
 + (NSString*) defaultDirectory {
-    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory,
-                                                         NSUserDomainMask, YES);
+    NSSearchPathDirectory dirID = NSApplicationSupportDirectory;
+#if TARGET_OS_TV
+    dirID = NSCachesDirectory; // Apple TV only allows apps to store data in the Caches directory
+#endif
+    NSArray* paths = NSSearchPathForDirectoriesInDomains(dirID, NSUserDomainMask, YES);
     NSString* path = paths[0];
 #if !TARGET_OS_IPHONE
     path = [path stringByAppendingPathComponent: [[NSBundle mainBundle] bundleIdentifier]];


### PR DESCRIPTION
Without this change, on an AppleTV device `[CBLManager sharedInstance]` is unusable, since trying to create a database will fail with a file permission error. This only reproduces on real devices, not the simulator.

(Copied from commit 35453d6c on the 1.1.1-appleTV branch; i.e. this change has been tested previously.)