### PR TITLE
Public API tweaks for better Swift compatibility

### DIFF
--- a/Source/API/CBLBase.h
+++ b/Source/API/CBLBase.h
@@ -27,9 +27,11 @@
 #if __has_feature(objc_generics)
 #define CBLArrayOf(VALUE) NSArray<VALUE>
 #define CBLDictOf(KEY, VALUE) NSDictionary<KEY, VALUE>
+#define CBLEnumeratorOf(VALUE) NSEnumerator<VALUE>
 #else
 #define CBLArrayOf(VALUE) NSArray
 #define CBLDictOf(KEY, VALUE) NSDictionary
+#define CBLEnumeratorOf(VALUE) NSEnumerator
 #endif
 
 typedef CBLDictOf(NSString*, id) CBLJSONDict;

--- a/Source/API/CBLDocument.h
+++ b/Source/API/CBLDocument.h
@@ -52,15 +52,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable CBLSavedRevision*) revisionWithID: (NSString*)revisionID;
 
 /** Returns the document's history as an array of CBLRevisions. (See CBLRevision's method.) */
-- (nullable CBLArrayOf(CBLRevision*)*) getRevisionHistory: (NSError**)outError;
+- (nullable CBLArrayOf(CBLSavedRevision*)*) getRevisionHistory: (NSError**)outError;
 
 /** Returns all the current conflicting revisions of the document. If the document is not
     in conflict, only the single current revision will be returned. */
-- (nullable CBLArrayOf(CBLRevision*)*) getConflictingRevisions: (NSError**)outError;
+- (nullable CBLArrayOf(CBLSavedRevision*)*) getConflictingRevisions: (NSError**)outError;
 
 /** Returns all the leaf revisions in the document's revision tree,
     including deleted revisions (i.e. previously-resolved conflicts.) */
-- (nullable CBLArrayOf(CBLRevision*)*) getLeafRevisions: (NSError**)outError;
+- (nullable CBLArrayOf(CBLSavedRevision*)*) getLeafRevisions: (NSError**)outError;
 
 /** Creates an unsaved new revision whose parent is the currentRevision,
     or which will be the first revision if the document doesn't exist yet.
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param outError  Error information will be stored here if the insertion fails.
     @return  YES on success, NO on failure. */
 - (BOOL) putExistingRevisionWithProperties: (NSDictionary*)properties
-                           revisionHistory: (NSArray*)revIDs
+                           revisionHistory: (CBLArrayOf(NSString*)*)revIDs
                                    fromURL: (nullable NSURL*)sourceURL
                                      error: (NSError**)outError;
 

--- a/Source/API/CBLJSON.h
+++ b/Source/API/CBLJSON.h
@@ -50,23 +50,23 @@ typedef NSUInteger CBLJSONWritingOptions;
 + (NSString*) JSONObjectWithDate: (NSDate*)date timeZone:(NSTimeZone *)tz;
 
 /** Parses an ISO-8601 formatted date string to an NSDate object.
-    If the object is not a string, or not valid ISO-8601, it returns nil. */
-+ (nullable NSDate*) dateWithJSONObject: (id)jsonObject;
+    If the object is not a string, or not valid ISO-8601, or nil, it returns nil. */
++ (nullable NSDate*) dateWithJSONObject: (nullable id)jsonObject;
 
 /** Parses an ISO-8601 formatted date string to an absolute time (timeSinceReferenceDate).
-    If the object is not a string, or not valid ISO-8601, it returns a NAN value. */
-+ (CFAbsoluteTime) absoluteTimeWithJSONObject: (id)jsonObject;
+    If the object is not a string, or not valid ISO-8601, or nil, it returns a NAN value. */
++ (CFAbsoluteTime) absoluteTimeWithJSONObject: (nullable id)jsonObject;
 
 /** Follows a JSON-Pointer, returning the value pointed to, or nil if nothing.
     See spec at: http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-04 */
-+ (nullable id) valueAtPointer: (NSString*)pointer inObject: (id)object;
++ (nullable id) valueAtPointer: (NSString*)pointer inObject: (nullable id)object;
 
 /** Encodes an NSData as a string in Base64 format. */
 + (NSString*) base64StringWithData: (NSData*)data;
 
 /** Parses a Base64-encoded string into an NSData object.
-    If the object is not a string, or not valid Base64, it returns nil. */
-+ (nullable NSData*) dataWithBase64String: (id)jsonObject;
+    If the object is not a string, or not valid Base64, or nil, it returns nil. */
++ (nullable NSData*) dataWithBase64String: (nullable id)jsonObject;
 
 /** Estimates the amount of memory used by the object and those it references. */
 + (size_t) estimateMemorySize: (id)object;

--- a/Source/API/CBLManager.h
+++ b/Source/API/CBLManager.h
@@ -30,7 +30,7 @@ typedef struct CBLManagerOptions {
       the value is nil.
     * If the database exists, and the value is not nil, the database will be upgraded to that
       storage engine if possible. (SQLite-to-ForestDB upgrades are supported.) */
-@property (nonatomic, copy) NSString* storageType;
+@property (nonatomic, copy, nullable) NSString* storageType;
 
 /** A key to encrypt the database with. If the database does not exist and is being created, it
     will use this key, and the same key must be given every time it's opened.
@@ -43,7 +43,7 @@ typedef struct CBLManagerOptions {
     * On Mac OS only, the value may be @YES. This instructs Couchbase Lite to use a key stored in
       the user's Keychain, or generate one there if it doesn't exist yet.
     * A default nil value, of course, means the database is unencrypted. */
-@property (nonatomic, strong) id encryptionKey;
+@property (nonatomic, strong, nullable) id encryptionKey;
 @end
 
 

--- a/Source/API/CBLQuery+Geo.h
+++ b/Source/API/CBLQuery+Geo.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** The GeoJSON object emitted as the key of the emit() call by the map function.
     The format is a parsed GeoJSON point or polygon; see http://geojson.org/geojson-spec */
-@property (readonly, nullable) NSDictionary* geometry;
+@property (readonly, nullable) CBLJSONDict* geometry;
 
 /** The GeoJSON object type of the row's geometry.
     Usually @"Point" or @"Rectangle", but may be another type if the emitted key was GeoJSON.

--- a/Source/API/CBLQuery.h
+++ b/Source/API/CBLQuery.h
@@ -9,7 +9,7 @@
 #import "CBLBase.h"
 
 @class CBLDatabase, CBLDocument;
-@class CBLLiveQuery, CBLQueryEnumerator, CBLQueryRow, CBLRevision;
+@class CBLLiveQuery, CBLQueryEnumerator, CBLQueryRow, CBLSavedRevision;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -181,7 +181,7 @@ typedef NS_ENUM(unsigned, CBLIndexUpdateMode) {
 
 /** Enumerator on a CBLQuery's result rows.
     The objects returned are instances of CBLQueryRow. */
-@interface CBLQueryEnumerator : NSEnumerator <NSCopying, NSFastEnumeration>
+@interface CBLQueryEnumerator : NSEnumerator <NSCopying>
 
 /** The number of rows returned in this enumerator */
 @property (readonly) NSUInteger count;
@@ -191,6 +191,8 @@ typedef NS_ENUM(unsigned, CBLIndexUpdateMode) {
 
 /** YES if the database has changed since the view was generated. */
 @property (readonly) BOOL stale;
+
+- (nullable CBLQueryRow*) nextObject;
 
 /** The next result row. This is the same as -nextObject but with a checked return type. */
 - (nullable CBLQueryRow*) nextRow;
@@ -277,12 +279,12 @@ typedef NS_ENUM(unsigned, CBLIndexUpdateMode) {
 /** The database sequence number of the associated doc/revision. */
 @property (readonly) UInt64 sequenceNumber;
 
-/** Returns all conflicting revisions of the document, as an array of CBLRevision, or nil if the
-    document is not in conflict.
+/** Returns all conflicting revisions of the document, as an array of CBLSavedRevision,
+    or nil if the document is not in conflict.
     The first object in the array will be the default "winning" revision that shadows the others.
     This is only valid in an allDocuments query whose allDocsMode is set to kCBLShowConflicts
     or kCBLOnlyConflicts; otherwise it returns nil. */
-@property (readonly, nullable) CBLArrayOf(CBLRevision*)* conflictingRevisions;
+@property (readonly, nullable) CBLArrayOf(CBLSavedRevision*)* conflictingRevisions;
 
 - (instancetype) init NS_UNAVAILABLE;
 

--- a/Source/API/CBLQueryEnumerator.m
+++ b/Source/API/CBLQueryEnumerator.m
@@ -163,7 +163,7 @@
 }
 
 
-- (id) nextObject {
+- (CBLQueryRow*) nextObject {
     return [self nextRow];
 }
 

--- a/Source/API/CBLRevision.h
+++ b/Source/API/CBLRevision.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
     (In other words, does it have a "_deleted_ or "_removed" property?) */
 @property (readonly) BOOL isGone;
 
-/** The ID of this revision. Will be nil if this is an unsaved CBLNewRevision. */
+/** The ID of this revision. Will be nil if this is a CBLUnsavedRevision. */
 @property (readonly, nullable) NSString* revisionID;
 
 /** The revision this one is a child of. */

--- a/Source/API/CBLView.h
+++ b/Source/API/CBLView.h
@@ -9,13 +9,7 @@
 #import <Foundation/Foundation.h>
 @class CBLDatabase, CBLQuery;
 
-#if __has_feature(nullability) // Xcode 6.3+
-#pragma clang assume_nonnull begin
-#else
-#define nullable
-#define __nullable
-#define __nonnull
-#endif
+NS_ASSUME_NONNULL_BEGIN
 
 
 typedef enum {


### PR DESCRIPTION
* Made some parameters nullable
* Made some parameter or return types more specific, either using
  generics or by specifying a subclass
* Made CBLQueryEnumerator's item type CBLQueryRow to improve Swift 'for'
  loop

These may cause compile errors in existing Swift app code, but they're
easy to fix (and will make the code cleaner.) Since Apple is doing the
same type of thing in their stepwise improvement of the Obj-C bindings,
I think this is reasonable.

Fixes #1143