### PR TITLE
Fix major listener memory leak

### DIFF
--- a/Listener/CBLHTTPConnection.m
+++ b/Listener/CBLHTTPConnection.m
@@ -29,6 +29,11 @@
 #import "Test.h"
 
 
+// For some reason this is not declared in HTTPConnection's @interface
+@interface HTTPConnection () <GCDAsyncSocketDelegate>
+@end
+
+
 @implementation CBLHTTPConnection
 {
     BOOL _hasClientCert;
@@ -139,6 +144,7 @@ static void evaluate(SecTrustRef trust, SecTrustCallback callback) {
                                  code: GCDAsyncSocketReadTimeoutError]) {
         Warn(@"CBLHTTPConnection: Client disconnected: %@", error);
     }
+    [super socketDidDisconnect: socket withError: error];
 }
 
 


### PR DESCRIPTION
CBLHTTPConnection objects never got cleaned up, because my override of
-socketDidDisconnect:withError: wasn't calling the (undeclared)
superclass method, which is what removes the connection object from
the server's connection list.
This caused the CBLHTTPConnection, GCDAsyncSocket, and other objects
to stay in memory; not leaked exactly, but kept in the HTTPServer's
connection list.
Fixed by adding the 'super' call.

Fixes #1017