### PR TITLE
Allow incoming attachments with revpos:0, for PouchDB compatibility

### DIFF
--- a/Source/CBL_Attachment.m
+++ b/Source/CBL_Attachment.m
@@ -101,8 +101,13 @@ static NSString* blobKeyToDigest(CBLBlobKey key) {
             // Get the revpos:
             id revPosObj = attachInfo[@"revpos"];
             if (revPosObj) {
-                int revPos = [$castIf(NSNumber, revPosObj) intValue];
-                if (revPos <= 0) {
+                if (![revPosObj isKindOfClass: [NSNumber class]]) {
+                    *outStatus = kCBLStatusBadAttachment;
+                    return nil;
+                }
+                int revPos = [revPosObj intValue];
+                // PouchDB has a bug that generates "revpos":0; allow this (#1200)
+                if (revPos < 0) {
                     *outStatus = kCBLStatusBadAttachment;
                     return nil;
                 }

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -1023,6 +1023,24 @@
     Assert(!error);
     Assert(rev4);
     AssertEq([rev4.attachmentNames count], (NSUInteger)0);
+
+    // Add an attachment with revpos=0 (see #1200)
+    NSMutableDictionary* props = [rev3.properties mutableCopy];
+    NSMutableDictionary* atts = [props.cbl_attachments mutableCopy];
+    props[@"_attachments"] = atts;
+    atts[@"zero.txt"] = @{@"content_type": @"text/plain",
+                          @"revpos": @0,
+                          @"following": @YES};
+    BOOL ok = [doc putExistingRevisionWithProperties: props
+                                         attachments: @{@"zero.txt": [@"zero" dataUsingEncoding: NSUTF8StringEncoding]}
+                                     revisionHistory: @[@"3-0000", rev3.revisionID, rev.revisionID]
+                                             fromURL: nil
+                                               error: &error];
+    Assert(ok, @"Adding attachment with revpos=0 failed: %@", error);
+
+    CBLRevision* rev5 = [doc revisionWithID: @"3-0000"];
+    CBLAttachment* att = [rev5 attachmentNamed: @"zero.txt"];
+    Assert(att);
 }
 
 


### PR DESCRIPTION
Fixes #1200