### PR TITLE
Detect/handle file errors when saving a new attachment

### DIFF
--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -98,8 +98,7 @@
 
 
 @interface CBLAttachment ()
-+ (NSDictionary*) installAttachmentBodies: (NSDictionary*)attachments
-                             intoDatabase: (CBLDatabase*)database   __attribute__((nonnull(2)));
+- (BOOL) saveToDatabase: (CBLDatabase*)database error: (NSError**)outError;
 @property (readwrite, copy) NSString* name;
 @property (readwrite, retain) CBLRevision* revision;
 @end

--- a/Source/CBLInternal.h
+++ b/Source/CBLInternal.h
@@ -92,8 +92,6 @@
 - (instancetype) initWithRevision: (CBLRevision*)rev
                              name: (NSString*)name
                          metadata: (NSDictionary*)metadata          __attribute__((nonnull));
-+ (NSDictionary*) installAttachmentBodies: (NSDictionary*)attachments
-                             intoDatabase: (CBLDatabase*)database   __attribute__((nonnull(2)));
 @end
 
 

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -1050,6 +1050,38 @@
 }
 
 
+- (void) test18b_AttachmentMissingFile {
+    NSDictionary* properties = [NSDictionary dictionaryWithObjectsAndKeys:
+                                @"testAttachments", @"testName",
+                                nil];
+    CBLDocument* doc = [self createDocumentWithProperties: properties];
+
+    // Adding an attachment from a nonexistent file should fail:
+    NSURL* bodyURL = [NSURL fileURLWithPath: @"/tmp/cbl_body"];
+    [NSFileManager.defaultManager removeItemAtURL: bodyURL error: NULL];
+    CBLUnsavedRevision *rev2 = [doc newRevision];
+    [rev2 setAttachmentNamed: @"index.html"
+             withContentType: @"text/plain; charset=utf-8"
+                  contentURL: bodyURL];
+    AssertNil([rev2 attachmentNamed: @"index.html"]);
+
+    [[@"hi" dataUsingEncoding: NSUTF8StringEncoding] writeToURL: bodyURL atomically: NO];
+    [rev2 setAttachmentNamed: @"index.html"
+             withContentType: @"text/plain; charset=utf-8"
+                  contentURL: bodyURL];
+    Assert([rev2 attachmentNamed: @"index.html"]);
+
+    [NSFileManager.defaultManager removeItemAtURL: bodyURL error: NULL];
+
+    [self allowWarningsIn:^{
+        NSError * error;
+        AssertNil([rev2 save:&error]);
+        Assert(error);
+        Log(@"Error saving doc: %@", error);
+    }];
+}
+
+
 #pragma mark - CHANGE TRACKING
 
 


### PR DESCRIPTION
CBLAttachment checks file paths for validity when initialized, but it
doesn't check for read errors when copying the file to the blob-store.
So if the file is moved or deleted before the revision is saved, the
blob isn't created but there's no error. This causes errors later on
when trying to push the revision.

Fixed by adding error handling when reading the file, and did some
refactoring to clean up the code.

Fixes #1180