### PR TITLE
Disallow rekeying a db if it's open in multiple CBLManagers

### DIFF
--- a/Source/CBL_Shared.h
+++ b/Source/CBL_Shared.h
@@ -34,15 +34,12 @@
 
 - (void) openedDatabase: (NSString*)dbName;
 - (void) closedDatabase: (NSString*)dbName;
-- (BOOL) isDatabaseOpened: (NSString*)dbName;
+
+- (NSUInteger) countForOpenedDatabase: (NSString*)dbName;
 
 // Blocks till everyone who opened the database has closed it
 - (void) forgetDatabaseNamed: (NSString*)name;
 
 @property CBL_Server* backgroundServer;
-
-#if DEBUG
-- (NSUInteger) countForOpenedDatabase: (NSString*)dbName;
-#endif
 
 @end

--- a/Source/CBL_Shared.m
+++ b/Source/CBL_Shared.m
@@ -41,19 +41,11 @@
     [_backgroundServer close];
 }
 
-- (BOOL) isDatabaseOpened: (NSString*)dbName {
-    @synchronized(self) {
-        return [_openDatabaseNames containsObject: dbName];
-    }
-}
-
-#if DEBUG
 - (NSUInteger) countForOpenedDatabase: (NSString*)dbName {
     @synchronized(self) {
         return [_openDatabaseNames countForObject: dbName];
     }
 }
-#endif
 
 - (void) openedDatabase: (NSString*)dbName {
     @synchronized(self) {

--- a/Unit-Tests/DatabaseEncryption_Tests.m
+++ b/Unit-Tests/DatabaseEncryption_Tests.m
@@ -241,6 +241,22 @@
 }
 
 
+- (void) test08_MultipleDBHandles {
+    NSError* error;
+    seekrit = [dbmgr databaseNamed: @"seekrit" error: &error];
+    Assert(seekrit, @"Failed to create unencrypted db: %@", error);
+    [self createDocumentWithProperties: @{@"answer": @42} inDatabase: seekrit];
+
+    CBLManager* mgr2 = [dbmgr copy];
+    CBLDatabase* seekrit2 = [mgr2 databaseNamed: @"seekrit" error: NULL];
+    Assert(seekrit2);
+
+    Assert(![seekrit changeEncryptionKey: @"foobar" error: &error]);
+
+    [mgr2 close];
+}
+
+
 - (void) test08_AddKey      { [self rekeyUsingOldKey: nil        newKey: @"letmein"]; }
 - (void) test09_Rekey       { [self rekeyUsingOldKey: @"letmein" newKey: @"letmeout"]; }
 - (void) test10_RemoveKey   { [self rekeyUsingOldKey: @"letmein" newKey: nil]; }


### PR DESCRIPTION
We can't rewrite the db if it's open by multiple handles (SQLite or
ForestDB). The proper solution is to close the other handles and then
re-open them [with the new key] afterwards, but that would be too
difficult to do for 1.3. So for now, just detect the situation and
fail with a descriptive error.

Fixes #1233 (we think)