### PR TITLE
Fixed #1140 _asyncTaskCount double decreased in CBLMultipartDownloader completion block

### DIFF
--- a/Source/CBLRestPuller.m
+++ b/Source/CBLRestPuller.m
@@ -442,6 +442,12 @@
             if (!strongSelf) return; // already dealloced
             // OK, now we've got the response:
             LogTo(SyncPerf, @"%@: Got %@", strongSelf, rev);
+            
+            // Remove the remote request first to prevent this block to be called second time
+            // when setting a permanent error to the error property. If that happens the
+            // _asyncTaskCount will be over-decreased and lead to an assertion failure (#1140).
+            [strongSelf removeRemoteRequest:dl];
+            
             if (error) {
                 if (isDocumentError(error)) {
                     // Revision is missing or not accessible:
@@ -459,7 +465,6 @@
             }
             
             // Note that we've finished this task:
-            [strongSelf removeRemoteRequest:dl];
             [strongSelf asyncTasksFinished:1];
             --strongSelf->_httpConnectionCount;
             // Start another task if there are still revisions waiting to be pulled:


### PR DESCRIPTION
- Remove the remote request from the list first to prevent this block to be called second time when setting a permanent error to the error property.

- As the implementation on 1.2 and dev branch are diverted. This is a double fix of the dev branch's aeae2ea8552d20d4085c9d4128dfa9f41e65446f commit.

#1140