### PR TITLE
Don't close view index while it's being enumerated

### DIFF
--- a/Source/CBLForestBridge.mm
+++ b/Source/CBLForestBridge.mm
@@ -195,6 +195,8 @@ CBLStatus err2status(C4Error c4err) {
                     return kCBLStatusBadID;
                 case kC4ErrorCorruptIndexData:
                     return kCBLStatusCorruptError;
+                case kC4ErrorIndexBusy:
+                    return kCBLStatusDBBusy;
                 case kC4ErrorAssertionFailed:
                     Assert(NO, @"Assertion failure in CBForest (check log)");
                     break;

--- a/Source/CBL_ForestDBViewStorage.mm
+++ b/Source/CBL_ForestDBViewStorage.mm
@@ -113,6 +113,11 @@ static inline NSString* viewNameToFileName(NSString* viewName) {
 }
 
 
+- (NSString*) description {
+    return [NSString stringWithFormat: @"%@[%@]", self.class, _name];
+}
+
+
 - (BOOL) setVersion: (NSString*)version {
     [self closeIndex];
     return YES;
@@ -201,19 +206,43 @@ static void onCompactCallback(void *context, bool compacting) {
 
 
 - (void) closeIndex {
-    [NSObject cancelPreviousPerformRequestsWithTarget: self selector: @selector(closeIndex)
+    CBLStatus status;
+    if (![self closeIndex: &status])
+        Warn(@"Couldn't close index of %@: status=%d", self, status);
+}
+
+
+- (BOOL) closeIndex: (CBLStatus*)outStatus {
+    [NSObject cancelPreviousPerformRequestsWithTarget: self selector: @selector(closeIndexNow)
                                                object: nil];
     if (_view) {
         LogTo(View, @"%@: Closing index", self);
-        c4view_close(_view, NULL);
+        C4Error c4err;
+        if (!c4view_close(_view, &c4err)) {
+            *outStatus = err2status(c4err);
+            return NO;
+        }
         _view = NULL;
+    }
+    return YES;
+}
+
+- (void) closeIndexNow {
+    CBLStatus status;
+    if (![self closeIndex: &status]) {
+        if (status == kCBLStatusDBBusy) {
+            LogTo(View, @"%@: ...index is busy, will retry", self);
+            [self closeIndexSoon];      // Try again later if the index is currently busy
+        } else {
+            Warn(@"Couldn't close index of idle view %@: status=%d", self, status);
+        }
     }
 }
 
 - (void) closeIndexSoon {
-    [NSObject cancelPreviousPerformRequestsWithTarget: self selector: @selector(closeIndex)
+    [NSObject cancelPreviousPerformRequestsWithTarget: self selector: @selector(closeIndexNow)
                                                object: nil];
-    [self performSelector: @selector(closeIndex) withObject: nil afterDelay: kCloseDelay];
+    [self performSelector: @selector(closeIndexNow) withObject: nil afterDelay: kCloseDelay];
 }
 
 


### PR DESCRIPTION
If the index is being auto-closed for being idle, it will just retry
the auto-close after another minute.
If the view itself is being closed, it'll log a warning that the
C4View couldn't close.

**NOTE:** This commit is dependent on a CBForest commit that's in [a PR being reviewed by Jim](https://github.com/couchbaselabs/cbforest/pull/72). Please review, but don't press the Merge button unless the other PR has been merged already. If it hasn't, just add a comment that you've reviewed, and I'll merge it when I get notified that Jim's merged the other one.