### PR TITLE
Fixed #1140 : CBLRemoteRequest onCompletion gets called twice

### DIFF
--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -179,8 +179,8 @@ typedef enum {
     Assert(result || error);
 
     CBLRemoteRequestCompletionBlock onCompletion = _onCompletion;   // keep block alive till return
-    onCompletion(result, error);
     _onCompletion = nil;  // break cycles
+    onCompletion(result, error);
 }
 
 

--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -179,8 +179,10 @@ typedef enum {
     Assert(result || error);
 
     CBLRemoteRequestCompletionBlock onCompletion = _onCompletion;   // keep block alive till return
-    _onCompletion = nil;  // break cycles
-    onCompletion(result, error);
+    if (onCompletion) {
+        _onCompletion = nil;  // break cycles
+        onCompletion(result, error);
+    }
 }
 
 


### PR DESCRIPTION
When there is a permanent error occurred, the onCompletion block could be called second time on stopping remote requests originated from setting error property value inside the onCompletion block. So change to break cycles before executing onCompletion block.

#1140