### PR TITLE
Fixed Listener not checking basic auth over SSL connections

### DIFF
--- a/Listener/CBLHTTPConnection.m
+++ b/Listener/CBLHTTPConnection.m
@@ -83,7 +83,7 @@ static void evaluate(SecTrustRef trust, SecTrustCallback callback) {
                                                    || result == kSecTrustResultInvalid);
             // kSecTrustResultInvalid means there's no TrustRef, i.e. no client cert. OK by default.
         }
-        _hasClientCert = ok;
+        _hasClientCert = (trustRef != nil) && ok;
         completionHandler(ok);
     });
 }

--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -239,7 +239,7 @@ UsingLogDomain(Sync);
         _gzip = nil;
     }
     LogTo(SyncPerf, @"%@ reached EOF after %.3f sec", self, CFAbsoluteTimeGetCurrent()-_startTime);
-    if (_mode == kContinuous) {
+    if (_mode == kContinuous || _error) {
         [self stop];
     } else if ([self endParsingData] >= 0) {
         // Successfully reached end.


### PR DESCRIPTION
Added a unit test for this case.
Also fixed a minor issue in CBLSocketChangeTracker that was causing it
to log a warning about unexpected EOF when it gets an HTTP error.

Fixes #1168