### PR TITLE
Speculative fixes for assertion failures caused by invalid JSON

### DIFF
--- a/Source/CBLRestPusher.m
+++ b/Source/CBLRestPusher.m
@@ -282,10 +282,14 @@
                 CBLStatus status;
                 CBL_Revision* loadedRev = [db revisionByLoadingBody: rev
                                                              status: &status];
+                if (loadedRev && !loadedRev.properties)
+                    status = kCBLStatusBadJSON;
                 if (status >= 300) {
-                    Warn(@"%@: Couldn't get local contents of %@", self, rev);
-                    [self revisionFailed];
-                    continue;
+                    Warn(@"%@: Couldn't get local contents of %@ (status=%d)", self, rev, status);
+                    if (status < 500)
+                        [self removePending: rev];
+                    else
+                        [self revisionFailed]; // db error, may be temporary
                 }
 
                 if ($castIf(NSNumber, loadedRev[@"_removed"]).boolValue) {

--- a/Source/CBL_Revision.m
+++ b/Source/CBL_Revision.m
@@ -215,6 +215,8 @@
 
 - (CBL_Revision*) revisionByAddingBasicMetadata {
     NSMutableDictionary* props = [self.properties mutableCopy];
+    if (!props)
+        return nil; // failed to parse
     props[@"_id"] = self.docID;
     props[@"_rev"] = self.revID;
     if (_deleted)
@@ -321,6 +323,8 @@
 
 - (void) setObject: (UU id)object forKeyedSubscript: (UU NSString*)key {
     NSMutableDictionary* nuProps = self.properties.mutableCopy;
+    if (!nuProps)
+        return; // failed to parse
     [nuProps setValue: object forKey: key];
     self.properties = nuProps;
 }
@@ -348,6 +352,8 @@
 - (BOOL) mutateAttachments: (NSDictionary*(^)(NSString*, NSDictionary*))block
 {
     NSDictionary* properties = self.properties;
+    if (!properties)
+        return NO; // failed to parse
     NSMutableDictionary* editedProperties = nil;
     NSDictionary* attachments = (id)properties.cbl_attachments;
     NSMutableDictionary* editedAttachments = nil;


### PR DESCRIPTION
In diagnosing @hermanccw's crash (#1179) I read through some code and found a few ways that invalid JSON data could trigger assertion failures. I still don't know exactly how the bad data could have happened, but these are worth fixing and should prevent it in the future.

Fixes #1179