### PR TITLE
Gracefully handle missing attachments when pushing a document

### DIFF
--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -282,8 +282,7 @@ static UInt64 smallestLength(NSDictionary* attachment) {
                 }
                 NSData* data = decodeAttachments ? attachObj.content : attachObj.encodedContent;
                 if (!data) {
-                    Warn(@"Can't get binary data of attachment '%@' of %@", name, rev);
-                    *outStatus = kCBLStatusNotFound;
+                    *outStatus = kCBLStatusAttachmentNotFound;
                     return attachment;
                 }
                 expanded[@"data"] = [CBLBase64 encode: data];

--- a/Unit-Tests/P2P_Tests.m
+++ b/Unit-Tests/P2P_Tests.m
@@ -73,7 +73,7 @@ static UInt16 sPort = 60100;
 
     // Wait for listener to start:
     [self keyValueObservingExpectationForObject: listener keyPath: @"port" expectedValue: @(sPort)];
-    [listener start: NULL];
+    Assert([listener start: &error], @"Couldn't start listener: %@", error);
     [self waitForExpectationsWithTimeout: 5.0 handler: nil];
 }
 


### PR DESCRIPTION
With lazy attachment downloading, it's possible to have a document but
not have its attachments. That document might be pushed later, i.e. to
a different server, but the replicator would end up failing an assertion
due to the missing attachment.

This commit fixes the crash by detecting the missing attachment and
bailing out of the push. The document won't be pushed, but the checkpoint
won't be advanced past it, so it will be retried on subsequent
replications to that server, so if the attachment is later downloaded,
the doc will be pushed.

Fixes #1128