### PR TITLE
REST API for document expiration

### DIFF
--- a/Source/CBL_Router.h
+++ b/Source/CBL_Router.h
@@ -41,6 +41,7 @@ enum {
     kCBLIncludeRevs = 4,                     // adds '_revisions' property
     kCBLIncludeRevsInfo = 8,                 // adds '_revs_info' property
     kCBLIncludeLocalSeq = 16,                // adds '_local_seq' property
+    kCBLIncludeExpiration = 32               // adds '_exp' property
 };
 
 

--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -162,6 +162,8 @@ DefineLogDomain(Router);
         options |= kCBLIncludeRevs;
     if ([self boolQuery: @"revs_info"])
         options |= kCBLIncludeRevsInfo;
+    if ([self boolQuery: @"show_exp"])
+        options |= kCBLIncludeExpiration;
     return options;
 }
 


### PR DESCRIPTION
* In a PUT of a doc (or _bulk_docs), adding an _exp property sets the
  expiration date. Property value can be a number (Unix timestamp),
  string (ISO-8601), or JSON null. A 0 or null clears the expiration.
* To retrieve expiration date, add ?show_exp=true to the GET request,
  and the document body(ies) will contain an _exp property (with a
  string value) if the document has an expiration.

See https://github.com/couchbaselabs/couchbase-lite-api/issues/141