### PR TITLE
Prevent premature dealloc of CBL_Router

### DIFF
--- a/Source/CBL_Router.h
+++ b/Source/CBL_Router.h
@@ -57,7 +57,6 @@ enum {
     CBLResponse* _response;
     CBLDatabase* _db;
     BOOL _local;
-    BOOL _waiting;
     BOOL _responseSent;
     BOOL _processRanges;
     OnAccessCheckBlock _onAccessCheck;


### PR DESCRIPTION
It was possible for a CBL_Router sending an async response to be
dealloced early, since there was nothing keeping a reference to it
during the entire duration of its lifecycle. (I couldn't actually
reproduce this crash, unfortunately.)

To fix this I added a global set sRunningRouters that the router is
added to at the start of its -run method, and removed from at the end
of its -stopNow method.

Fixes #1325