### PR TITLE
Keep LiveQuery from triggering if view index didn't change

### DIFF
--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -120,4 +120,6 @@
 
 @interface CBLQuery ()
 @property (nonatomic, strong) BOOL (^filterBlock)(CBLQueryRow*);
+- (void) runAsyncIfChangedSince: (SInt64)ifChangedSince
+                     onComplete: (void (^)(CBLQueryEnumerator*, NSError*))onComplete;
 @end


### PR DESCRIPTION
If the database changes and a view index is updated, but doesn't change,
a LiveQuery on that view shouldn't re-run its query. I thought I'd
implemented that earlier, but I made a mistake, so the query ended up
being run anyway. (The LiveQuery still wouldn't notify, though, because
it would see that the old and new query results were the same.)

This commit fixes it so the query doesn't even happen.

Note that this optimization only works for ForestDB-based views, because
SQLite views don't implement the lastSequenceChangedAt property.

Fixes #1114