### PR TITLE
Fixed: One-shot push from empty database never stops

### DIFF
--- a/Source/CBLRestPusher.m
+++ b/Source/CBLRestPusher.m
@@ -115,6 +115,13 @@
     CBL_RevisionList* unpushedRevisions = self.unpushedRevisions;
     if (!unpushedRevisions)
         return;
+    if (unpushedRevisions.count == 0 && !_settings.continuous) {
+        // Nothing to push, so stop. Use a delayed-perform, because various things like tests
+        // don't expect the replicator to stop during the call to -start, before any async
+        // activity occurs.
+        [self performSelector: @selector(stopped) withObject: nil afterDelay: 0.0];
+        return;
+    }
     [self addRevsToInbox: unpushedRevisions];
     [_batcher flush];  // process up to the first 100 revs
     

--- a/Unit-Tests/ReplicatorInternal_Tests.m
+++ b/Unit-Tests/ReplicatorInternal_Tests.m
@@ -79,6 +79,17 @@
 }
 
 
+- (void) test_00_Pusher_From_Empty {
+    NSURL* remoteURL = [self remoteTestDBURL: kScratchDBName];
+    if (!remoteURL)
+        return;
+    [self eraseRemoteDB: remoteURL];
+
+    id lastSeq = replic8(db, remoteURL, YES, nil, nil, nil);
+    AssertEqual(lastSeq, nil);
+}
+
+
 - (void) test_01_Pusher {
     RequireTestCase(CBLDatabase);
     __block int filterCalls = 0;
@@ -352,6 +363,7 @@
 
 - (void) test_09_Pusher_NonExistentServer {
     RequireTestCase(Pusher);
+    [self createDocuments: 1];
     NSURL* remoteURL = [NSURL URLWithString:@"https://mylocalhost/db"];
     if (!remoteURL) {
         Warn(@"Skipping test CBL_Pusher_NonExistentServer: invalid URL");
@@ -709,7 +721,6 @@
             expectError: (NSError*) expectError
 {
     CBL_ReplicatorSettings* settings = [[CBL_ReplicatorSettings alloc] initWithRemote: remote push: push];
-    settings.createTarget = push;
     settings.filterName = filter;
     settings.docIDs = docIDs;
     settings.authorizer = self.authorizer;


### PR DESCRIPTION
Weird edge case: the replicator never becomes active, so it didn't realize it should stop when it didn't find any work to do.

I had to take out the line that sets the `createTarget` property to reproduce the bug; that property causes the replicator to send a PUT request, so work actually happens and the bug isn't triggered. In fact we shouldn't have this line anymore, because that property is useless with Sync Gateway.

Fixes #1228