### PR TITLE
Be more careful calling blocks

### DIFF
--- a/Source/CBLBatcher.m
+++ b/Source/CBLBatcher.m
@@ -41,8 +41,6 @@
 }
 
 
-
-
 - (void) unschedule {
     _scheduled = false;
     [NSObject cancelPreviousPerformRequestsWithTarget: self
@@ -79,7 +77,8 @@
 
     __unused id retainSelf = self;  // Prevent _processor block from deallocating me (#508)
 
-    _processor(toProcess);
+    __typeof(_processor) processor = _processor;
+    processor(toProcess);
     _lastProcessedTime = CFAbsoluteTimeGetCurrent();
 }
 
@@ -124,7 +123,8 @@
         [self unschedule];
         NSArray* toProcess = _inbox;
         _inbox = nil;
-        _processor(toProcess);
+        __typeof(_processor) processor = _processor;
+        processor(toProcess);
         _lastProcessedTime = CFAbsoluteTimeGetCurrent();
     }
 }

--- a/Source/CBLBulkDownloader.m
+++ b/Source/CBLBulkDownloader.m
@@ -179,7 +179,8 @@
         return NO;
     }
     ++_docCount;
-    _onDocument(_docReader.document);
+    __typeof(_onDocument) onDocument = _onDocument;
+    onDocument(_docReader.document);
     _docReader = nil;
     return YES;
 }

--- a/Source/CBLMultipartDocumentReader.m
+++ b/Source/CBLMultipartDocumentReader.m
@@ -238,7 +238,8 @@
     [stream close];
     if (!CBLStatusIsError(_status))
         [self finish];
-    _completionBlock(self);
+    __typeof(_completionBlock) completionBlock = _completionBlock;
+    completionBlock(self);
     _completionBlock = nil;
     _retainSelf = nil;  // clears the reference acquired in -readStream:
 }

--- a/Source/CBLProgressGroup.m
+++ b/Source/CBLProgressGroup.m
@@ -93,7 +93,8 @@
 - (void) setCompletedUnitCount: (int64_t)completed {
     completed = MIN(completed, _total-1);   // don't allow _completed to equal _total yet
     _completed = completed;
-    _noteProgress();
+    __typeof(_noteProgress) noteProgress = _noteProgress;
+    noteProgress();
 }
 
 - (void) setTotalUnitCount: (int64_t)total {

--- a/Source/CBLReachability.m
+++ b/Source/CBLReachability.m
@@ -161,8 +161,9 @@ static void ClientCallback(SCNetworkReachabilityRef target,
     if (!_reachabilityKnown || flags != _reachabilityFlags) {
         self.reachabilityFlags = flags;
         self.reachabilityKnown = YES;
-        if (_onChange)
-            _onChange();
+        __typeof(_onChange) onChange = _onChange;
+        if (onChange)
+            onChange();
     }
 }
 

--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -176,7 +176,9 @@ typedef enum {
 
 - (void) respondWithResult: (id)result error: (NSError*)error {
     Assert(result || error);
-    _onCompletion(result, error);
+
+    CBLRemoteRequestCompletionBlock onCompletion = _onCompletion;   // keep block alive till return
+    onCompletion(result, error);
     _onCompletion = nil;  // break cycles
 }
 

--- a/Source/CBLSyncConnection+Push.m
+++ b/Source/CBLSyncConnection+Push.m
@@ -62,9 +62,10 @@
     query.inclusiveStart = NO;
     if (limit > 0)
         query.limit = limit;
-    if (_pushFilter) {
+    __typeof(_pushFilter) pushFilter = _pushFilter;
+    if (pushFilter) {
         query.filterBlock = ^BOOL(CBLQueryRow* row) {
-            return _pushFilter(row.document.currentRevision, _pushFilterParams);
+            return pushFilter(row.document.currentRevision, _pushFilterParams);
         };
     }
     NSError* error;
@@ -217,9 +218,10 @@
     NSMutableArray* changes = [NSMutableArray new];
     for (CBLDatabaseChange* change in (n.userInfo)[@"changes"]) {
         if (![change.source isEqual: _peerURL]) {  // ignore echoes of changes rcvd from this peer
-            if (_pushFilter) {
+            __typeof(_pushFilter) pushFilter = _pushFilter;
+            if (pushFilter) {
                 CBLSavedRevision* rev = [_db[change.documentID] revisionWithID: change.revisionID];
-                if (!_pushFilter(rev, _pushFilterParams))
+                if (!pushFilter(rev, _pushFilterParams))
                     continue;
             }
             [changes addObject: encodeChange(change.sequenceNumber, change.documentID,

--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -450,9 +450,10 @@ static NSArray* splitPath( NSURL* url ) {
 
         sel = hasAltMethod ? @selector(do_METHOD_NOT_ALLOWED) : @selector(do_UNKNOWN);
     }
-    
-    if (_onAccessCheck) {
-        CBLStatus status = _onAccessCheck(_db, docID, sel);
+
+    __typeof(_onAccessCheck) onAccessCheck = _onAccessCheck;
+    if (onAccessCheck) {
+        CBLStatus status = onAccessCheck(_db, docID, sel);
         if (CBLStatusIsError(status)) {
             LogTo(CBL_Router, @"Access check failed for %@", _db.name);
             return status;
@@ -624,9 +625,10 @@ static NSArray* splitPath( NSURL* url ) {
     for (NSString *key in [_server.customHTTPHeaders allKeys]) {
         _response[key] = _server.customHTTPHeaders[key];
     }
-    
-    if (_onResponseReady)
-        _onResponseReady(_response);
+
+    __typeof(_onResponseReady) onResponseReady = _onResponseReady;
+    if (onResponseReady)
+        onResponseReady(_response);
 }
 
 
@@ -648,14 +650,16 @@ static NSArray* splitPath( NSURL* url ) {
 
 // Send data without closing the connection.
 - (void) sendData: (NSData*)data {
-    if (_onDataAvailable)
-        _onDataAvailable(data, NO);
+    __typeof(_onDataAvailable) onDataAvailable = _onDataAvailable;
+    if (onDataAvailable)
+        onDataAvailable(data, NO);
 }
 
 
 - (void) sendResponseBodyAndFinish: (BOOL)finished {
-    if (_onDataAvailable && _response.body && !$equal(_request.HTTPMethod, @"HEAD")) {
-        _onDataAvailable(_response.body.asJSON, finished);
+    __typeof(_onDataAvailable) onDataAvailable = _onDataAvailable;
+    if (onDataAvailable && _response.body && !$equal(_request.HTTPMethod, @"HEAD")) {
+        onDataAvailable(_response.body.asJSON, finished);
     }
     if (finished)
         [self finished];
@@ -731,8 +735,9 @@ static NSArray* splitPath( NSURL* url ) {
 #pragma mark - Heartbeat
 
 - (void) sendHeartbeatResponse: (NSTimer*)timer {
-    if (_onDataAvailable) {
-        _onDataAvailable(timer.userInfo, NO);
+    __typeof(_onDataAvailable) onDataAvailable = _onDataAvailable;
+    if (onDataAvailable) {
+        onDataAvailable(timer.userInfo, NO);
     }
 }
 


### PR DESCRIPTION
If a block ref is stored in an ivar, and the ivar might change due to
a re-entrant call during a call to the block, then be safe and copy the
block ref to a local variable before calling it. Otherwise the block
might be dealloced while its code is running, which will cause garbage
results or even crashes when it accesses a captured variable.

Fixes #1015 (I think)