### PR TITLE
SQLite: Prune deepest revisions when new ones are inserted

### DIFF
--- a/Unit-Tests/DatabaseInternal_Tests.m
+++ b/Unit-Tests/DatabaseInternal_Tests.m
@@ -1019,4 +1019,59 @@ static CBL_Revision* mkrev(NSString* revID) {
     [manualDB close: &error];
 }
 
+
+- (void) test29_autoPruneOnPut {    // Test #1165
+    db.maxRevTreeDepth = 5;
+
+    CBL_Revision* lastRev = nil;
+    NSMutableArray *revs = [NSMutableArray new];
+    for (int gen = 1; gen <= 10; gen++) {
+        CBL_MutableRevision* newRev = [CBL_MutableRevision revisionWithProperties: @{@"_id": @"foo",
+                                                                                     @"gen": @(gen)}];
+        CBLStatus status;
+        CBL_Revision* rev = [db putRevision: newRev prevRevisionID: lastRev.revID allowConflict: NO status: &status error: NULL];
+        Assert(rev, @"Failed to putRevision: %d", status);
+        [revs addObject: rev];
+        lastRev = rev;
+    }
+
+    // Verify that the first five revs are no longer available:
+    for (int gen = 1; gen <= 10; gen++) {
+        CBL_Revision* rev = [db getDocumentWithID: @"foo" revisionID: [revs[gen-1] revID]];
+        if (gen <= 5)
+            AssertNil(rev);
+        else
+            Assert(rev != nil);
+    }
+}
+
+
+- (void) test29_autoPruneOnForceInsert {    // Test #1165
+    db.maxRevTreeDepth = 5;
+
+    CBL_Revision* lastRev = nil;
+    NSMutableArray *revs = [NSMutableArray new];
+    NSMutableArray *history = [NSMutableArray new];
+    for (int gen = 1; gen <= 10; gen++) {
+        CBL_Revision* rev = [CBL_Revision revisionWithProperties: @{@"_id": @"foo",
+                                                                    @"_rev": $sprintf(@"%d-cafebabe", gen),
+                                                                    @"gen": @(gen)}];
+        CBLStatus status = [db forceInsert: rev revisionHistory: history source: nil error: NULL];
+        Assert(status == 201, @"Failed to forceInsert: %d", status);
+        [history insertObject: rev.revID atIndex: 0];
+        [revs addObject: rev];
+        lastRev = rev;
+    }
+
+    // Verify that the first five revs are no longer available:
+    for (int gen = 1; gen <= 10; gen++) {
+        CBL_Revision* rev = [db getDocumentWithID: @"foo" revisionID: [revs[gen-1] revID]];
+        if (gen <= 5)
+            AssertNil(rev);
+        else
+            Assert(rev != nil);
+    }
+}
+
+
 @end


### PR DESCRIPTION
This makes revision pruning incremental, the way it is in ForestDB. A document's revision tree will never get deeper than the database's maxRevTreeDepth.

The -compact method used to prune every doc in the database. This is still needed, _once_, for pre-existing databases that might have a lot of docs that need pruning. I've added a special key to the database's 'info' metadata to indicate that this bulk prune isn't needed; it's set after the prune, or when a new database is created.

Fixes #1165

CC: @borrrden , @hideki 