### PR TITLE
Don't return an empty "_conflicts" array from REST API

### DIFF
--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -235,10 +235,9 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
 
 - (NSArray*) getLeafRevisions: (NSError**)outError includeDeleted: (BOOL)includeDeleted {
     CBL_RevisionList* revs = [_database.storage getAllRevisionsOfDocumentID: _docID
-                                                                onlyCurrent: YES];
+                                                                onlyCurrent: YES
+                                                             includeDeleted: includeDeleted];
     return [revs.allRevisions my_map: ^CBLSavedRevision*(CBL_Revision* rev) {
-        if (!includeDeleted && rev.deleted)
-            return nil;
         return [self revisionFromRev: rev];
     }];
 }

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -399,6 +399,7 @@ static CBLStatus selectRev(C4Document* doc, CBL_RevID* revID, BOOL withBody) {
 
 - (CBL_RevisionList*) getAllRevisionsOfDocumentID: (NSString*)docID
                                       onlyCurrent: (BOOL)onlyCurrent
+                                   includeDeleted: (BOOL)includeDeleted
 {
     CLEANUP(C4Document) *doc = [self getC4Doc: docID status: NULL];
     if (!doc)
@@ -407,6 +408,8 @@ static CBLStatus selectRev(C4Document* doc, CBL_RevID* revID, BOOL withBody) {
     CBL_RevisionList* revs = [[CBL_RevisionList alloc] init];
     do {
         if (onlyCurrent && !(doc->selectedRev.flags & kRevLeaf))
+            continue;
+        if (!includeDeleted && (doc->selectedRev.flags & kRevDeleted))
             continue;
         CBLStatus status;
         CBL_Revision *rev = [CBLForestBridge revisionObjectFromForestDoc: doc

--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -640,11 +640,10 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
             // ?open_revs=all returns all current/leaf revisions:
             BOOL includeDeleted = [self boolQuery: @"include_deleted"];
             CBL_RevisionList* allRevs = [_db.storage getAllRevisionsOfDocumentID: docID
-                                                                     onlyCurrent: YES];
+                                                                     onlyCurrent: YES
+                                                                  includeDeleted: includeDeleted];
             result = [NSMutableArray arrayWithCapacity: allRevs.count];
             for (CBL_Revision* rev in allRevs.allRevisions) {
-                if (!includeDeleted && rev.deleted)
-                    continue;
                 CBLStatus status;
                 CBL_Revision* loadedRev = [_db revisionByLoadingBody: rev status: &status];
                 if (loadedRev)
@@ -744,10 +743,11 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
         }
         if (options & kCBLIncludeConflicts) {
             CBL_RevisionList* revs = [storage getAllRevisionsOfDocumentID: rev.docID
-                                                                  onlyCurrent: YES];
+                                                              onlyCurrent: YES
+                                                           includeDeleted: NO];
             if (revs.count > 1) {
-                dst[@"_conflicts"] = [revs.allRevisions my_map: ^(CBL_Revision* aRev) {
-                    return ($equal(aRev, rev) || aRev.deleted) ? nil : aRev.revIDString;
+                dst[@"_conflicts"] =  [revs.allRevisions my_map: ^(CBL_Revision* aRev) {
+                    return $equal(aRev, rev) ? nil : aRev.revIDString;
                 }];
             }
         }

--- a/Source/CBL_Storage.h
+++ b/Source/CBL_Storage.h
@@ -117,7 +117,8 @@
     @param onlyCurrent  If YES, only leaf revisions (whether or not deleted) should be returned.
     @return  An array of all available revisions of the document. */
 - (CBL_RevisionList*) getAllRevisionsOfDocumentID: (NSString*)docID
-                                      onlyCurrent: (BOOL)onlyCurrent;
+                                      onlyCurrent: (BOOL)onlyCurrent
+                                   includeDeleted: (BOOL)includeDeleted;
 
 /** Returns IDs of local revisions of the same document, that have a lower generation number.
     If possible, returns only leaf revisions; if none match, returns non-leaves.

--- a/Unit-Tests/DatabaseInternal_Tests.m
+++ b/Unit-Tests/DatabaseInternal_Tests.m
@@ -512,7 +512,7 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
     AssertEqual(current, conflict);
 
     // Check that the list of conflicts is accurate:
-    CBL_RevisionList* conflictingRevs = [db.storage getAllRevisionsOfDocumentID: rev.docID onlyCurrent: YES];
+    CBL_RevisionList* conflictingRevs = [db.storage getAllRevisionsOfDocumentID: rev.docID onlyCurrent: YES includeDeleted: YES];
     AssertEqual(conflictingRevs.allRevisions, (@[conflict, rev]));
 
     // Get the _changes feed and verify only the winner is in it:
@@ -761,7 +761,7 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
     AssertEq([db.storage purgeRevisions: toPurge result: &result], kCBLStatusOK);
     AssertEqual(result, toPurge);
 
-    CBL_RevisionList* remainingRevs = [db.storage getAllRevisionsOfDocumentID: @"doc" onlyCurrent: NO];
+    CBL_RevisionList* remainingRevs = [db.storage getAllRevisionsOfDocumentID: @"doc" onlyCurrent: NO includeDeleted: YES];
     AssertEq(remainingRevs.count, 0u);
     [db _close];
 }
@@ -784,7 +784,7 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
     AssertEq([db.storage purgeRevisions: toPurge result: &result], kCBLStatusOK);
     AssertEqual(result, toPurge);
 
-    CBL_RevisionList* remainingRevs = [db.storage getAllRevisionsOfDocumentID: @"doc" onlyCurrent: NO];
+    CBL_RevisionList* remainingRevs = [db.storage getAllRevisionsOfDocumentID: @"doc" onlyCurrent: NO includeDeleted: YES];
     AssertEq(remainingRevs.count, 0u);
 }
 
@@ -1110,7 +1110,7 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
         Assert(longBranch);
     }
 
-    Log(@"All revisions = %@", [db.storage getAllRevisionsOfDocumentID: @"robin" onlyCurrent: NO]);
+    Log(@"All revisions = %@", [db.storage getAllRevisionsOfDocumentID: @"robin" onlyCurrent: NO includeDeleted: YES]);
 
     NSArray<CBLSavedRevision*>* all = [db[@"robin"] getConflictingRevisions: &error];
     Log(@"Conflicts = %@", all);
@@ -1133,7 +1133,7 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
                        status: &status error: &error];
     Assert(longBranch);
 
-    Log(@"After merge, all revisions = %@", [db.storage getAllRevisionsOfDocumentID: @"robin" onlyCurrent: NO]);
+    Log(@"After merge, all revisions = %@", [db.storage getAllRevisionsOfDocumentID: @"robin" onlyCurrent: NO includeDeleted: YES]);
     all = [db[@"robin"] getConflictingRevisions: &error];
     Log(@"After merge, conflicts = %@", all);
     AssertEq(all.count, 1u);

--- a/Unit-Tests/ReplicatorInternal_Tests.m
+++ b/Unit-Tests/ReplicatorInternal_Tests.m
@@ -704,7 +704,7 @@
     id lastSeq = replic8(db, remoteURL, NO, nil, nil, nil);
     AssertEqual(lastSeq, @7);
     // Ensure we didn't pull the deleted document 'propertytest':
-    CBL_RevisionList* revs = [db.storage getAllRevisionsOfDocumentID: @"propertytest" onlyCurrent: NO];
+    CBL_RevisionList* revs = [db.storage getAllRevisionsOfDocumentID: @"propertytest" onlyCurrent: NO includeDeleted: YES];
     AssertEq(revs.count, 0u);
 }
 
@@ -718,7 +718,7 @@
     id lastSeq = replic8(db, remoteURL, NO, nil, nil, nil);
     AssertEqual(lastSeq, @7);
     // Verify we did pull the deleted document 'propertytest':
-    CBL_RevisionList* revs = [db.storage getAllRevisionsOfDocumentID: @"propertytest" onlyCurrent: NO];
+    CBL_RevisionList* revs = [db.storage getAllRevisionsOfDocumentID: @"propertytest" onlyCurrent: NO includeDeleted: YES];
     Assert(revs);
     Assert(revs[0].deleted);
 }


### PR DESCRIPTION
In a document GET with ?conflicts=true, the code to find the conflicts
could filter out all the revisions and end up with an empty array, then
add the _conflicts property anyway.

Turns out most of the callers of -getAllRevisionsOfDocumentID: needed
to filter out deleted revisions, so I added an includeDeleted parameter.
This simplifies the callers a bit and saves some work, as well as
fixing this bug.

Fixes #1260