### PR TITLE
Added 'attachments:' parameter to -[CBLDocument putExistingRevision...]

### DIFF
--- a/Source/API/CBLDocument.h
+++ b/Source/API/CBLDocument.h
@@ -116,6 +116,9 @@ NS_ASSUME_NONNULL_BEGIN
     implementing some new kind of replicator that transfers revisions from another database.
     @param properties  The properties of the revision (_id and _rev will be ignored, but _deleted
                     and _attachments are recognized.)
+    @param attachments  A dictionary providing attachment bodies. The keys are the attachment
+                    names (matching the keys in the properties' `_attachments` dictionary) and
+                    the values are the attachment bodies as NSData or NSURL.
     @param revIDs  The revision history in the form of an array of revision-ID strings, in
                     reverse chronological order. The first item must be the new revision's ID.
                     Following items are its parent's ID, etc.
@@ -124,7 +127,8 @@ NS_ASSUME_NONNULL_BEGIN
                     decide whether the change is local or not.)
     @param outError  Error information will be stored here if the insertion fails.
     @return  YES on success, NO on failure. */
-- (BOOL) putExistingRevisionWithProperties: (NSDictionary*)properties
+- (BOOL) putExistingRevisionWithProperties: (CBLJSONDict*)properties
+                               attachments: (nullable NSDictionary*)attachments
                            revisionHistory: (CBLArrayOf(NSString*)*)revIDs
                                    fromURL: (nullable NSURL*)sourceURL
                                      error: (NSError**)outError;

--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -315,7 +315,8 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
     return nil;
 }
 
-- (BOOL) putExistingRevisionWithProperties: (NSDictionary*)properties
+- (BOOL) putExistingRevisionWithProperties: (CBLJSONDict*)properties
+                               attachments: (NSDictionary*)attachments
                            revisionHistory: (NSArray*)revIDs
                                    fromURL: (NSURL*)sourceURL
                                      error: (NSError**)outError
@@ -325,6 +326,8 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
                                                                     revID: revIDs[0]
                                                                   deleted: properties.cbl_deleted];
     rev.properties = [self propertiesToInsert: properties];
+    if (![_database registerAttachmentBodies: attachments forRevision: rev error: outError])
+        return NO;
     CBLStatus status = [_database forceInsert: rev
                               revisionHistory: revIDs
                                        source: sourceURL

--- a/Source/CBLDatabase+Attachments.h
+++ b/Source/CBLDatabase+Attachments.h
@@ -24,6 +24,13 @@ typedef enum {
 
 + (NSString*) blobKeyToDigest: (CBLBlobKey)key;
 
+/** Register attachment bodies in `attachments` (NSData or file NSURLs) corresponding to the
+    attachments in `rev`. The _attachments dict will be mutated if necessary to add "digest"
+    and "follows" properties. */
+- (BOOL) registerAttachmentBodies: (NSDictionary*)attachments
+                      forRevision: (CBL_MutableRevision*)rev
+                            error: (NSError**)outError;
+
 /** Scans the rev's _attachments dictionary, adding inline attachment data to the blob-store
     and turning all the attachments into stubs. */
 - (BOOL) processAttachmentsForRevision: (CBL_MutableRevision*)rev

--- a/Source/CBLDatabase+Attachments.m
+++ b/Source/CBLDatabase+Attachments.m
@@ -236,6 +236,68 @@
 #pragma mark - UPDATING _attachments DICTS:
 
 
+- (BOOL) registerAttachmentBodies: (NSDictionary*)attachments
+                      forRevision: (CBL_MutableRevision*)rev
+                            error: (NSError**)outError
+{
+    __block BOOL ok = YES;
+    [rev mutateAttachments: ^NSDictionary *(NSString *name, NSDictionary *meta) {
+        id value = attachments[name];
+        if (value) {
+            @autoreleasepool {
+                NSData* data = $castIf(NSData, value);
+                if (!data) {
+                    NSURL* url = $castIf(NSURL, value);
+                    if (url.isFileURL) {
+                        data = [NSData dataWithContentsOfURL: url
+                                                     options: NSDataReadingMappedIfSafe
+                                                       error: outError];
+                    } else {
+                        Warn(@"attachments[\"%@\"] is neither NSData nor file NSURL", name);
+                        CBLStatusToOutNSError(kCBLStatusBadAttachment, outError);
+                    }
+                    if (!data) {
+                        ok = NO;
+                        return nil;
+                    }
+                }
+
+                // Register attachment body with database:
+                CBL_BlobStoreWriter* writer = self.attachmentWriter;
+                [writer appendData: data];
+                [writer finish];
+
+                // Make attachment mode "follows", indicating the data is registered:
+                NSMutableDictionary* nuMeta = [meta mutableCopy];
+                [nuMeta removeObjectForKey: @"data"];
+                [nuMeta removeObjectForKey: @"stub"];
+                nuMeta[@"follows"] = @YES;
+
+                // Add or verify metadata "digest" property:
+                NSString* digest = meta[@"digest"];
+                NSString* sha1Digest = writer.SHA1DigestString;
+                if (digest) {
+                    if (![digest isEqualToString: sha1Digest] &&
+                        ![digest isEqualToString: writer.MD5DigestString]) {
+                        Warn(@"Attachment '%@' body digest (%@) doesn't match 'digest' property %@",
+                             name, sha1Digest, digest);
+                        CBLStatusToOutNSError(kCBLStatusBadAttachment, outError);
+                        ok = NO;
+                        return nil;
+                    }
+                } else {
+                    nuMeta[@"digest"] = digest = sha1Digest;
+                }
+                [self rememberAttachmentWriter: writer forDigest: digest];
+                return nuMeta;
+            }
+        }
+        return meta;
+    }];
+    return ok;
+}
+
+
 static UInt64 smallestLength(NSDictionary* attachment) {
     UInt64 length = [attachment[@"length"] unsignedLongLongValue];
     NSNumber* encodedLength = attachment[@"encoded_length"];


### PR DESCRIPTION
Allows revisions with attachments to be added.

Fixes #1195