### PR TITLE
Fix local-to-local replication

### DIFF
--- a/Source/CBLRemoteSession.m
+++ b/Source/CBLRemoteSession.m
@@ -36,6 +36,12 @@
     config.HTTPShouldSetCookies = NO;
     config.URLCache = nil;
     config.HTTPAdditionalHeaders = @{@"User-Agent": [CBL_ReplicatorSettings userAgentHeader]};
+
+    // Register the router's NSURLProtocol. This allows the replicator to access local databases
+    // via their internalURLs.
+    Class cblURLProtocol = NSClassFromString(@"CBL_URLProtocol");
+    if (cblURLProtocol)
+        config.protocolClasses = @[cblURLProtocol];
     return config;
 }
 

--- a/Source/CBLStatus.h
+++ b/Source/CBLStatus.h
@@ -28,6 +28,8 @@ typedef enum {
     
     kCBLStatusServerError    = 500,
     kCBLStatusNotImplemented = 501,
+    kCBLStatusServiceUnavailable = 503,
+    kCBLStatusTimedOut       = 504,     // "Gateway Timeout"
 
     // Non-HTTP errors:
     kCBLStatusBadEncoding    = 490,

--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -1128,6 +1128,7 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
         // OPT: Should read this asynchronously
         NSMutableData* buffer = [NSMutableData dataWithLength: 32768];
         NSInteger bytesRead;
+        [bodyStream open];
         do {
             bytesRead = [bodyStream read: buffer.mutableBytes maxLength: buffer.length];
             if (bytesRead > 0) {
@@ -1135,6 +1136,7 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
                                                        length: bytesRead freeWhenDone: NO]];
             }
         } while (bytesRead > 0);
+        [bodyStream close];
         if (bytesRead < 0)
             return kCBLStatusBadAttachment;
         


### PR DESCRIPTION
Fixed a regression from the conversion to NSURLSession. The CBL_URLProtocol has to be explicitly registered with the session. This restores the ability of the replicator to reach URLs served by the router.

As part of this, fixed two other things:

* Fixed router errors when HTTP request has indeterminate length: CBLRouter had trouble reading the response body if it was in the form of an HTTPBodyStream instead of an HTTPBody. (#1045)
* Greatly improved error messages from _replicate and _active_tasks: If a one-shot replication fails, you now get full info in the response body, instead of just a "500 Internal Server Error" status.

Fixes #1292 (a functional-testing blocker)