### PR TITLE
Added API to remove OpenID tokens from Keychain

### DIFF
--- a/Source/API/CBLAuthenticator.h
+++ b/Source/API/CBLAuthenticator.h
@@ -17,11 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
     This protocol is currently entirely opaque and not intended for applications to implement.
     The authenticator types are limited to those createable by factory methods. */
 @protocol CBLAuthenticator <NSObject>
-
-@optional
-/** The server user name that the authenticator has logged in as, if known. */
-@property (readonly) NSString* username;
-
 @end
 
 

--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -899,7 +899,7 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
         *outHeaders = $castIf(NSDictionary, remoteDict[@"headers"]);
     
     if (outAuthorizer) {
-        *outAuthorizer = nil;
+        id<CBLAuthorizer> authorizer = nil;
         NSDictionary* auth = $castIf(NSDictionary, remoteDict[@"auth"]);
         if (auth) {
             NSDictionary* oauth = $castIf(NSDictionary, auth[@"oauth"]);
@@ -911,20 +911,22 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
                 NSString* token = $castIf(NSString, oauth[@"token"]);
                 NSString* tokenSec = $castIf(NSString, oauth[@"token_secret"]);
                 NSString* sigMethod = $castIf(NSString, oauth[@"signature_method"]);
-                *outAuthorizer = [[CBLOAuth1Authorizer alloc] initWithConsumerKey: consumerKey
-                                                                   consumerSecret: consumerSec
-                                                                            token: token
-                                                                      tokenSecret: tokenSec
-                                                                  signatureMethod: sigMethod];
+                authorizer = [[CBLOAuth1Authorizer alloc] initWithConsumerKey: consumerKey
+                                                               consumerSecret: consumerSec
+                                                                        token: token
+                                                                  tokenSecret: tokenSec
+                                                              signatureMethod: sigMethod];
             } else if (persona) {
                 NSString* email = $castIf(NSString, persona[@"email"]);
-                *outAuthorizer = [[CBLPersonaAuthorizer alloc] initWithEmailAddress: email];
+                authorizer = [[CBLPersonaAuthorizer alloc] initWithEmailAddress: email];
             } else if (facebook) {
                 NSString* email = $castIf(NSString, facebook[@"email"]);
-                *outAuthorizer = [[CBLFacebookAuthorizer alloc] initWithEmailAddress: email];
+                authorizer = [[CBLFacebookAuthorizer alloc] initWithEmailAddress: email];
             }
-            if (!*outAuthorizer)
+            if (!authorizer)
                 Warn(@"Invalid authorizer settings: %@", auth);
+            authorizer.remoteURL = remote;
+            *outAuthorizer = authorizer;
         }
     }
 

--- a/Source/API/CBLReplication.h
+++ b/Source/API/CBLReplication.h
@@ -105,6 +105,9 @@ typedef void (^CBLAttachmentProgressBlock)(uint64_t bytesRead,
     or be stored in the NSURLCredentialStorage, which is a wrapper around the Keychain. */
 @property (nonatomic, strong, nullable) NSURLCredential* credential;
 
+/** The server user name that the authenticator has logged in as, if known. Observable. */
+@property (nonatomic, readonly) NSString* username;
+
 /** OAuth parameters that the replicator should use when authenticating to the remote database.
     Keys in the dictionary should be "consumer_key", "consumer_secret", "token", "token_secret",
     and optionally "signature_method". */
@@ -133,6 +136,10 @@ typedef void (^CBLAttachmentProgressBlock)(uint64_t bytesRead,
 
 /** Deletes the named cookie from this replication's cookie storage. */
 - (void) deleteCookieNamed: (NSString *)name;
+
+/** Deletes any persistent credentials (passwords, auth tokens...) associated with this 
+    replication's CBLAuthenticator. Also removes session cookies from the cookie store. */
+- (BOOL) removeStoredCredentials: (NSError**)outError;
 
 /** Adds additional SSL root certificates to be trusted by the replicator, or entirely overrides the
     OS's default list of trusted root certs.

--- a/Source/CBLAuthorizer.h
+++ b/Source/CBLAuthorizer.h
@@ -16,6 +16,9 @@
 @protocol CBLAuthorizer <CBLAuthenticator>
 /** The base URL of the remote service. The replicator sets this property when it starts up. */
 @property NSURL* remoteURL;
+- (BOOL) removeStoredCredentials: (NSError**)outError;
+@optional
+@property (readonly, atomic) NSString* username;
 @end
 
 

--- a/Source/CBLAuthorizer.m
+++ b/Source/CBLAuthorizer.m
@@ -22,7 +22,13 @@
 
 
 @implementation CBLAuthorizer
+
 @synthesize remoteURL=_remoteURL;
+
+- (BOOL) removeStoredCredentials: (NSError**)outError {
+    return YES;
+}
+
 @end
 
 
@@ -88,6 +94,15 @@
     if (!auth)
         return NO;
     [request setValue: auth forHTTPHeaderField: @"Authorization"];
+    return YES;
+}
+
+
+- (BOOL) removeStoredCredentials: (NSError**)outError {
+    NSURLProtectionSpace* space = [self.remoteURL my_protectionSpaceWithRealm: nil
+                                         authenticationMethod: NSURLAuthenticationMethodDefault];
+    NSURLCredentialStorage* storage = [NSURLCredentialStorage sharedCredentialStorage];
+    [storage removeCredential: _credential forProtectionSpace: space];
     return YES;
 }
 

--- a/Source/CBLOpenIDConnectAuthorizer.h
+++ b/Source/CBLOpenIDConnectAuthorizer.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
                            error: (NSError**)outError;
 
 #if DEBUG
-@property (copy) NSString* IDToken, *refreshToken;  // for testing only
+@property (copy, nullable) NSString* IDToken, *refreshToken;  // for testing only
 #endif
 
 @end


### PR DESCRIPTION
New method is -[CBLReplication removeStoredCredentials:]

Also moved the recently-added .username property from CBLAuthenticator
to CBLReplication -- this makes it consistent that CBLAuthenticator
has no API of its own but has to be accessed through the replication object.

Fixes #1302