### PR TITLE
Newly-pulled docs shouldn't show up in pusher's pendingDocuments

### DIFF
--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -107,6 +107,7 @@
 
 @interface CBLReplication ()
 @property (nonatomic, readonly) NSDictionary* properties;
+@property (nonatomic, readonly) SInt64 lastSequencePushed;
 @end
 
 

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -178,14 +178,15 @@
             _lastSequenceChanged = YES;
             [self performSelector: @selector(saveLastSequence) withObject: nil afterDelay: 5.0];
         }
+        [self postProgressChanged];
     }
 }
 
 
 - (void) postProgressChanged {
-    LogVerbose(Sync, @"%@: postProgressChanged (%u/%u, active=%d (batch=%u, net=%u), online=%d)",
+    LogVerbose(Sync, @"%@: postProgressChanged (%u/%u, active=%d (batch=%u, net=%u), lastSeq=%@, online=%d, error=%@)",
           self, (unsigned)_changesProcessed, (unsigned)_changesTotal,
-          _active, (unsigned)_batcher.count, _asyncTaskCount, _online);
+          _active, (unsigned)_batcher.count, _asyncTaskCount, _lastSequence, _online, _error.my_compactDescription);
     NSNotification* n = [NSNotification notificationWithName: CBL_ReplicatorProgressChangedNotification
                                                       object: self];
     [[NSNotificationQueue defaultQueue] enqueueNotification: n


### PR DESCRIPTION
When the pusher is notified of a new revision, but decides to ignore it
because it's an 'echo' from a pull replication (or because it's rejected
by the filter), it should advance the checkpoint past that rev's
sequence.

This is a good optimization in general, to prevent the next push from
re-scanning the same revisions, but more importantly it tells
CBLReplication.pendingDocuments that those revisions aren't pending.

To fix this I did have to change the timing at which the pusher adds
revs to its internal _pendingSequences set, because it needs to happen
at the same time that skipped sequences are being handled.

Fixes #1274