### PR TITLE
Improved CBLReachability (proxy handling, intermittent connections)

### DIFF
--- a/Source/CBLBlipReplicator.m
+++ b/Source/CBLBlipReplicator.m
@@ -210,7 +210,7 @@
 
     if (!_reachability && CBLIsOfflineError(_error)) {
         // Network seems to be offline, so start a reachability monitor so I can retry ASAP:
-        _reachability = [[CBLReachability alloc] initWithHostName: _settings.remote.host];
+        _reachability = [[CBLReachability alloc] initWithURL: _settings.remote];
         __weak CBLBlipReplicator* weakSelf = self;
         _reachability.onChange = ^{
             [weakSelf reachabilityChanged];

--- a/Source/CBLReachability.h
+++ b/Source/CBLReachability.h
@@ -25,7 +25,12 @@ typedef void (^CBLReachabilityOnChangeBlock)(void);
     "Reachable" means simply that the local IP stack has resolved the host's DNS name and knows how to route packets toward its IP address. It does NOT guarantee that you can successfully connect. Generally it just means that you have an Internet connection. */
 @interface CBLReachability : NSObject
 
-- (instancetype) initWithHostName: (NSString*)hostName;
+/** Tracks the reachability of the given URL. In general this just uses the URL's hostname,
+    but if the URL must be reached via a proxy, it will track reachability of a local network. */
+- (instancetype) initWithURL: (NSURL*)url;
+
+/** Tracks reachability of any network address, i.e. whether there is a network connection. */
+- (instancetype) init;
 
 @property (readonly, nonatomic) NSString* hostName;
 
@@ -54,5 +59,10 @@ typedef void (^CBLReachabilityOnChangeBlock)(void);
 
 /** If you set this, the block will be called whenever the reachability related properties change. */
 @property (copy) CBLReachabilityOnChangeBlock onChange;
+
+
+#if DEBUG
++ (void) setAlwaysAssumesProxy: (BOOL)alwaysAssumesProxy;   // For debugging
+#endif
 
 @end

--- a/Source/CBLReachability.m
+++ b/Source/CBLReachability.m
@@ -18,6 +18,9 @@
 #include <arpa/inet.h>
 
 
+DefineLogDomain(Reachability);
+
+
 static void ClientCallback(SCNetworkReachabilityRef target,
                            SCNetworkReachabilityFlags flags,
                            void *info);
@@ -38,21 +41,71 @@ static void ClientCallback(SCNetworkReachabilityRef target,
     dispatch_queue_t _queue;
     SCNetworkReachabilityFlags _reachabilityFlags;
     BOOL _reachabilityKnown;
+    BOOL _usingProxy;
     CBLReachabilityOnChangeBlock _onChange;
 }
 
 
-- (instancetype) initWithHostName: (NSString*)hostName {
+#if DEBUG
+static BOOL sAlwaysAssumeProxy = NO;
++ (void) setAlwaysAssumesProxy: (BOOL)alwaysAssumesProxy {
+    sAlwaysAssumeProxy = alwaysAssumesProxy;
+}
+#endif
+
+
+
++ (BOOL) usingProxyForURL: (NSURL*)url {
+    NSDictionary* settings = CFBridgingRelease(CFNetworkCopySystemProxySettings());
+    NSArray* proxies = CFBridgingRelease(CFNetworkCopyProxiesForURL((__bridge CFURLRef)url,
+                                                                    (__bridge CFDictionaryRef)settings));
+    for (NSDictionary* proxy in proxies) {
+        if (![proxy[(id)kCFProxyTypeKey] isEqual: (id)kCFProxyTypeNone])
+            return YES;
+    }
+#if DEBUG
+    return sAlwaysAssumeProxy;
+#endif
+    return NO;
+}
+
+
+- (instancetype) initWithReachabilityRef: (SCNetworkReachabilityRef)ref {
     self = [super init];
     if (self) {
-        if (!hostName.length)
-            hostName = @"localhost";
-        _hostName = [hostName copy];
-        _ref = SCNetworkReachabilityCreateWithName(NULL, [_hostName UTF8String]);
+        _ref = ref;
         SCNetworkReachabilityContext context = {0, (__bridge void *)(self)};
         if (!_ref || !SCNetworkReachabilitySetCallback(_ref, ClientCallback, &context)) {
             return nil;
         }
+    }
+    return self;
+}
+
+
+- (instancetype) init {
+    struct sockaddr_in addr = {sizeof(addr), AF_INET};  // IP address 0.0.0.0
+    SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithAddress(NULL,
+                                                                          (struct sockaddr*)&addr);
+    return [self initWithReachabilityRef: ref];
+}
+
+
+- (instancetype) initWithURL: (NSURL*)url {
+    NSString* hostName = url.host;
+    if (!hostName.length)
+        hostName = @"localhost";
+    // If network access requires a proxy, just track whether there is any network connection:
+    if ([[self class] usingProxyForURL: url]) {
+        self = [self init];
+        if (self)
+            _usingProxy = YES;
+    } else {
+        self = [self initWithReachabilityRef: SCNetworkReachabilityCreateWithName(NULL,
+                                                                          hostName.UTF8String)];
+    }
+    if (self) {
+        _hostName = [hostName copy];
     }
     return self;
 }
@@ -78,14 +131,20 @@ static void ClientCallback(SCNetworkReachabilityRef target,
 
 - (BOOL) started {
     // See whether status is already known:
-    if (SCNetworkReachabilityGetFlags(_ref, &_reachabilityFlags))
+    if (SCNetworkReachabilityGetFlags(_ref, &_reachabilityFlags)) {
         _reachabilityKnown = YES;
-    //Log(@"ReachabilityKnown=%d; flags=%04x", _reachabilityKnown, _reachabilityFlags);
+        LogTo(Reachability, @"%@: flags=%x; starting...", self, _reachabilityFlags);
+    } else {
+        LogTo(Reachability, @"%@: starting...", self);
+    }
     return YES;
 }
 
 
 - (void) stop {
+    _reachabilityKnown = NO;
+    if (_runLoop || _queue)
+        LogTo(Reachability, @"%@: stopped", self);
     if (_runLoop) {
         SCNetworkReachabilityUnscheduleFromRunLoop(_ref, _runLoop, kCFRunLoopCommonModes);
         CFRelease(_runLoop);
@@ -124,19 +183,24 @@ static void ClientCallback(SCNetworkReachabilityRef target,
 }
 
 - (NSString*) description {
-    return $sprintf(@"<%@>:%@", _hostName, self.status);
+    NSString* desc;
+    if (!_hostName)
+        desc = @"<(any)>";
+    else if (_usingProxy)
+        desc = $sprintf(@"<(proxy to)%@>", _hostName);
+    else
+        desc = $sprintf(@"<%@>", _hostName);
+    if (_reachabilityKnown)
+        desc = [desc stringByAppendingFormat: @":%@", self.status];
+    return desc;
 }
 
 
 - (BOOL) reachable {
-    // We want 'reachable' to be on, but not any of the flags that indicate that a network interface
-    // must first be brought online.
+    // We want 'reachable' flag to be on, but not if user intervention is required (like PPP login)
     return _reachabilityKnown
-        && (_reachabilityFlags & (kSCNetworkReachabilityFlagsReachable
-                                | kSCNetworkReachabilityFlagsConnectionRequired
-                                | kSCNetworkReachabilityFlagsConnectionAutomatic
-                                | kSCNetworkReachabilityFlagsInterventionRequired))
-                == kSCNetworkReachabilityFlagsReachable;
+        &&  (_reachabilityFlags & kSCNetworkReachabilityFlagsReachable)
+        && !(_reachabilityFlags & kSCNetworkReachabilityFlagsInterventionRequired);
 }
 
 - (BOOL) reachableByWiFi {
@@ -161,6 +225,7 @@ static void ClientCallback(SCNetworkReachabilityRef target,
     if (!_reachabilityKnown || flags != _reachabilityFlags) {
         self.reachabilityFlags = flags;
         self.reachabilityKnown = YES;
+        LogTo(Reachability, @"%@: flags <-- %x", self, flags);
         __typeof(_onChange) onChange = _onChange;
         if (onChange)
             onChange();

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -308,7 +308,7 @@
     } else {
         // Start reachability checks. (This creates another ref cycle, because
         // the block also retains a ref to self. Cycle is also broken in -stopped.)
-        _host = [[CBLReachability alloc] initWithHostName: _settings.remote.host];
+        _host = [[CBLReachability alloc] initWithURL: _settings.remote];
         
         __weak id weakSelf = self;
         _host.onChange = ^{


### PR DESCRIPTION
* Now takes a URL, not just a hostname.
* Supports checking for general network connectivity
* Now checks system proxy settings to see if a proxy is required to
  reach the given URL; if so, it switches to checking general
  network connectivity.
* Host is considered reachable even if the flags say 'ConnectionRequired'
  as long as the connection doesn't require user intervention.

Fixes #1005 (I think; don't have a proxied network to test with)