### PR TITLE
More accurate rev pruning in SQLite storage (fixes endless-merge bug)

### DIFF
--- a/Source/CBLDatabase+Insertion.m
+++ b/Source/CBLDatabase+Insertion.m
@@ -102,8 +102,8 @@ DefineLogDomain(Validation);
     __block NSString* docID = inDocID;
     __block CBL_RevID* prevRevID = inPrevRevID;
     BOOL deleting = !properties || properties.cbl_deleted;
-    LogTo(Database, @"PUT _id=%@, _rev=%@, _deleted=%d, allowConflict=%d",
-          docID, prevRevID, deleting, allowConflict);
+    LogTo(Database, @"%@ _id=%@, _rev=%@ (allowConflict=%d)",
+          (deleting ? @"DELETE" : @"PUT"), docID, prevRevID, allowConflict);
     if ((prevRevID && !docID) || (deleting && !docID)
             || (docID && ![CBLDatabase isValidDocumentID: docID])) {
         *outStatus = kCBLStatusBadID;
@@ -139,18 +139,14 @@ DefineLogDomain(Validation);
         };
     }
 
-    CBL_Revision* putRev = [_storage addDocID: inDocID
-                                    prevRevID: inPrevRevID
-                                   properties: properties
-                                     deleting: deleting
-                                allowConflict: allowConflict
-                              validationBlock: validationBlock
-                                       status: outStatus
-                                        error: outError];
-    if (putRev) {
-        LogTo(Database, @"--> created %@", putRev);
-    }
-    return putRev;
+    return [_storage addDocID: inDocID
+                    prevRevID: inPrevRevID
+                   properties: properties
+                     deleting: deleting
+                allowConflict: allowConflict
+              validationBlock: validationBlock
+                       status: outStatus
+                        error: outError];
 }
 
 
@@ -160,6 +156,7 @@ DefineLogDomain(Validation);
                    source: (NSURL*)source
                     error: (NSError**)outError
 {
+    LogTo(Database, @"INSERT %@, history[%lu]", inRev, (unsigned long)history.count);
     AssertContainsRevIDs(history);
     CBL_MutableRevision* rev = inRev.mutableCopy;
     rev.sequence = 0;

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -382,7 +382,8 @@ static BOOL sAutoCompact = YES;
 
 /** Posts a local NSNotification of a new revision of a document. */
 - (void) databaseStorageChanged:(CBLDatabaseChange *)change {
-    LogTo(Database, @"Added: %@", change.addedRevision);
+    LogTo(Database, @"---> Added: %@ as seq %lld",
+          change.addedRevision, change.addedRevision.sequence);
     if (!_changesToNotify)
         _changesToNotify = [[NSMutableArray alloc] init];
     [_changesToNotify addObject: change];
@@ -436,7 +437,7 @@ static BOOL sAutoCompact = YES;
                 else
                     [seqs appendFormat: @"%lld", seq];
             }
-            LogTo(Database, @"%@: Posting change notifications: seq %@", self, seqs);
+            LogVerbose(Database, @"%@: Posting change notifications: seq %@", self, seqs);
         }
         
         [self postPublicChangeNotification: changes];
@@ -475,8 +476,8 @@ static BOOL sAutoCompact = YES;
                     [echoedChanges addObject: change.copy]; // copied change is marked as echoed
             }
             if (echoedChanges.count > 0) {
-                LogTo(Database, @"%@: Notified of %u changes by %@",
-                      self, (unsigned)echoedChanges.count, senderDB);
+                LogVerbose(Database, @"%@: Notified of %u changes by %@",
+                           self, (unsigned)echoedChanges.count, senderDB);
                 [self doAsync: ^{
                     [self notifyChanges: echoedChanges];
                 }];

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -165,13 +165,14 @@ static void onCompactCallback(void *context, bool compacting) {
 
 
 - (BOOL) reopen: (NSError**)outError {
-    if (_encryptionKey)
-        LogTo(Database, @"Database is encrypted; setting CBForest encryption key");
     NSString* forestPath = [_directory stringByAppendingPathComponent: kDBFilename];
     C4DatabaseFlags flags = _readOnly ? kC4DB_ReadOnly : kC4DB_Create;
     if (_autoCompact)
         flags |= kC4DB_AutoCompact;
     C4EncryptionKey encKey = symmetricKey2Forest(_encryptionKey);
+
+    LogTo(Database, @"Open %@ with ForestDB (flags=%X%@)",
+          forestPath, flags, (_encryptionKey ? @", encryption key given" : nil));
 
     C4Error c4err;
     _forest = c4db_open(string2slice(forestPath), flags, &encKey, &c4err);


### PR DESCRIPTION
The quick-and-dirty pruning algorithm for SQLite wasn't good enough. It
would get rid of all non-leaf revisions of a branch, if there was a
much deeper branch as well. This could cause the parent of the short
branch's leaf to be added again if pulled by the replicator, which
effectively re-creates the conflict if the short branch ended in a
deletion.

The code now does the Right Thing by traversing the rev tree and
preserving all revisions that are within maxRevTreeDepth generations of
a leaf.

Unfortunately this is going to slow down insertions somewhat. It could
be optimized because there are some redundant fetches of revs being
done, but honestly I'd rather save the effort for ForestDB.

Fixes #1217