### PR TITLE
Fix OpenIDController+UIKit missing import UIKit

### DIFF
--- a/Source/API/Extras/OpenIDConnectUI/OpenIDController+UIKit.h
+++ b/Source/API/Extras/OpenIDConnectUI/OpenIDController+UIKit.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 Couchbase. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import "OpenIDController.h"
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Added `#import <UIKit/UIKit.h>` to OpenIDController+UIKit.h.

#1304