### PR TITLE
CBLRemoteRequest reads error from JSON body when it gets a 4xx/5xx status

### DIFF
--- a/Source/CBLRemoteRequest.h
+++ b/Source/CBLRemoteRequest.h
@@ -94,6 +94,8 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
 - (SecTrustRef) checkServerTrust:(NSURLAuthenticationChallenge*)challenge;
 - (NSURLRequest*) willSendRequest:(NSURLRequest *)request
                  redirectResponse:(NSURLResponse *)response;
+- (void) _didReceiveData:(NSData *)data;
+- (void) _didFinishLoading;
 
 #if DEBUG
 @property BOOL debugAlwaysTrust;    // For unit tests only!
@@ -105,10 +107,6 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
 /** A request that parses its response body as JSON.
     The parsed object will be returned as the first parameter of the completion block. */
 @interface CBLRemoteJSONRequest : CBLRemoteRequest
-{
-    @private
-    NSMutableData* _jsonBuffer;
-}
 @end
 
 

--- a/Source/CBLRemoteSession.m
+++ b/Source/CBLRemoteSession.m
@@ -261,7 +261,7 @@
 {
     [self requestForTask: dataTask do: ^(CBLRemoteRequest *request) {
         if (request.running)  // request might have just canceled itself
-            [request didReceiveData: data];
+            [request _didReceiveData: data];
     }];
 }
 
@@ -274,7 +274,7 @@
         if (error)
             [request didFailWithError: error];
         else
-            [request didFinishLoading];
+            [request _didFinishLoading];
     }];
     LogTo(RemoteRequest, @"CBLRemoteSession done with %@", _requestIDs[@(task.taskIdentifier)]);
     [self forgetTask: task];

--- a/Source/CBLStatus.m
+++ b/Source/CBLStatus.m
@@ -80,7 +80,7 @@ NSError* CBLStatusToNSErrorWithInfo( CBLStatus status, NSString *reason, NSURL* 
     reason = reason != nil ? reason : statusMessage;
     NSMutableDictionary* info = $mdict({NSURLErrorFailingURLErrorKey, url},
                                        {NSLocalizedFailureReasonErrorKey, reason},
-                                       {NSLocalizedDescriptionKey, $sprintf(@"%i %@", status, reason)});
+                                       {NSLocalizedDescriptionKey, reason});
     if (extraInfo)
         [info addEntriesFromDictionary: extraInfo];
     return [NSError errorWithDomain: CBLHTTPErrorDomain code: status userInfo: info];

--- a/Unit-Tests/DatabaseInternal_Tests.m
+++ b/Unit-Tests/DatabaseInternal_Tests.m
@@ -357,7 +357,7 @@ static CBL_Revision* revBySettingProperties(CBL_Revision* rev, NSDictionary* pro
     Assert(validationCalled);
     AssertEq(status, kCBLStatusForbidden);
     AssertEq(error.code, kCBLStatusForbidden);
-    AssertEqual(error.localizedDescription, @"403 Where's your towel?");
+    AssertEqual(error.localizedDescription, @"Where's your towel?");
 
 
     // POST an invalid new document:
@@ -371,7 +371,7 @@ static CBL_Revision* revBySettingProperties(CBL_Revision* rev, NSDictionary* pro
     Assert(validationCalled);
     AssertEq(status, kCBLStatusForbidden);
     AssertEq(error.code, kCBLStatusForbidden);
-    AssertEqual(error.localizedDescription, @"403 Where's your towel?");
+    AssertEqual(error.localizedDescription, @"Where's your towel?");
 
     // PUT a valid new document with an ID:
     props = $mdict({@"_id", @"ford"}, {@"name", @"Ford Prefect"}, {@"towel", @"terrycloth"});
@@ -409,7 +409,7 @@ static CBL_Revision* revBySettingProperties(CBL_Revision* rev, NSDictionary* pro
     Assert(validationCalled);
     AssertEq(status, kCBLStatusForbidden);
     AssertEq(error.code, kCBLStatusForbidden);
-    AssertEqual(error.localizedDescription, @"403 Where's your towel?");
+    AssertEqual(error.localizedDescription, @"Where's your towel?");
 }
 
 

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -531,7 +531,7 @@
     doc = [db createDocument];
     Assert(![doc putProperties: properties error: &error]);
     AssertEq(error.code, 403);
-    AssertEqual(error.localizedDescription, @"403 uncool");
+    AssertEqual(error.localizedDescription, @"uncool");
     AssertEqual(error.localizedFailureReason, @"uncool");
 }
 


### PR DESCRIPTION
- Moved the JSON buffer from CBLRemoteJSONRequest up to CBLRemoteRequest.
- Took the status code out of the error message created by
  CBLStatusToNSErrorWithInfo.
- Removed the createTarget setting from the replications run by
  ReplicatorInternal_Tests; it's not supported by SG so it just causes
  spurious 412 errors.

Fixes #1245