### PR TITLE
Improve multipart reading performance using a cyclic buffer

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -959,6 +959,10 @@
 		DA147C3C14BCAC780052DA4D /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA147C3A14BCAC780052DA4D /* MobileCoreServices.framework */; };
 		DA147C3D14BCAC780052DA4D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA147C3B14BCAC780052DA4D /* Security.framework */; };
 		DA147C3E14BCAC9D0052DA4D /* CBLListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 275315DE14ACF0A20065964D /* CBLListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE08015B1C847912005BAD7D /* CBLMultipartBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0801591C847912005BAD7D /* CBLMultipartBuffer.h */; };
+		EE0801681C847921005BAD7D /* CBLMultipartBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0801591C847912005BAD7D /* CBLMultipartBuffer.h */; };
+		EE0801691C847927005BAD7D /* CBLMultipartBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = EE08015A1C847912005BAD7D /* CBLMultipartBuffer.m */; };
+		EE08016A1C847928005BAD7D /* CBLMultipartBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = EE08015A1C847912005BAD7D /* CBLMultipartBuffer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1985,6 +1989,8 @@
 		DA147C3614BCAC3B0052DA4D /* CouchbaseLiteListener.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CouchbaseLiteListener.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA147C3A14BCAC780052DA4D /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.0.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
 		DA147C3B14BCAC780052DA4D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		EE0801591C847912005BAD7D /* CBLMultipartBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLMultipartBuffer.h; sourceTree = "<group>"; };
+		EE08015A1C847912005BAD7D /* CBLMultipartBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLMultipartBuffer.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2889,6 +2895,8 @@
 			children = (
 				279CE3FE14D749A7009F3FA6 /* CBLMultipartReader.h */,
 				279CE3FF14D749A7009F3FA6 /* CBLMultipartReader.m */,
+				EE0801591C847912005BAD7D /* CBLMultipartBuffer.h */,
+				EE08015A1C847912005BAD7D /* CBLMultipartBuffer.m */,
 				2766EFFB14DC7B37009ECCA8 /* CBLMultiStreamWriter.h */,
 				2766EFFC14DC7B37009ECCA8 /* CBLMultiStreamWriter.m */,
 				2766EFF614DB7F9F009ECCA8 /* CBLMultipartWriter.h */,
@@ -3296,6 +3304,7 @@
 				2701C1B31C4D5BDD006D7A99 /* CBLChangeMatcher.h in Headers */,
 				2701C1B41C4D5BDD006D7A99 /* CBLRestReplicator.h in Headers */,
 				2701C1B51C4D5BDD006D7A99 /* CBLView+Internal.h in Headers */,
+				EE0801681C847921005BAD7D /* CBLMultipartBuffer.h in Headers */,
 				2701C1B61C4D5BDD006D7A99 /* CBLSpecialKey.h in Headers */,
 				2701C1B71C4D5BDD006D7A99 /* CBL_SQLiteViewStorage.h in Headers */,
 				2701C1B81C4D5BDD006D7A99 /* DDRange.h in Headers */,
@@ -3451,6 +3460,7 @@
 				2764D2B81A5F054D005AC95A /* CBLChangeMatcher.h in Headers */,
 				27B0865E1B387C3900D3D9D8 /* CBLRestReplicator.h in Headers */,
 				279EB2CE149140DE00E74185 /* CBLView+Internal.h in Headers */,
+				EE08015B1C847912005BAD7D /* CBLMultipartBuffer.h in Headers */,
 				2726D14518FDF44000AACC2A /* CBLSpecialKey.h in Headers */,
 				27513A601A697CC80055DC40 /* CBL_SQLiteViewStorage.h in Headers */,
 				2753157614ACEFC90065964D /* DDRange.h in Headers */,
@@ -4583,6 +4593,7 @@
 				2701C0451C49CFE6006D7A99 /* CBLDatabase+Replication.m in Sources */,
 				2701C0461C49CFE6006D7A99 /* CBLMisc.m in Sources */,
 				2701C0471C49CFE6006D7A99 /* CBLMultipartReader.m in Sources */,
+				EE0801691C847927005BAD7D /* CBLMultipartBuffer.m in Sources */,
 				2701C0481C49CFE6006D7A99 /* CBLMultipartDownloader.m in Sources */,
 				2701C0491C49CFE6006D7A99 /* CBLMultipartWriter.m in Sources */,
 				2701C04A1C49CFE6006D7A99 /* CBLMultiStreamWriter.m in Sources */,
@@ -4940,6 +4951,7 @@
 				27E347721999502400076EAC /* Test_Assertions.m in Sources */,
 				279CE3BA14D4A886009F3FA6 /* MYBlockUtils.m in Sources */,
 				27D90B1915601C350000735E /* MYErrorUtils.m in Sources */,
+				EE08016A1C847928005BAD7D /* CBLMultipartBuffer.m in Sources */,
 				278E4DDA1562B40B00DDCEF9 /* MYURLUtils.m in Sources */,
 				27E721721BB4A08F001500DF /* CBLRestReplicator+Backgrounding.m in Sources */,
 				27DA435215918C0200F9E7B5 /* MYDynamicObject.m in Sources */,

--- a/Source/CBLMultipartBuffer.h
+++ b/Source/CBLMultipartBuffer.h
@@ -41,7 +41,10 @@
 /** An mutable reference the buffers bytes */
 - (void *)mutableBytes;
 
-/** A NSData copy of the buffer */
+/** A NSData copy of the available bytes in the buffer or nil if there are no available bytes */
 - (NSData *)data;
+
+/** A NSData copy of the available bytes with the given range or nil if there are no available bytes */
+- (NSData *)subdataWithRange:(NSRange)range;
 
 @end

--- a/Source/CBLMultipartBuffer.h
+++ b/Source/CBLMultipartBuffer.h
@@ -1,0 +1,47 @@
+//
+//  CBLMultipartBuffer.h
+//  CouchbaseLite
+//
+//  Created by Robert Payne on 1/03/16.
+//  Copyright © 2016 Couchbase, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/** Streaming MIME multipart parsing buffer  */
+@interface CBLMultipartBuffer : NSObject
+
+/** The current offset of the buffer in bytes */
+@property (nonatomic, assign) NSUInteger offset;
+
+/** The amount of bytes the buffer must be offset of before a compaction can happen */
+@property (nonatomic, assign) NSUInteger compactionLength;
+
+/** Whether or not the buffer has bytes available */
+- (BOOL)hasBytesAvailable;
+
+/** The number of bytes the buffer has available */
+- (NSUInteger)bytesAvailable;
+
+/** Append more data to the buffer */
+- (void)appendData:(NSData *)data;
+
+/** Append raw bytes to the buffer */
+- (void)appendBytes:(const void *)bytes length:(NSUInteger)length;
+
+/** Compact the buffer, if the buffer's offset >= compactionLength the offset will be reset to offset - compactionLength and bytes removed */
+- (void)compact;
+
+/** Resets the buffer to zero bytes, zero offset */
+- (void)reset;
+
+/** An unmutable reference the buffers bytes */
+- (const void *)bytes;
+
+/** An mutable reference the buffers bytes */
+- (void *)mutableBytes;
+
+/** A NSData copy of the buffer */
+- (NSData *)data;
+
+@end

--- a/Source/CBLMultipartBuffer.h
+++ b/Source/CBLMultipartBuffer.h
@@ -11,11 +11,11 @@
 /** Streaming MIME multipart parsing buffer  */
 @interface CBLMultipartBuffer : NSObject
 
-/** The current offset of the buffer in bytes */
-@property (nonatomic, assign) NSUInteger offset;
-
 /** The amount of bytes the buffer must be offset of before a compaction can happen */
 @property (nonatomic, assign) NSUInteger compactionLength;
+
+/** Advances the offset of the bytes pointers, will return NO if there is not enough memory left to advance */
+- (BOOL)advance:(NSUInteger)amount;
 
 /** Whether or not the buffer has bytes available */
 - (BOOL)hasBytesAvailable;

--- a/Source/CBLMultipartBuffer.m
+++ b/Source/CBLMultipartBuffer.m
@@ -32,7 +32,7 @@
 #pragma mark - Actions
 
 - (BOOL)advance:(NSUInteger)amount {
-    if (_offset + amount <= _data.length) {
+    if (_offset + amount >= _data.length) {
         Warn(@"Preventing unsafe buffer overflow", nil);
         return NO;
     }

--- a/Source/CBLMultipartBuffer.m
+++ b/Source/CBLMultipartBuffer.m
@@ -1,0 +1,70 @@
+//
+//  CBLMultipartBuffer.m
+//  CouchbaseLite
+//
+//  Created by Robert Payne on 1/03/16.
+//  Copyright © 2016 Couchbase, Inc. All rights reserved.
+//
+
+#import "CBLMultipartBuffer.h"
+
+@interface CBLMultipartBuffer() {
+    NSMutableData *_data;
+}
+
+@end
+@implementation CBLMultipartBuffer
+
+@synthesize offset=_offset, compactionLength=_compactionLength;
+
+#pragma mark - Initialization
+
+- (instancetype)init {
+    if((self = [super init])) {
+        _data = [NSMutableData dataWithCapacity:1024];
+        _offset = 0;
+        _compactionLength = 4096;
+    }
+    return self;
+}
+
+#pragma mark - Actions
+
+- (BOOL)hasBytesAvailable {
+    return _data.length > _offset;
+}
+- (NSUInteger)bytesAvailable {
+    if(_data.length > _offset) {
+        return _data.length - _offset;
+    }
+    return 0;
+}
+- (void)appendData:(NSData *)data {
+    [_data appendData:data];
+}
+- (void)appendBytes:(const void *)bytes length:(NSUInteger)length {
+    [_data appendBytes:bytes length:length];
+}
+- (void)compact {
+    if(_offset > _compactionLength && _offset > (_data.length >> 1)) {
+        _data = [NSMutableData dataWithBytes:(char *)_data.bytes + _offset
+                                      length:_data.length - _offset];
+        _offset = 0;
+    }
+}
+- (void)reset {
+    _offset = 0;
+    _data.length = 0;
+}
+- (const void *)bytes {
+    return _data.bytes + _offset;
+}
+- (void *)mutableBytes {
+    return _data.mutableBytes + _offset;
+}
+- (NSData *)data {
+    return [_data copy];
+}
+
+
+@end

--- a/Source/CBLMultipartBuffer.m
+++ b/Source/CBLMultipartBuffer.m
@@ -75,7 +75,7 @@
     if (!self.hasBytesAvailable) {
         return nil;
     }
-    return [[NSData dataWithBytes:self.bytes length:self.bytesAvailable freeWhenDone:NO] subdataWithRange:range];
+    return [[NSData dataWithBytesNoCopy:self.mutableBytes length:self.bytesAvailable freeWhenDone:NO] subdataWithRange:range];
 }
 
 @end

--- a/Source/CBLMultipartBuffer.m
+++ b/Source/CBLMultipartBuffer.m
@@ -8,13 +8,10 @@
 
 #import "CBLMultipartBuffer.h"
 
-@interface CBLMultipartBuffer() {
+@implementation CBLMultipartBuffer {
     NSMutableData *_data;
     NSUInteger _offset;
 }
-
-@end
-@implementation CBLMultipartBuffer
 
 @synthesize compactionLength=_compactionLength;
 
@@ -33,7 +30,7 @@
 
 - (BOOL)advance:(NSUInteger)amount {
     if (_offset + amount >= _data.length) {
-        Warn(@"Preventing unsafe buffer overflow", nil);
+        Warn(@"Preventing unsafe buffer overflow");
         return NO;
     }
     _offset += amount;
@@ -43,10 +40,7 @@
     return _data.length > _offset;
 }
 - (NSUInteger)bytesAvailable {
-    if(_data.length > _offset) {
-        return _data.length - _offset;
-    }
-    return 0;
+    return _data.length - _offset;
 }
 - (void)appendData:(NSData *)data {
     [_data appendData:data];
@@ -72,8 +66,16 @@
     return _data.mutableBytes + _offset;
 }
 - (NSData *)data {
-    return [_data copy];
+    if (!self.hasBytesAvailable) {
+        return nil;
+    }
+    return [NSData dataWithBytes:self.bytes length:self.bytesAvailable];
 }
-
+- (NSData *)subdataWithRange:(NSRange)range {
+    if (!self.hasBytesAvailable) {
+        return nil;
+    }
+    return [[NSData dataWithBytes:self.bytes length:self.bytesAvailable freeWhenDone:NO] subdataWithRange:range];
+}
 
 @end

--- a/Source/CBLMultipartBuffer.m
+++ b/Source/CBLMultipartBuffer.m
@@ -10,12 +10,13 @@
 
 @interface CBLMultipartBuffer() {
     NSMutableData *_data;
+    NSUInteger _offset;
 }
 
 @end
 @implementation CBLMultipartBuffer
 
-@synthesize offset=_offset, compactionLength=_compactionLength;
+@synthesize compactionLength=_compactionLength;
 
 #pragma mark - Initialization
 
@@ -30,6 +31,14 @@
 
 #pragma mark - Actions
 
+- (BOOL)advance:(NSUInteger)amount {
+    if (_offset + amount <= _data.length) {
+        Warn(@"Preventing unsafe buffer overflow", nil);
+        return NO;
+    }
+    _offset += amount;
+    return YES;
+}
 - (BOOL)hasBytesAvailable {
     return _data.length > _offset;
 }

--- a/Source/CBLMultipartReader.h
+++ b/Source/CBLMultipartReader.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+@class CBLMultipartBuffer;
 @protocol CBLMultipartReaderDelegate;
 
 
@@ -16,7 +17,7 @@
     @private
     __weak id<CBLMultipartReaderDelegate> _delegate;
     NSData* _boundary;
-    NSMutableData* _buffer;
+    CBLMultipartBuffer* _buffer;
     NSMutableDictionary* _headers;
     int _state;
     NSString* _error;

--- a/Source/CBLMultipartReader.m
+++ b/Source/CBLMultipartReader.m
@@ -16,6 +16,7 @@
 //  http://tools.ietf.org/html/rfc2046#section-5.1
 
 #import "CBLMultipartReader.h"
+#import "CBLMultipartBuffer.h"
 
 #import "CollectionUtils.h"
 #import "Test.h"
@@ -63,7 +64,7 @@ static NSData* kCRLFCRLF;
             return nil;
         }
         _delegate = delegate;
-        _buffer = [[NSMutableData alloc] initWithCapacity: 1024];
+        _buffer = [[CBLMultipartBuffer alloc] init];
         _state = kAtStart;
     }
     return self;
@@ -137,22 +138,26 @@ static NSData* kCRLFCRLF;
 
 
 - (NSRange) searchFor: (NSData*)pattern from: (NSUInteger)start {
-    return [_buffer rangeOfData: pattern
+    if (!_buffer.hasBytesAvailable)
+        return NSMakeRange(NSNotFound, 0);
+    NSData *data = [NSData dataWithBytesNoCopy:_buffer.mutableBytes length:_buffer.bytesAvailable freeWhenDone:NO];
+    return [data rangeOfData: pattern
                         options: 0
-                          range: NSMakeRange(start, _buffer.length-start)];
+                          range: NSMakeRange(start, data.length-start)];
 }
 
 - (void) deleteUpThrough: (NSRange)r {
-    [_buffer replaceBytesInRange: NSMakeRange(0, NSMaxRange(r)) withBytes: NULL length: 0];
+    _buffer.offset += NSMaxRange(r);
 }
 
 - (BOOL) appendAndTrimBuffer {
-    NSUInteger bufLen = _buffer.length;
+    NSUInteger bufLen = _buffer.bytesAvailable;
     NSUInteger boundaryLen = _boundary.length;
     if (bufLen > boundaryLen) {
         // Leave enough bytes in _buffer that we can find an incomplete boundary string
         NSRange trim = NSMakeRange(0, bufLen - boundaryLen);
-        if (![_delegate appendToPart: [_buffer subdataWithRange: trim]])
+        NSData *data = [NSData dataWithBytesNoCopy:_buffer.mutableBytes length:_buffer.bytesAvailable freeWhenDone:NO];
+        if (![_delegate appendToPart: [data subdataWithRange: trim]])
             return NO;
         [self deleteUpThrough: trim];
     }
@@ -187,7 +192,7 @@ static NSData* kCRLFCRLF;
     int nextState;
     do {
         nextState = -1;
-        NSUInteger bufLen = _buffer.length;
+        NSUInteger bufLen = _buffer.bytesAvailable;
         id<CBLMultipartReaderDelegate> delegate = _delegate;
         switch (_state) {
             case kAtStart: {
@@ -195,8 +200,7 @@ static NSData* kCRLFCRLF;
                 NSUInteger testLen = _boundary.length - 2;
                 if (bufLen >= testLen) {
                     if (memcmp(_buffer.bytes, _boundary.bytes + 2, testLen) == 0) {
-                        [_buffer replaceBytesInRange: NSMakeRange(0, testLen)
-                                           withBytes: NULL length: 0];
+                        _buffer.offset += testLen;
                         nextState = kInHeaders;
                     } else {
                         nextState = kInPrologue;
@@ -215,7 +219,8 @@ static NSData* kCRLFCRLF;
                 if (r.length > 0) {
                     if (_state == kInBody) {
                         __unused id retainSelf = self;
-                        if (![delegate appendToPart: [_buffer subdataWithRange: NSMakeRange(0, r.location)]]
+                        NSData *data = [NSData dataWithBytesNoCopy:_buffer.mutableBytes length:_buffer.bytesAvailable freeWhenDone:NO];
+                        if (![delegate appendToPart: [data subdataWithRange: NSMakeRange(0, r.location)]]
                                 || ![delegate finishedPart]) {
                             [self stop];
                             break;
@@ -265,7 +270,8 @@ static NSData* kCRLFCRLF;
         }
         if (nextState > 0)
             _state = nextState;
-    } while (nextState >= 0 && _buffer.length > 0);
+    } while (nextState >= 0 && _buffer.hasBytesAvailable);
+    [_buffer compact];
 }
 
 

--- a/Source/CBLMultipartReader.m
+++ b/Source/CBLMultipartReader.m
@@ -147,7 +147,7 @@ static NSData* kCRLFCRLF;
 }
 
 - (void) deleteUpThrough: (NSRange)r {
-    _buffer.offset += NSMaxRange(r);
+    [_buffer advance:NSMaxRange(r)];
 }
 
 - (BOOL) appendAndTrimBuffer {
@@ -200,7 +200,7 @@ static NSData* kCRLFCRLF;
                 NSUInteger testLen = _boundary.length - 2;
                 if (bufLen >= testLen) {
                     if (memcmp(_buffer.bytes, _boundary.bytes + 2, testLen) == 0) {
-                        _buffer.offset += testLen;
+                        [_buffer advance:testLen];
                         nextState = kInHeaders;
                     } else {
                         nextState = kInPrologue;

--- a/Source/CBLMultipartReader.m
+++ b/Source/CBLMultipartReader.m
@@ -156,8 +156,7 @@ static NSData* kCRLFCRLF;
     if (bufLen > boundaryLen) {
         // Leave enough bytes in _buffer that we can find an incomplete boundary string
         NSRange trim = NSMakeRange(0, bufLen - boundaryLen);
-        NSData *data = [NSData dataWithBytesNoCopy:_buffer.mutableBytes length:_buffer.bytesAvailable freeWhenDone:NO];
-        if (![_delegate appendToPart: [data subdataWithRange: trim]])
+        if (![_delegate appendToPart: [_buffer subdataWithRange: trim]])
             return NO;
         [self deleteUpThrough: trim];
     }
@@ -219,8 +218,7 @@ static NSData* kCRLFCRLF;
                 if (r.length > 0) {
                     if (_state == kInBody) {
                         __unused id retainSelf = self;
-                        NSData *data = [NSData dataWithBytesNoCopy:_buffer.mutableBytes length:_buffer.bytesAvailable freeWhenDone:NO];
-                        if (![delegate appendToPart: [data subdataWithRange: NSMakeRange(0, r.location)]]
+                        if (![delegate appendToPart: [_buffer subdataWithRange: NSMakeRange(0, r.location)]]
                                 || ![delegate finishedPart]) {
                             [self stop];
                             break;


### PR DESCRIPTION
The CBLMultipartReader is somewhat slow parsing on older devices. This is almost entirely caused by the `[CBLMultipartReader deleteUpThrough:]` API, mostly because this particular NSMutableData API is very slow though even a realloc here wouldn't be that great.

This slowness is easily observable on an older device ( iPhone 4S in my case ) with instruments time profiler.

This PR addresses this by bringing in a more cyclic style buffer that appends data and maintains a offset/bytes pointer and finally compacts itself once it's past a certain amount of data.

This change makes most of the memory operations inside the `CBLMutlipartReader` negligible.