### PR TITLE
Patch OIDC unit tests

### DIFF
--- a/Unit-Tests/Replication_Tests.m
+++ b/Unit-Tests/Replication_Tests.m
@@ -1676,7 +1676,7 @@ static UInt8 sEncryptionIV[kCCBlockSizeAES128];
 
 
 - (NSError*) pullWithOIDCAuth: (id<CBLAuthenticator>)auth {
-    NSURL* remoteDbURL = [self remoteTestDBURL: @"openid_db"];
+    NSURL* remoteDbURL = [self remoteNonSSLTestDBURL: @"openid_db"];
     if (!remoteDbURL)
         return nil;
     CBLReplication* repl = [db createPullReplication: remoteDbURL];


### PR DESCRIPTION
The previous fix (9c4dfb81b418c88cfc97dbd3e37beeca89446cff) is missing the fix in pullWithOIDCAuth: method.