### PR TITLE
OpenID tokens in Keychain should be per-database

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -926,6 +926,7 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
             if (!authorizer)
                 Warn(@"Invalid authorizer settings: %@", auth);
             authorizer.remoteURL = remote;
+            authorizer.localUUID = db.publicUUID;
             *outAuthorizer = authorizer;
         }
     }

--- a/Source/CBLAuthorizer.h
+++ b/Source/CBLAuthorizer.h
@@ -16,6 +16,8 @@
 @protocol CBLAuthorizer <CBLAuthenticator>
 /** The base URL of the remote service. The replicator sets this property when it starts up. */
 @property NSURL* remoteURL;
+/** The unique ID of the local database. The replicator sets this property when it starts up. */
+@property NSString* localUUID;
 - (BOOL) removeStoredCredentials: (NSError**)outError;
 @optional
 @property (readonly, atomic) NSString* username;

--- a/Source/CBLAuthorizer.m
+++ b/Source/CBLAuthorizer.m
@@ -23,7 +23,7 @@
 
 @implementation CBLAuthorizer
 
-@synthesize remoteURL=_remoteURL;
+@synthesize remoteURL=_remoteURL, localUUID=_localUUID;
 
 - (BOOL) removeStoredCredentials: (NSError**)outError {
     return YES;

--- a/Source/CBLRemoteLogin.h
+++ b/Source/CBLRemoteLogin.h
@@ -17,11 +17,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CBLRemoteLogin : NSObject
 
 - (instancetype) initWithURL: (NSURL*)remoteURL
+                   localUUID: (NSString*)localUUID
                      session: (CBLRemoteSession*)session
              requestDelegate: (nullable id<CBLRemoteRequestDelegate>)requestDelegate
                 continuation: (void(^)(NSError* nullable))continuation NS_DESIGNATED_INITIALIZER;
 
 - (instancetype) initWithURL: (NSURL*)remoteURL
+                   localUUID: (NSString*)localUUID
                   authorizer: (nullable id<CBLAuthorizer>)authorizer
                 continuation: (void(^)(NSError* nullable))continuation;
 

--- a/Source/CBLRemoteLogin.m
+++ b/Source/CBLRemoteLogin.m
@@ -20,6 +20,7 @@ UsingLogDomain(Sync);
 @implementation CBLRemoteLogin
 {
     NSURL* _remoteURL;
+    NSString* _localUUID;
     CBLRemoteSession* _remoteSession;
     id<CBLRemoteRequestDelegate> _requestDelegate;
     void(^_continuation)(NSError*);
@@ -27,6 +28,7 @@ UsingLogDomain(Sync);
 
 
 - (instancetype) initWithURL: (NSURL*)remoteURL
+                   localUUID: (NSString*)localUUID
                      session: (CBLRemoteSession*)session
              requestDelegate: (id<CBLRemoteRequestDelegate>)requestDelegate
                 continuation: (void(^)(NSError*))continuation
@@ -36,6 +38,7 @@ UsingLogDomain(Sync);
     self = [super init];
     if (self) {
         _remoteURL = remoteURL;
+        _localUUID = [localUUID copy];
         _remoteSession = session;
         _requestDelegate = requestDelegate;
         _continuation = continuation;
@@ -45,6 +48,7 @@ UsingLogDomain(Sync);
 
 
 - (instancetype) initWithURL: (NSURL*)remoteURL
+                   localUUID: (NSString*)localUUID
                   authorizer: (id<CBLAuthorizer>)authorizer
                 continuation: (void(^)(NSError*))continuation
 {
@@ -55,6 +59,7 @@ UsingLogDomain(Sync);
                                                                      authorizer: authorizer
                                                                   cookieStorage: nil];
     return [self initWithURL: remoteURL
+                   localUUID: localUUID
                      session: session
              requestDelegate: nil
                 continuation: continuation];
@@ -76,6 +81,7 @@ UsingLogDomain(Sync);
 - (void) start {
     CFRetain((__bridge CFTypeRef)self); // keep self from being released until it's done
     _remoteSession.authorizer.remoteURL = _remoteURL;
+    _remoteSession.authorizer.localUUID = _localUUID;
     if ([_remoteSession.authorizer conformsToProtocol: @protocol(CBLSessionCookieAuthorizer)]) {
         // Sync Gateway session API is at /db/_session; try that first
         [self checkSessionAtPath: @"_session"];

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -279,6 +279,7 @@
             LogVerbose(Sync, @"%@: Found credential, using %@", self, authorizer);
     }
     authorizer.remoteURL = _settings.remote;
+    authorizer.localUUID = db.publicUUID;
 
     // Initialize the CBLRemoteSession:
     NSURLSessionConfiguration* config = [[CBLRemoteSession defaultConfiguration] copy];
@@ -584,9 +585,10 @@
     if (_settings.authorizer) {
         [self asyncTaskStarted];
         CBLRemoteLogin* login = [[CBLRemoteLogin alloc] initWithURL: _settings.remote
-                                                        session: _remoteSession
-                                                requestDelegate: self
-                                                   continuation: ^(NSError* error)
+                                                          localUUID: _db.publicUUID
+                                                            session: _remoteSession
+                                                    requestDelegate: self
+                                                       continuation: ^(NSError* error)
         {
             if (error) {
                 LogTo(Sync, @"%@: Login error: %@", self, error.my_compactDescription);

--- a/Unit-Tests/Replication_Tests.m
+++ b/Unit-Tests/Replication_Tests.m
@@ -1695,8 +1695,9 @@ static UInt8 sEncryptionIV[kCCBlockSizeAES128];
         __block bool loginDone = false;
         __block NSError* error = nil;
         CBLRemoteLogin* login = [[CBLRemoteLogin alloc] initWithURL: remoteDbURL
-                                                     authorizer: (id<CBLAuthorizer>)auth
-                                                   continuation: ^(NSError* e)
+                                                          localUUID: db.publicUUID
+                                                         authorizer: (id<CBLAuthorizer>)auth
+                                                       continuation: ^(NSError* e)
         {
             error = e;
             loginDone = true;


### PR DESCRIPTION
Store the database UUID in the kSecAttrAccount property in the Keychain
items. That lets us scope the lookup to that database.

Fixes #1348