### PR TITLE
Added missing CBLDynamicObject.h header to CBL iOS target's Public headers…

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -962,6 +962,7 @@
 		93FFB4881C615629006CBE30 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93FFB4871C615629006CBE30 /* Security.framework */; };
 		AA1776BC1857AE4D00CB01A3 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA1776BB1857AE4D00CB01A3 /* CoreData.framework */; };
 		AA24F8E4184538AE0091D577 /* CBLDatabaseChange.h in Headers */ = {isa = PBXBuildFile; fileRef = 2776A62E16A9BCBC006FF199 /* CBLDatabaseChange.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6E5D39A1CB4457D00BC0598 /* CBLDynamicObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 270A3A821CAB1B3200EC3D99 /* CBLDynamicObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA023B4614BCA94C008184BB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27F0745C11CD50A600E9A2AB /* Foundation.framework */; };
 		DA147C0D14BCA98A0052DA4D /* CBLHTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 2753160B14ACFC2A0065964D /* CBLHTTPConnection.m */; };
 		DA147C0E14BCA98A0052DA4D /* CBLHTTPResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 27E11F0F14AD15940006B340 /* CBLHTTPResponse.m */; };
@@ -3777,6 +3778,7 @@
 				27DA43621592387400F9E7B5 /* CBLManager.h in Headers */,
 				27DA43631592387400F9E7B5 /* CBLDatabase.h in Headers */,
 				27DA43641592387400F9E7B5 /* CBLDocument.h in Headers */,
+				C6E5D39A1CB4457D00BC0598 /* CBLDynamicObject.h in Headers */,
 				27DA43651592387400F9E7B5 /* CBLRevision.h in Headers */,
 				27DA43661592387400F9E7B5 /* CBLView.h in Headers */,
 				934744EA1B2F975B00F6ADD4 /* CBLRegisterJSViewCompiler.h in Headers */,


### PR DESCRIPTION
Without this, the built CouchbaseLite.framework would display a CBLDynamicObject.h not found error when trying to build your project.