### PR TITLE
Moved customHTTPHeaders initialization to the common initializer

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -166,13 +166,9 @@ static CBLManager* sInstance;
 
 - (instancetype) init {
     NSError* error;
-    self = [self initWithDirectory: [[self class] defaultDirectory]
+    return [self initWithDirectory: [[self class] defaultDirectory]
                            options: NULL
                              error: &error];
-    if (self) {
-        _customHTTPHeaders = [NSMutableDictionary dictionary];
-    }
-    return self;
 }
 
 
@@ -239,6 +235,7 @@ static CBLManager* sInstance;
 {
     self = [super init];
     if (self) {
+        _customHTTPHeaders = [NSMutableDictionary dictionary];
         _dir = [directory copy];
         _options = options ? *options : kCBLManagerDefaultOptions;
         _shared = shared;


### PR DESCRIPTION
`customHTTPHeaders` was initialized in the `init` method but not by the public method `initWithDirectory:options:error:`. So it is legally possible to create an instance of `CBLManager` with a `nil` `customHTTPHeaders`.
To fix this, I moved `customHTTPHeaders` initialization to the custom initialization method.