### PR TITLE
Fix OIDC Authenticator not getting refresh token

### DIFF
--- a/Source/CBLOpenIDConnectAuthorizer.m
+++ b/Source/CBLOpenIDConnectAuthorizer.m
@@ -85,7 +85,7 @@ UsingLogDomain(Sync);
     else if (_authURL)
         path = [@"_oidc_callback?" stringByAppendingString: _authURL.query];
     else
-        path = @"_oidc_challenge";
+        path = @"_oidc_challenge?offline=true";
     return @[@"GET", path];
 }
 


### PR DESCRIPTION
Add offline=true to the GET _oidc_challenge request.

#1301