### PR TITLE
Change cookie storage scope from replicator to database

### DIFF
--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -30,7 +30,6 @@
 
 
 typedef void (^PendingAction)(id<CBL_Replicator>);
-typedef void (^PendingCookieAction)(CBLCookieStorage*);
 
 
 NSString* const kCBLReplicationChangeNotification = @"CBLReplicationChange";
@@ -54,6 +53,11 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 @property (nonatomic, readwrite) NSString* username;
 @end
 
+@interface CBLReplication (Internal)
+// For unit test only:
+@property (nonatomic, readonly) NSArray* cookies;
+@end
+
 
 @implementation CBLReplication
 {
@@ -65,7 +69,6 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
     // ONLY used on the server thread:
     id<CBL_Replicator> _bg_replicator;
     NSMutableArray<PendingAction>* _bg_pendingActions;
-    NSMutableArray<PendingCookieAction>* _bg_pendingCookieActions;
     NSConditionLock* _bg_stopLock;
 }
 
@@ -211,15 +214,23 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 
 - (void) deleteCookieNamed: (NSString*)name {
     Assert(name);
-    [self tellCookieStorage: ^(CBLCookieStorage *storage) {
+    [self tellCookieStorage: ^(CBLCookieStorage* storage) {
         [storage deleteCookiesNamed: name];
     }];
 }
 
 
 - (void) deleteAllCookies {
-    [self tellCookieStorage: ^(CBLCookieStorage *storage) {
+    [self tellCookieStorage: ^(CBLCookieStorage* storage) {
         [storage deleteAllCookies];
+    }];
+}
+
+
+// For unit test only:
+- (NSArray*) cookies {
+    return [self tellCookieStorageAndWait:^id(CBLCookieStorage* storage) {
+        return storage.cookies;
     }];
 }
 
@@ -582,15 +593,17 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
     }];
 }
 
-- (void) tellCookieStorage: (PendingCookieAction)block {
-    [self tellReplicator: ^(id<CBL_Replicator> bgRepl) {
-        if (bgRepl) {
-            block(bgRepl.cookieStorage);
-        } else {
-            if (!_bg_pendingCookieActions)
-                _bg_pendingCookieActions = [NSMutableArray array];
-            [_bg_pendingCookieActions addObject: block];
-        }
+- (void) tellCookieStorage: (void (^)(CBLCookieStorage*))block {
+    [_database.manager.backgroundServer tellDatabaseNamed: _database.name
+                                                       to: ^(CBLDatabase* bgDb) {
+        block(bgDb.cookieStorage);
+    }];
+}
+
+- (id) tellCookieStorageAndWait: (id (^)(CBLCookieStorage*))block {
+    return [_database.manager.backgroundServer waitForDatabaseNamed: _database.name
+                                                                 to: ^id(CBLDatabase* bgDb) {
+        return block(bgDb.cookieStorage);
     }];
 }
 
@@ -634,11 +647,6 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 
     if (auth)
         repl.settings.authorizer = auth;
-
-    // Make all pending changes to the cookie storage:
-    for (PendingCookieAction action in _bg_pendingCookieActions)
-        action(repl.cookieStorage);
-    _bg_pendingCookieActions = nil;
 
     CBLPropertiesTransformationBlock xformer = self.propertiesTransformationBlock;
     if (xformer) {

--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -217,7 +217,7 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 
 - (void) deleteAllCookies {
     [self tellCookieStorage: ^(CBLCookieStorage* storage) {
-        [storage deleteAllCookies];
+        [storage reset];
     }];
 }
 

--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -53,11 +53,6 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 @property (nonatomic, readwrite) NSString* username;
 @end
 
-@interface CBLReplication (Internal)
-// For unit test only:
-@property (nonatomic, readonly) NSArray* cookies;
-@end
-
 
 @implementation CBLReplication
 {

--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -108,6 +108,7 @@
 @interface CBLReplication ()
 @property (nonatomic, readonly) NSDictionary* properties;
 @property (nonatomic, readonly) SInt64 lastSequencePushed;
+@property (nonatomic, readonly) NSArray* cookies;
 @end
 
 

--- a/Source/CBLBlipReplicator.m
+++ b/Source/CBLBlipReplicator.m
@@ -13,6 +13,7 @@
 #import "CBLReachability.h"
 #import "CBLMisc.h"
 #import "CBLCookieStorage.h"
+#import "CBLDatabase+Internal.h"
 #import "BLIPPocketSocketConnection.h"
 #import "BLIPHTTPLogic.h"
 #import "CollectionUtils.h"
@@ -83,8 +84,6 @@
         _sessionID = [$sprintf(@"repl%03d", ++sLastSessionID) copy];
         _progress = [NSProgress progressWithTotalUnitCount: -1]; // indeterminate
         _remoteCheckpointDocID = [_settings remoteCheckpointDocIDForLocalUUID: _db.privateUUID];
-        _cookieStorage = [[CBLCookieStorage alloc] initWithDB: db
-                                                   storageKey: _remoteCheckpointDocID];
 
         __weak CBLBlipReplicator* weakSelf = self;
         _updateProgressSoon = MYBatchedBlock(0.25, _syncQueue,
@@ -139,6 +138,12 @@
 #if DEBUG
 @synthesize savingCheckpoint=_savingCheckpoint, active=_active;
 #endif
+
+- (CBLCookieStorage*) cookieStorage {
+    if (!_cookieStorage)
+        _cookieStorage = _db.cookieStorage;
+    return _cookieStorage;
+}
 
 
 #pragma mark - INTERNALS:

--- a/Source/CBLBlipReplicator.m
+++ b/Source/CBLBlipReplicator.m
@@ -55,7 +55,7 @@
 }
 
 @synthesize db=_db, settings=_settings, error=_error, sessionID=_sessionID;
-@synthesize serverCert=_serverCert, cookieStorage = _cookieStorage;
+@synthesize serverCert=_serverCert;
 @synthesize sync=_sync, status=_status;
 @synthesize changesProcessed=_changesProcessed, changesTotal=_changesTotal;
 @synthesize remoteCheckpointDocID=_remoteCheckpointDocID;
@@ -139,12 +139,6 @@
 @synthesize savingCheckpoint=_savingCheckpoint, active=_active;
 #endif
 
-- (CBLCookieStorage*) cookieStorage {
-    if (!_cookieStorage)
-        _cookieStorage = _db.cookieStorage;
-    return _cookieStorage;
-}
-
 
 #pragma mark - INTERNALS:
 
@@ -160,7 +154,7 @@
     [_settings.requestHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
         [request setValue: value forHTTPHeaderField: key];
     }];
-    [self.cookieStorage addCookieHeaderToRequest: request];
+    [_db.cookieStorage addCookieHeaderToRequest: request];
 
     id<CBLAuthorizer> auth = _settings.authorizer;
     NSURLCredential* credential = $castIfProtocol(CBLCredentialAuthorizer, auth).credential;

--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -43,7 +43,7 @@ extern NSString* const CBLCookieStorageCookiesChangedNotification;
 - (void) deleteCookiesNamed: (NSString*)name;
 
 /** Deletes all cookies from the cookie storage. */
-- (void) deleteAllCookies;
+- (void) reset;
 
 @end
 

--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -25,7 +25,7 @@ extern NSString* const CBLCookieStorageCookiesChangedNotification;
 
 /** Creates a cookie storage that will store cookies inside the given database as a local document 
     referenced by a unique storage key. */
-- (instancetype) initWithDB: (CBLDatabase*)db storageKey: (NSString*)storageKey;
+- (instancetype) initWithDB: (CBLDatabase*)db;
 
 /** Returns an array of cookies that match with the given url. */
 - (NSArray*) cookiesForURL: (NSURL*)theURL;

--- a/Source/CBLCookieStorage.m
+++ b/Source/CBLCookieStorage.m
@@ -206,19 +206,13 @@ NSString* const CBLCookieStorageCookiesChangedNotification = @"CookieStorageCook
     }
 }
 
-- (void) deleteAllCookies {
+- (void) reset {
     @synchronized(self) {
-        if ([_cookies count] == 0)
-            return;
-
-        [_cookies removeAllObjects];
-
-        NSError* error;
-        if (![self saveCookies: &error]) {
-            Warn(@"%@: Cannot save cookies with an error : %@", self, error.my_compactDescription);
+        [_db.storage setInfo: nil forKey: kDatabaseInfoCookiesKey];
+        if ([_cookies count] > 0) {
+            [_cookies removeAllObjects];
+            [self notifyCookiesChanged];
         }
-        
-        [self notifyCookiesChanged];
     }
 }
 
@@ -402,16 +396,6 @@ NSString* const CBLCookieStorageCookiesChangedNotification = @"CookieStorageCook
                                                       userInfo: nil];
 }
 
-
-- (NSString*) databaseInfoCookiesKey {
-    return kDatabaseInfoCookiesKey;
-}
-
-
-// For unit test only.
-- (void) reset {
-    [_db.storage setInfo: nil forKey: kDatabaseInfoCookiesKey];
-}
 
 @end
 

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -9,7 +9,7 @@
 #import "CBL_Storage.h"
 #import "CBLDatabase.h"
 @class CBLQueryOptions, CBLView, CBLQueryRow, CBL_BlobStore, CBLDocument, CBLCache, CBLDatabase,
-       CBLDatabaseChange, CBL_Shared, CBLModelFactory, CBLDatabaseOptions;
+       CBLDatabaseChange, CBL_Shared, CBLModelFactory, CBLDatabaseOptions, CBLCookieStorage;
 
 
 UsingLogDomain(Database);
@@ -54,6 +54,7 @@ extern NSArray* CBL_RunloopModes;
     NSDate* _startTime;
     CBLModelFactory* _modelFactory;
     NSMutableSet* _unsavedModelsMutable;   // All CBLModels that have unsaved changes
+    __weak CBLCookieStorage* _cookieStorage;
 #if DEBUG
     CBL_Shared* _debug_shared;
 #endif
@@ -90,6 +91,7 @@ extern NSArray* CBL_RunloopModes;
 @property (nonatomic, readonly) id<CBL_Storage> storage;
 @property (nonatomic, readonly) CBL_BlobStore* attachmentStore;
 @property (nonatomic, readonly) CBL_Shared* shared;
+@property (nonatomic, readonly) CBLCookieStorage* cookieStorage;
 
 @property (nonatomic, readonly) BOOL exists;
 @property (nonatomic, readonly) UInt64 totalDataSize;
@@ -152,5 +154,23 @@ extern NSArray* CBL_RunloopModes;
 - (void) postNotification: (NSNotification*)notification;
 
 - (void) setExpirationDate: (NSDate*)date ofDocument: (NSString*)documentID;
+
+
+// LOCAL DOC DATABASE INFO:
+
+/** Put a property with a given key and value into the local database info document. */
+- (BOOL) putLocalDatabaseInfoWithKey: (NSString*)key
+                               value: (id)value
+                            outError: (NSError**)outError;
+
+/** Remove a property with a given key from the local database info document. */
+- (BOOL) removeLocalDatabaseInfoWithKey: (NSString*)key
+                               outError: (NSError**)outError;
+
+/** Returns a property value specifiec by the key from the local database info document. */
+- (NSDictionary*) getLocalDatabaseInfoDocument;
+
+/** Returns local databaes info document if it exists. Otherwise returns nil. */
+- (id) getLocalDatabaseInfoPropertyValueForKey: (NSString*)key;
 
 @end

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -155,22 +155,4 @@ extern NSArray* CBL_RunloopModes;
 
 - (void) setExpirationDate: (NSDate*)date ofDocument: (NSString*)documentID;
 
-
-// LOCAL DOC DATABASE INFO:
-
-/** Put a property with a given key and value into the local database info document. */
-- (BOOL) putLocalDatabaseInfoWithKey: (NSString*)key
-                               value: (id)value
-                            outError: (NSError**)outError;
-
-/** Remove a property with a given key from the local database info document. */
-- (BOOL) removeLocalDatabaseInfoWithKey: (NSString*)key
-                               outError: (NSError**)outError;
-
-/** Returns a property value specifiec by the key from the local database info document. */
-- (NSDictionary*) getLocalDatabaseInfoDocument;
-
-/** Returns local databaes info document if it exists. Otherwise returns nil. */
-- (id) getLocalDatabaseInfoPropertyValueForKey: (NSString*)key;
-
 @end

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -55,8 +55,6 @@ const CBLChangesOptions kDefaultCBLChangesOptions = {UINT_MAX, NO, NO, YES, NO};
 // How long to wait after a database opens before expiring docs
 #define kHousekeepingDelayAfterOpening 3.0
 
-// Local document for keeping internal database info, e.g. cookies)
-#define kLocalDatabaseInfoDocId @"CBL_DatabaseInfo"
 
 static BOOL sAutoCompact = YES;
 

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -818,56 +818,6 @@ static SequenceNumber keyToSequence(id key, SequenceNumber dflt) {
 }
 
 
-#pragma mark - Database Info Local Document:
-
-
-- (BOOL) putLocalDatabaseInfoWithKey: (NSString*)key
-                               value: (id)value
-                            outError: (NSError**)outError {
-    if (key == nil || value == nil)
-        return NO;
-    
-    NSMutableDictionary* document = [NSMutableDictionary dictionaryWithDictionary:
-                                     [self getLocalDatabaseInfoDocument]];
-    document[key] = value;
-    BOOL result = [self putLocalDocument: document withID: kLocalDatabaseInfoDocId error: outError];
-    if (!result)
-        Warn(@"CBLDatabase: Could not create a local database info with an error: %@", *outError);
-    return result;
-}
-
-
-- (BOOL) removeLocalDatabaseInfoWithKey: (NSString*)key
-                               outError: (NSError**)outError {
-    if (key == nil)
-        return NO;
-
-    NSMutableDictionary* document = [NSMutableDictionary dictionaryWithDictionary:
-                                     [self getLocalDatabaseInfoDocument]];
-    if (![document objectForKey: key]) {
-        if (outError) *outError = nil;
-        return NO;
-    }
-
-    [document removeObjectForKey: key];
-    BOOL result = [self putLocalDocument: document withID: kLocalDatabaseInfoDocId error: outError];
-    if (!result)
-        Warn(@"CBLDatabase: Could not delete database info document property %@ with an error: %@",
-             key, *outError);
-    return result;
-}
-
-
-- (NSDictionary*) getLocalDatabaseInfoDocument {
-    return [self existingLocalDocumentWithID: kLocalDatabaseInfoDocId];
-}
-
-
-- (id) getLocalDatabaseInfoPropertyValueForKey: (NSString*)key {
-    return [[self getLocalDatabaseInfoDocument] objectForKey: key];
-}
-
-
 #pragma mark - Cookie Storage:
 
 

--- a/Source/CBLDatabase+Replication.h
+++ b/Source/CBLDatabase+Replication.h
@@ -31,6 +31,10 @@
                                      value:(id)value
                                   outError: (NSError**)outError;
 
+/** Remove a property with a given key from the local checkpoint document. */
+- (BOOL) removeLocalCheckpointDocumentWithKey: (NSString*)key
+                                     outError: (NSError**)outError;
+
 /** Returns a property value specifiec by the key from the local checkpoint document. */
 - (id) getLocalCheckpointDocumentPropertyValueForKey: (NSString*)key;
 

--- a/Source/CBLDatabase+Replication.m
+++ b/Source/CBLDatabase+Replication.m
@@ -94,7 +94,7 @@ static NSString* checkpointInfoKey(NSString* checkpointID) {
 }
 
 - (BOOL) putLocalCheckpointDocumentWithKey: (NSString*)key
-                                     value:(id)value
+                                     value: (id)value
                                   outError: (NSError**)outError {
     if (key == nil || value == nil)
         return NO;
@@ -105,6 +105,26 @@ static NSString* checkpointInfoKey(NSString* checkpointID) {
     BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: outError];
     if (!result)
         Warn(@"CBLDatabase: Could not create a local checkpoint document with an error: %@", *outError);
+    return result;
+}
+
+- (BOOL) removeLocalCheckpointDocumentWithKey: (NSString*)key
+                                     outError: (NSError**)outError {
+    if (key == nil)
+        return NO;
+    
+    NSMutableDictionary* document = [NSMutableDictionary dictionaryWithDictionary:
+                                     [self getLocalCheckpointDocument]];
+    if (![document objectForKey: key]) {
+        if (outError) *outError = nil;
+        return NO;
+    }
+    
+    [document removeObjectForKey: key];
+    BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: outError];
+    if (!result)
+        Warn(@"CBLDatabase: Could not delete checkpoint document property %@ with an error: %@",
+             key, *outError);
     return result;
 }
 

--- a/Source/CBLDatabase+Replication.m
+++ b/Source/CBLDatabase+Replication.m
@@ -99,8 +99,9 @@ static NSString* checkpointInfoKey(NSString* checkpointID) {
     if (key == nil || value == nil)
         return NO;
 
-    NSMutableDictionary* document = [NSMutableDictionary dictionaryWithDictionary:
-                                        [self getLocalCheckpointDocument]];
+    NSMutableDictionary* document = [[self getLocalCheckpointDocument] mutableCopy];
+    if (!document)
+        document = [NSMutableDictionary dictionary];
     document[key] = value;
     BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: outError];
     if (!result)
@@ -113,12 +114,9 @@ static NSString* checkpointInfoKey(NSString* checkpointID) {
     if (key == nil)
         return NO;
     
-    NSMutableDictionary* document = [NSMutableDictionary dictionaryWithDictionary:
-                                     [self getLocalCheckpointDocument]];
-    if (![document objectForKey: key]) {
-        if (outError) *outError = nil;
-        return NO;
-    }
+    NSMutableDictionary* document = [[self getLocalCheckpointDocument] mutableCopy];
+    if (![document objectForKey: key])
+        return YES;
     
     [document removeObjectForKey: key];
     BOOL result = [self putLocalDocument: document withID: kLocalCheckpointDocId error: outError];

--- a/Source/CBLInternal.h
+++ b/Source/CBLInternal.h
@@ -15,6 +15,7 @@
 #import "CBL_Server.h"
 #import "CBL_BlobStore.h"
 #import "CBLCache.h"
+#import "CBLCookieStorage.h"
 @class CBL_Attachment, CBL_BlobStoreWriter, CBLDatabaseChange;
 
 
@@ -160,4 +161,9 @@ NSString* CBLKeyPathForQueryRow(NSString* keyPath); // for testing
 - (instancetype) initWithDatabase: (CBLDatabase*)database
                            remote: (NSURL*)remote
                              pull: (BOOL)pull                       __attribute__((nonnull));
+@end
+
+
+@interface CBLCookieStorage ()
+- (void) reset;
 @end

--- a/Source/CBLInternal.h
+++ b/Source/CBLInternal.h
@@ -162,8 +162,3 @@ NSString* CBLKeyPathForQueryRow(NSString* keyPath); // for testing
                            remote: (NSURL*)remote
                              pull: (BOOL)pull                       __attribute__((nonnull));
 @end
-
-
-@interface CBLCookieStorage ()
-- (void) reset;
-@end

--- a/Source/CBLRestPuller.m
+++ b/Source/CBLRestPuller.m
@@ -98,6 +98,7 @@
 
 - (void) startChangeTracker {
     Assert(!_changeTracker);
+    CBLDatabase* db = _db;
     NSTimeInterval pollInterval = _settings.pollInterval;
     CBLChangeTrackerMode mode = kOneShot;
     if (_settings.continuous && pollInterval == 0.0 && self.canUseWebSockets)
@@ -109,12 +110,12 @@
                                                       lastSequence: _lastSequence
                                                             client: self];
     _changeTracker.continuous = _settings.continuous;
-    _changeTracker.activeOnly = (_lastSequence == nil && _db.documentCount == 0);
+    _changeTracker.activeOnly = (_lastSequence == nil && db.documentCount == 0);
     _changeTracker.filterName = _settings.filterName;
     _changeTracker.filterParameters = _settings.filterParameters;
     _changeTracker.docIDs = _settings.docIDs;
     _changeTracker.authorizer = _remoteSession.authorizer;
-    _changeTracker.cookieStorage = self.cookieStorage;
+    _changeTracker.cookieStorage = db.cookieStorage;
 
     unsigned heartbeat = $castIf(NSNumber, _settings.options[kCBLReplicatorOption_Heartbeat]).unsignedIntValue;
     if (heartbeat >= 15000)

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -79,10 +79,9 @@
     BOOL _suspended;
     SecCertificateRef _serverCert;
     NSData* _pinnedCertData;
-    CBLCookieStorage* _cookieStorage;
 }
 
-@synthesize db=_db, settings=_settings, serverCert=_serverCert, cookieStorage=_cookieStorage;
+@synthesize db=_db, settings=_settings, serverCert=_serverCert;
 #if DEBUG
 @synthesize running=_running, active=_active;
 #endif
@@ -295,7 +294,7 @@
                                                              baseURL: _settings.remote
                                                             delegate: self
                                                           authorizer: authorizer
-                                                       cookieStorage: self.cookieStorage];
+                                                       cookieStorage: db.cookieStorage];
 
     _running = YES;
     _online = NO;
@@ -603,14 +602,6 @@
         [self fetchRemoteCheckpointDoc];
     }
 }
-
-
-- (CBLCookieStorage*) cookieStorage {
-    if (!_cookieStorage)
-        _cookieStorage = _db.cookieStorage;
-    return _cookieStorage;
-}
-
 
 - (BOOL) serverIsSyncGatewayVersion: (NSString*)minVersion {
     return [_serverType hasPrefix: @"Couchbase Sync Gateway/"]

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -82,7 +82,7 @@
     CBLCookieStorage* _cookieStorage;
 }
 
-@synthesize db=_db, settings=_settings, cookieStorage=_cookieStorage, serverCert=_serverCert;
+@synthesize db=_db, settings=_settings, serverCert=_serverCert, cookieStorage=_cookieStorage;
 #if DEBUG
 @synthesize running=_running, active=_active;
 #endif
@@ -146,7 +146,6 @@
     [self clearDbRef];
     // Explicitly clear the reference to the storage to ensure that the cookie storage will
     // get dealloc and the database referenced inside the storage will get cleared as well.
-    _cookieStorage = nil;
 }
 
 
@@ -607,10 +606,8 @@
 
 
 - (CBLCookieStorage*) cookieStorage {
-    if (!_cookieStorage) {
-        _cookieStorage = [[CBLCookieStorage alloc] initWithDB: _db
-                                                   storageKey: self.remoteCheckpointDocID];
-    }
+    if (!_cookieStorage)
+        _cookieStorage = _db.cookieStorage;
     return _cookieStorage;
 }
 

--- a/Source/CBL_Replicator.h
+++ b/Source/CBL_Replicator.h
@@ -50,8 +50,6 @@ extern NSString* CBL_ReplicatorStoppedNotification;
 
 @property (readonly, nonatomic) CBLDatabase* db;
 
-@property (readonly) CBLCookieStorage* cookieStorage;
-
 @property (readonly) NSString* remoteCheckpointDocID;
 
 @property (readonly) CBL_ReplicatorStatus status;

--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -8,20 +8,13 @@
 
 #import "CBLTestCase.h"
 #import "CBLCookieStorage.h"
-#import "CBLDatabase+Internal.h"
 #import "CBLDatabase+Replication.h"
-#import "CBLInternal.h"
 
 #define $URL(urlStr)                            ([NSURL URLWithString: urlStr])
 #define COMPARE_COOKIES(cookies1, cookies2)     [self compareCookies: cookies1 withCookies: cookies2]
 
 @interface CookieStorage_Tests : CBLTestCaseWithDB
 
-@end
-
-
-@interface CBLCookieStorage (Internal)
-- (NSString*) localDatabaseInfoCookiesKey;
 @end
 
 
@@ -146,7 +139,6 @@
 
     // Reset cookie store: clear an empty cookies array so the migration will be triggered:
     [_cookieStore reset];
-
 
     // Recreate the cookie store:
     [self reloadCookieStore];
@@ -398,7 +390,7 @@
     AssertEqual(_cookieStore.cookies[0], cookie2);
 }
 
-- (void) test_DeleteAllCookies {
+- (void) test_Reset {
     NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
                                              NSHTTPCookieDomain: @"mycookie.com",
                                              NSHTTPCookiePath: @"/",
@@ -431,7 +423,7 @@
     AssertEqual(_cookieStore.cookies[1], cookie2);
     AssertEqual(_cookieStore.cookies[2], cookie3);
 
-    [_cookieStore deleteAllCookies];
+    [_cookieStore reset];
 
     AssertEq(_cookieStore.cookies.count, 0u);
 

--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -10,6 +10,7 @@
 #import "CBLCookieStorage.h"
 #import "CBLDatabase+Internal.h"
 #import "CBLDatabase+Replication.h"
+#import "CBLInternal.h"
 
 #define $URL(urlStr)                            ([NSURL URLWithString: urlStr])
 #define COMPARE_COOKIES(cookies1, cookies2)     [self compareCookies: cookies1 withCookies: cookies2]
@@ -117,13 +118,6 @@
     AssertEq(_cookieStore.cookies.count, 2u);
     AssertEqual(_cookieStore.cookies[0], cookie1);
     AssertEqual(_cookieStore.cookies[1], cookie3);
-
-    // Check if cookies are stored in the local database info document:
-    NSArray* cookies = [db getLocalDatabaseInfoPropertyValueForKey:
-                        [_cookieStore localDatabaseInfoCookiesKey]];
-    AssertEq(cookies.count, 2u);
-    AssertEqual([self cookie: cookies[0]], cookie1);
-    AssertEqual([self cookie: cookies[1]], cookie3);
 }
 
 - (void) test_Migration {
@@ -150,9 +144,9 @@
     NSArray* cookies = [db getLocalCheckpointDocumentPropertyValueForKey: localCheckpointCookiesKey];
     AssertEq(cookies.count, 2u);
 
-    // Clear an empty cookies array at the local database info document:
-    Assert([db removeLocalDatabaseInfoWithKey: [_cookieStore localDatabaseInfoCookiesKey]
-                                     outError: NULL]);
+    // Reset cookie store: clear an empty cookies array so the migration will be triggered:
+    [_cookieStore reset];
+
 
     // Recreate the cookie store:
     [self reloadCookieStore];

--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -8,6 +8,8 @@
 
 #import "CBLTestCase.h"
 #import "CBLCookieStorage.h"
+#import "CBLDatabase+Internal.h"
+#import "CBLDatabase+Replication.h"
 
 #define $URL(urlStr)                            ([NSURL URLWithString: urlStr])
 #define COMPARE_COOKIES(cookies1, cookies2)     [self compareCookies: cookies1 withCookies: cookies2]
@@ -15,6 +17,12 @@
 @interface CookieStorage_Tests : CBLTestCaseWithDB
 
 @end
+
+
+@interface CBLCookieStorage (Internal)
+- (NSString*) localDatabaseInfoCookiesKey;
+@end
+
 
 @implementation CookieStorage_Tests
 {
@@ -24,8 +32,7 @@
 
 - (void)setUp {
     [super setUp];
-    _cookieStore = [[CBLCookieStorage alloc] initWithDB: db
-                                             storageKey: @"cookie_store_unit_test"];
+    _cookieStore = [[CBLCookieStorage alloc] initWithDB: db];
     _appleCookieStore = [NSHTTPCookieStorage sharedHTTPCookieStorage];
 }
 
@@ -37,8 +44,7 @@
 }
 
 - (void) reloadCookieStore {
-    _cookieStore = [[CBLCookieStorage alloc] initWithDB: db
-                                             storageKey: @"cookie_store_unit_test"];
+    _cookieStore = [[CBLCookieStorage alloc] initWithDB: db];
 }
 
 - (NSHTTPCookie*) cookie: (NSDictionary*)props {
@@ -111,6 +117,51 @@
     AssertEq(_cookieStore.cookies.count, 2u);
     AssertEqual(_cookieStore.cookies[0], cookie1);
     AssertEqual(_cookieStore.cookies[1], cookie3);
+
+    // Check if cookies are stored in the local database info document:
+    NSArray* cookies = [db getLocalDatabaseInfoPropertyValueForKey:
+                        [_cookieStore localDatabaseInfoCookiesKey]];
+    AssertEq(cookies.count, 2u);
+    AssertEqual([self cookie: cookies[0]], cookie1);
+    AssertEqual([self cookie: cookies[1]], cookie3);
+}
+
+- (void) test_Migration {
+    // Manually create cookies at the local checkpoint document:
+    NSDictionary* cookie1 = @{ NSHTTPCookieName: @"whitechoco",
+                               NSHTTPCookieDomain: @"mycookie.com",
+                               NSHTTPCookiePath: @"/",
+                               NSHTTPCookieValue: @"sweet",
+                               NSHTTPCookieMaximumAge: @(3600),
+                               };
+
+    NSDictionary* cookie2 = @{ NSHTTPCookieName: @"oatmeal_raisin",
+                               NSHTTPCookieDomain: @"mycookie.com",
+                               NSHTTPCookiePath: @"/",
+                               NSHTTPCookieValue: @"sweet",
+                               NSHTTPCookieMaximumAge: @(3600),
+                               NSHTTPCookieVersion: @"1"
+                               };
+
+    NSString* localCheckpointCookiesKey = @"cbl_cookie_storage_xxxxx";
+    [db putLocalCheckpointDocumentWithKey: localCheckpointCookiesKey
+                                    value: @[ cookie1, cookie2]
+                                 outError: NULL];
+    NSArray* cookies = [db getLocalCheckpointDocumentPropertyValueForKey: localCheckpointCookiesKey];
+    AssertEq(cookies.count, 2u);
+
+    // Clear an empty cookies array at the local database info document:
+    Assert([db removeLocalDatabaseInfoWithKey: [_cookieStore localDatabaseInfoCookiesKey]
+                                     outError: NULL]);
+
+    // Recreate the cookie store:
+    [self reloadCookieStore];
+
+    // Check if migration is correct:
+    AssertEq(_cookieStore.cookies.count, 2u);
+    AssertEqual(_cookieStore.cookies[0], [self cookie: cookie1]);
+    AssertEqual(_cookieStore.cookies[1], [self cookie: cookie2]);
+    AssertNil([db getLocalCheckpointDocumentPropertyValueForKey: localCheckpointCookiesKey]);
 }
 
 - (void) test_SetCookie_NameDomainPath {

--- a/Unit-Tests/Replication_Tests.m
+++ b/Unit-Tests/Replication_Tests.m
@@ -38,6 +38,9 @@
 @property (nonatomic, readonly) NSString* dir;
 @end
 
+@interface CBLReplication (Internal)
+@property (nonatomic, readonly) NSArray* cookies;
+@end
 
 @interface Replication_Tests : CBLTestCaseWithDB
 @end
@@ -106,29 +109,6 @@
 }
 
 
-- (void) runReplication: (CBLReplication*)repl
-   expectedChangesCount: (unsigned)expectedChangesCount
- expectedChangedCookies: (NSArray*) expectedChangedCookies {
-
-    _changedCookies = nil;
-
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(cookiesChanged:)
-                                                 name: CBLCookieStorageCookiesChangedNotification
-                                               object: nil];
-
-    [self runReplication: repl expectedChangesCount: expectedChangesCount];
-
-    [[NSNotificationCenter defaultCenter] removeObserver: self
-                                                    name: CBLCookieStorageCookiesChangedNotification
-                                                  object: nil];
-
-    AssertEq(_changedCookies.count, expectedChangedCookies.count);
-    for (NSHTTPCookie* cookie in expectedChangedCookies)
-        Assert([_changedCookies containsObject: cookie]);
-}
-
-
 - (void) replChanged: (NSNotification*)n {
     AssertEq(n.object, _currentReplication, @"Wrong replication given to notification");
     Log(@"Replication status=%u; completedChangesCount=%u; changesCount=%u",
@@ -144,13 +124,6 @@
             AssertEq(_currentReplication.changesCount, _expectedChangesCount);
         }
     }
-}
-
-
-- (void) cookiesChanged: (NSNotification*)n {
-    CBLCookieStorage* storage = n.object;
-    _changedCookies = storage.cookies;
-    Log(@"%@ changed: %lu cookies", storage, (unsigned long)_changedCookies.count);
 }
 
 
@@ -626,7 +599,9 @@ static UInt8 sEncryptionIV[kCCBlockSizeAES128];
                                 }];
 
     CBLReplication* repl = [db createPullReplication: remoteDbURL];
+    repl.continuous = YES;
 
+    // 1: Set and delete cookies before starting the replicator:
     [repl setCookieNamed: cookie1.name
                withValue: cookie1.value
                     path: cookie1.path
@@ -647,16 +622,48 @@ static UInt8 sEncryptionIV[kCCBlockSizeAES128];
 
     [repl deleteCookieNamed: cookie2.name];
 
-    [self runReplication: repl expectedChangesCount: 0 expectedChangedCookies: @[cookie1, cookie3]];
-    AssertNil(repl.lastError);
+    // Check cookies:
+    NSArray* cookies = repl.cookies;
+    AssertEq(cookies.count, 2u);
+    AssertEqual(cookies[0], cookie1);
+    AssertEqual(cookies[1], cookie3);
 
-    // Recreate the replicator and delete a cookie:
+    // Run a continuous the replicator:
+    [self runReplication: repl expectedChangesCount: 0];
+
+    // 2: Set and delete cookies while the replicator is running:
+    [repl setCookieNamed: cookie2.name
+               withValue: cookie2.value
+                    path: cookie2.path
+          expirationDate: cookie2.expiresDate
+                  secure: cookie2.isSecure];
+
+    [repl deleteCookieNamed: cookie3.name];
+
+    // Check cookies:
+    cookies = repl.cookies;
+    AssertEq(cookies.count, 2u);
+    AssertEqual(cookies[0], cookie1);
+    AssertEqual(cookies[1], cookie2);
+
+    // Stop the replicator:
+    [self keyValueObservingExpectationForObject: repl
+                                        keyPath: @"status" expectedValue: @(kCBLReplicationStopped)];
+    [repl stop];
+    [self waitForExpectationsWithTimeout: 2.0 handler: nil];
+
+    // 3: Recreate the replicator (single shot) and delete a cookie:
     Log(@"***** Testing cookie deletion *****");
     repl = [db createPullReplication: remoteDbURL];
-    [repl deleteCookieNamed: cookie3.name];
+    [repl deleteCookieNamed: cookie2.name];
     [repl start];
-    [self runReplication: repl expectedChangesCount: 0 expectedChangedCookies: @[cookie1]];
+    [self runReplication: repl expectedChangesCount: 0];
     AssertNil(repl.lastError);
+
+    // Check cookies:
+    cookies = repl.cookies;
+    AssertEq(cookies.count, 1u);
+    AssertEqual(cookies[0], cookie1);
 }
 
 - (void) test11_ReplicationWithReplacedDatabase {

--- a/Unit-Tests/Replication_Tests.m
+++ b/Unit-Tests/Replication_Tests.m
@@ -38,10 +38,6 @@
 @property (nonatomic, readonly) NSString* dir;
 @end
 
-@interface CBLReplication (Internal)
-@property (nonatomic, readonly) NSArray* cookies;
-@end
-
 @interface Replication_Tests : CBLTestCaseWithDB
 @end
 


### PR DESCRIPTION
- Added cookieStorages properties to the internal CBLDatabase.
- Cookies are stored in the local database info document under the key named `cookies`.
- Implemented migrateOldCookieStorage to migrate cookies from checkpoint docs to the new local data info document. The old cookies are removed after the migration.
- CBLReplication always accesses the database cookie storage only from the background thread.

#1334