### PR TITLE
Fixed assertion failure due to not ending background task on app wakeup

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -128,7 +128,10 @@ static NSCharacterSet* kIllegalNameChars;
 
 + (void) redirectLogging: (void (^)(NSString* type, NSString* message))callback {
 #ifndef MY_DISABLE_LOGGING
-    MYLoggingCallback = callback;
+    MYLoggingCallback = ^(NSString* domain, NSString* message) {
+        callback(domain, message);
+        return NO;
+    };
 #endif
 }
 

--- a/Source/CBLRestReplicator.h
+++ b/Source/CBLRestReplicator.h
@@ -23,7 +23,6 @@
     NSString* _serverType;
 #if TARGET_OS_IPHONE
     MYBackgroundMonitor *_bgMonitor;
-    BOOL _hasBGTask;
 #endif
 }
 

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -114,7 +114,6 @@
 #if TARGET_OS_IPHONE
         // Keeps static analyzer from complaining this ivar is unused:
         _bgMonitor = nil;
-        _hasBGTask = NO;
 #endif
     }
     return self;

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -119,10 +119,8 @@ static void onCompactCallback(void *context, bool compacting) {
         [self performSelector: @selector(checkStillCompacting) withObject: nil afterDelay: 0.5];
         return YES;
     } else {
-        if (bgMonitor.hasBackgroundTask) {
+        if ([bgMonitor endBackgroundTask])
             Log(@"Database finished compacting; allowing app to suspend.");
-            [bgMonitor endBackgroundTask];
-        }
         return NO;
     }
 }


### PR DESCRIPTION
CBLRestReplicator wasn't ending its background task when the app became
active, which mean that when the app backgrounded again it attempted to
set another background task, which MYBackgroundMonitor doesn't support.

Fixes #1006