### PR TITLE
Fixed #1323 : attachment content length = 0 when pushing the document

### DIFF
--- a/Source/CBLMultipartWriter.m
+++ b/Source/CBLMultipartWriter.m
@@ -109,10 +109,14 @@
                                                              andLength: &contentLength];
     if (!contentStream)
         return kCBLStatusAttachmentNotFound;
+    
     uint64_t declaredLength = attachment.possiblyEncodedLength;
-    if (declaredLength != 0 && contentLength != declaredLength)
+    if (attachment.isEncrypted)
+        contentLength = declaredLength;
+    else if (declaredLength != 0 && contentLength != declaredLength)
         Warn(@"Attachment '%@' length mismatch; actually %llu, declared %llu",
              attachment.name, contentLength, declaredLength);
+    
     [self addStream: contentStream length: contentLength];
     return kCBLStatusOK;
 }

--- a/Source/CBLMultipartWriter.m
+++ b/Source/CBLMultipartWriter.m
@@ -111,7 +111,7 @@
         return kCBLStatusAttachmentNotFound;
     
     uint64_t declaredLength = attachment.possiblyEncodedLength;
-    if (attachment.isEncrypted)
+    if (contentLength == 0)
         contentLength = declaredLength;
     else if (declaredLength != 0 && contentLength != declaredLength)
         Warn(@"Attachment '%@' length mismatch; actually %llu, declared %llu",

--- a/Source/CBL_Attachment.h
+++ b/Source/CBL_Attachment.h
@@ -43,6 +43,8 @@
 @property (readonly, nonatomic) NSData* content;
 @property (readonly, nonatomic) NSURL* contentURL; // only if already stored in db blob-store
 
+@property (readonly, nonatomic) BOOL isEncrypted;
+
 @property (readonly) BOOL hasBlobKey;
 @property (readonly) BOOL isValid;
 

--- a/Source/CBL_Attachment.h
+++ b/Source/CBL_Attachment.h
@@ -43,8 +43,6 @@
 @property (readonly, nonatomic) NSData* content;
 @property (readonly, nonatomic) NSURL* contentURL; // only if already stored in db blob-store
 
-@property (readonly, nonatomic) BOOL isEncrypted;
-
 @property (readonly) BOOL hasBlobKey;
 @property (readonly) BOOL isValid;
 

--- a/Source/CBL_Attachment.m
+++ b/Source/CBL_Attachment.m
@@ -17,6 +17,7 @@
 #import "CBLBase64.h"
 #import "CBLDatabase+Internal.h"
 #import "CBL_BlobStore.h"
+#import "CBL_BlobStore+Internal.h"
 #import "CBLGZip.h"
 
 
@@ -259,6 +260,10 @@ static NSString* blobKeyToDigest(CBLBlobKey key) {
     if (!path || ![[NSFileManager defaultManager] fileExistsAtPath: path isDirectory: NULL])
         return nil;
     return [NSURL fileURLWithPath: path];
+}
+
+- (BOOL) isEncrypted {
+    return _database.attachmentStore.encryptionKey != nil;
 }
 
 

--- a/Source/CBL_Attachment.m
+++ b/Source/CBL_Attachment.m
@@ -262,9 +262,5 @@ static NSString* blobKeyToDigest(CBLBlobKey key) {
     return [NSURL fileURLWithPath: path];
 }
 
-- (BOOL) isEncrypted {
-    return _database.attachmentStore.encryptionKey != nil;
-}
-
 
 @end


### PR DESCRIPTION
The issue happens only when the database is encrypted. When the attachment is encrypted, the actual content length cannot be determined when getting the attachment stream.

The fixing is to use the declared length as the content length if the attachment is encrypted.

#1323