### PR TITLE
Fixed: doc._conflicts passed to map function may include wrong revID

### DIFF
--- a/Source/CBL_SQLiteViewStorage.m
+++ b/Source/CBL_SQLiteViewStorage.m
@@ -445,7 +445,9 @@
                         if (deleted || [oldRevID compare: revID] > 0) {
                             // It still 'wins' the conflict, so it's the one that
                             // should be mapped [again], not the current revision!
+                            CBL_RevID* temp = revID;
                             revID = oldRevID;
+                            oldRevID = temp;
                             deleted = NO;
                             sequence = oldSequence;
                             json = [fmdb dataForQuery: @"SELECT json FROM revs WHERE sequence=?",


### PR DESCRIPTION
When a new revision of a doc isn't the winner (i.e. it's on a shallower
branch), the view indexing code re-indexes the existing winning revision
instead. It should add the new losing revision to the _conflicts array,
but it was getting mixed up and adding the winning rev. Fixed.

Fixes #1252