### PR TITLE
Disable App Transport Security for Mac OS X LiteServ

### DIFF
--- a/LiteServ App/LiteServ App-Info.plist
+++ b/LiteServ App/LiteServ App-Info.plist
@@ -30,14 +30,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>

--- a/LiteServ App/LiteServ App-Info.plist
+++ b/LiteServ App/LiteServ App-Info.plist
@@ -38,6 +38,8 @@
 				<true/>
 			</dict>
 		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2013-2016 Couchbase, Inc. All rights reserved.</string>


### PR DESCRIPTION
Fixes #1271 

This disables App Transport Security by default to enable testing against non-SSL enabled endpoints. I'm not sure about the ramifications for releasing this by default (i.e. Is anyone using Mac OSX LiteServ for anything in production?).