### PR TITLE
ChangeTracker: Only use active_only=true if db is empty

### DIFF
--- a/Source/CBLRestPuller.m
+++ b/Source/CBLRestPuller.m
@@ -108,6 +108,7 @@
                                                       lastSequence: _lastSequence
                                                             client: self];
     _changeTracker.continuous = _settings.continuous;
+    _changeTracker.activeOnly = (_lastSequence == nil && _db.documentCount == 0);
     _changeTracker.filterName = _settings.filterName;
     _changeTracker.filterParameters = _settings.filterParameters;
     _changeTracker.docIDs = _settings.docIDs;

--- a/Source/ChangeTracker/CBLChangeTracker.h
+++ b/Source/ChangeTracker/CBLChangeTracker.h
@@ -82,6 +82,7 @@ typedef enum CBLChangeTrackerMode {
 @property (readonly, copy, nonatomic) id lastSequenceID;
 @property (nonatomic) BOOL continuous;  // If true, never give up due to errors
 @property (nonatomic) NSTimeInterval pollInterval;  // 0.0 to not poll
+@property (nonatomic) BOOL activeOnly;
 @property (strong, nonatomic) NSError* error;
 @property (weak, nonatomic) id<CBLChangeTrackerClient> client;
 @property (strong, nonatomic) NSDictionary *requestHeaders;

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -53,7 +53,7 @@ DefineLogDomain(ChangeTracker);
 @synthesize limit=_limit, heartbeat=_heartbeat, error=_error, continuous=_continuous;
 @synthesize client=_client, filterName=_filterName, filterParameters=_filterParameters;
 @synthesize requestHeaders = _requestHeaders, authorizer=_authorizer, cookieStorage=_cookieStorage;
-@synthesize docIDs = _docIDs, pollInterval=_pollInterval, paused=_paused;
+@synthesize docIDs = _docIDs, pollInterval=_pollInterval, paused=_paused, activeOnly=_activeOnly;
 
 - (instancetype) initWithDatabaseURL: (NSURL*)databaseURL
                                 mode: (CBLChangeTrackerMode)mode
@@ -110,10 +110,9 @@ DefineLogDomain(ChangeTracker);
         if ([seq isKindOfClass: [NSArray class]] || [seq isKindOfClass: [NSDictionary class]])
             seq = [CBLJSON stringWithJSONObject: seq options: 0 error: nil];
         [path appendFormat: @"&since=%@", CBLEscapeURLParam([seq description])];
-    } else {
-        // On first replication we can skip getting deleted docs. (SG enhancement in ver. 1.2)
-        [path appendString: @"&active_only=true"];
     }
+    if (_activeOnly && !_caughtUp)
+        [path appendString: @"&active_only=true"];
     if (_limit > 0)
         [path appendFormat: @"&limit=%u", _limit];
 
@@ -168,7 +167,7 @@ DefineLogDomain(ChangeTracker);
     NSMutableDictionary* post = $mdict({@"feed", self.feed},
                                        {@"heartbeat", @(round(_heartbeat*1000.0))},
                                        {@"style", (_includeConflicts ? @"all_docs" : nil)},
-                                       {@"active_only", (since ? nil : @YES)},
+                                       {@"active_only", (_activeOnly && !_caughtUp ? @YES : nil)},
                                        {@"since", since},
                                        {@"limit", (_limit > 0 ? @(_limit) : nil)},
                                        {@"filter", filterName},

--- a/Unit-Tests/ChangeTracker_Tests.m
+++ b/Unit-Tests/ChangeTracker_Tests.m
@@ -35,12 +35,15 @@
 
 - (void) test_Simple {
     for (CBLChangeTrackerMode mode = kOneShot; mode <= kLongPoll; ++mode) {
-        Log(@"Mode = %d ...", mode);
-        NSURL* url = [self remoteNonSSLTestDBURL: @"attach_test"];
-        if (!url)
-            return;
-        CBLChangeTracker* tracker = [[CBLChangeTracker alloc] initWithDatabaseURL: url mode: mode conflicts: NO lastSequence: nil client: self];
-        NSArray* expected = $array($dict({@"seq", @1},
+        for (int activeOnly = 0; activeOnly <= 1; ++activeOnly) {
+            Log(@"Mode = %d, activeOnly=%d ...", mode, activeOnly);
+            NSURL* url = [self remoteNonSSLTestDBURL: @"attach_test"];
+            if (!url)
+                return;
+            CBLChangeTracker* tracker = [[CBLChangeTracker alloc] initWithDatabaseURL: url mode: mode conflicts: NO lastSequence: nil client: self];
+            tracker.activeOnly = (BOOL)activeOnly;
+            NSMutableArray* expected = $marray(
+                                   $dict({@"seq", @1},
                                          {@"id", @"_user/GUEST"},
                                          {@"revs", $array()}),
                                    $dict({@"seq", @2},
@@ -49,6 +52,10 @@
                                    $dict({@"seq", @3},
                                          {@"id", @"038c536dc29ff0f4127705879700062c"},
                                          {@"revs", $array(@"3-e715bcf1865f8283ab1f0ba76e7a92ba")}),
+                                   $dict({@"seq", @4},
+                                         {@"id", @"propertytest"},
+                                         {@"revs", $array(@"2-61de0ad4b61a3106195e9b21bcb69d0c")},
+                                         {@"deleted", @YES}),
                                    $dict({@"seq", @5},
                                          {@"id", @"extrameta"},
                                          {@"revs", $array(@"1-11d28a27038a6cce1f08674ab3d67653")}),
@@ -59,8 +66,11 @@
                                          {@"id", @"text_attachment"},
                                          {@"revs", $array(@"2-116dc4ccc934971ae14d8a8afb29b023")})
                                    );
-        [self run: tracker expectingChanges: expected];
-        Assert(_gotHeaders);
+            if (activeOnly)
+                [expected removeObjectAtIndex: 3];
+            [self run: tracker expectingChanges: expected];
+            Assert(_gotHeaders);
+        }
     }
 }
 
@@ -214,6 +224,7 @@
 - (void) run: (CBLChangeTracker*)tracker expectingChanges: (NSArray*)expectedChanges {
     [tracker start];
     _running = YES;
+    _changes = nil;
     NSDate* timeout = [NSDate dateWithTimeIntervalSinceNow: 10];
     while (_running && _changes.count < expectedChanges.count
            && [timeout timeIntervalSinceNow] > 0
@@ -236,6 +247,7 @@
 - (void) run: (CBLChangeTracker*)tracker expectingError: (NSError*)error {
     [tracker start];
     _running = YES;
+    _changes = nil;
     NSDate* timeout = [NSDate dateWithTimeIntervalSinceNow: 60];
     while (_running && [timeout timeIntervalSinceNow] > 0
            && [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode

--- a/Unit-Tests/ReplicatorInternal_Tests.m
+++ b/Unit-Tests/ReplicatorInternal_Tests.m
@@ -552,7 +552,7 @@
 }
 
 
-- (void) test_FindCommonAncestor {
+- (void) test_16_FindCommonAncestor {
     NSDictionary* revDict = $dict({@"ids", @[@"second", @"first"]}, {@"start", @2});
     CBL_Revision* rev = [CBL_Revision revisionWithProperties: $dict({@"_revisions", revDict})];
     AssertEq(CBLFindCommonAncestor(rev, @[]), 0);
@@ -562,7 +562,7 @@
 }
 
 
-- (void) test_Reachability {
+- (void) test_17_Reachability {
     NSArray* hostnames = @[@"couchbase.com", @"localhost", @"127.0.0.1", @"67.221.231.37",
                            @"fsdfsaf.fsdfdaf.fsfddf"];
     for (NSString* hostname in hostnames) {
@@ -600,7 +600,7 @@
 }
 
 
-- (void) test_DistinctCheckpointIDs {
+- (void) test_18_DistinctCheckpointIDs {
     NSMutableDictionary* props = [@{@"source": @"http://fake.fake/fakedb",
                                     @"target": db.name,
                                     @"continuous": @NO} mutableCopy];
@@ -624,7 +624,7 @@
 }
 
 
-- (void) test_UseRemoteUUID {   // Test kCBLReplicatorOption_RemoteUUID (see #733)
+- (void) test_19_UseRemoteUUID {   // Test kCBLReplicatorOption_RemoteUUID (see #733)
     NSDictionary* props = @{@"source": @"http://alice.local:55555/db",
                             @"target": db.name,
                             kCBLReplicatorOption_RemoteUUID: @"cafebabe"};
@@ -650,6 +650,35 @@
     NSString* check3 = r3.remoteCheckpointDocID;
     Assert(![check3 isEqualToString: check2]);
     Assert(!$equal(r3.settings, r2.settings));
+}
+
+
+- (void) test20_PullActiveOnly {
+    // Database 'attach_test' happens to have a deleted document named 'propertytest'.
+    // Make sure the puller doesn't add it to an empty database:
+    NSURL* remoteURL = [self remoteTestDBURL: @"attach_test"];
+    if (!remoteURL)
+        return;
+    id lastSeq = replic8(db, remoteURL, NO, nil, nil, nil);
+    AssertEqual(lastSeq, @7);
+    // Ensure we didn't pull the deleted document 'propertytest':
+    CBL_RevisionList* revs = [db.storage getAllRevisionsOfDocumentID: @"propertytest" onlyCurrent: NO];
+    AssertEq(revs.count, 0u);
+}
+
+- (void) test21_PullNotActiveOnly {
+    // If database _isn't_ empty, the puller won't use the active_only optimization:
+    [self createDocuments: 1];
+
+    NSURL* remoteURL = [self remoteTestDBURL: @"attach_test"];
+    if (!remoteURL)
+        return;
+    id lastSeq = replic8(db, remoteURL, NO, nil, nil, nil);
+    AssertEqual(lastSeq, @7);
+    // Verify we did pull the deleted document 'propertytest':
+    CBL_RevisionList* revs = [db.storage getAllRevisionsOfDocumentID: @"propertytest" onlyCurrent: NO];
+    Assert(revs);
+    Assert(revs[0].deleted);
 }
 
 


### PR DESCRIPTION
Added two unit tests to make sure that deleted docs aren't pulled if the
db is empty, and are pulled if it isn't.

Fixes #1078