### PR TITLE
-[CBLReplication deleteAllCookies] should only delete cookies for its URL

### DIFF
--- a/Source/API/CBLReplication.m
+++ b/Source/API/CBLReplication.m
@@ -217,7 +217,7 @@ NSString* CBL_ReplicatorStoppedNotification = @"CBL_ReplicatorStopped";
 
 - (void) deleteAllCookies {
     [self tellCookieStorage: ^(CBLCookieStorage* storage) {
-        [storage reset];
+        [storage deleteCookiesForURL: _remoteURL];
     }];
 }
 

--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -42,6 +42,9 @@ extern NSString* const CBLCookieStorageCookiesChangedNotification;
 /** Deletes all cookies by name case-sensitively. */
 - (void) deleteCookiesNamed: (NSString*)name;
 
+/** Deletes all cookies that match the given URL. */
+- (void) deleteCookiesForURL: (NSURL*)url;
+
 /** Deletes all cookies from the cookie storage. */
 - (void) reset;
 

--- a/Source/CBLCookieStorage.m
+++ b/Source/CBLCookieStorage.m
@@ -178,11 +178,7 @@ NSString* const CBLCookieStorageCookiesChangedNotification = @"CookieStorageCook
         if (![self deleteCookie:aCookie outIndex: nil])
             return;
 
-        NSError* error;
-        if (![self saveCookies: &error]) {
-            Warn(@"%@: Cannot save cookies with an error : %@", self, error.my_compactDescription);
-        }
-        
+        [self saveCookies];
         [self notifyCookiesChanged];
     }
 }
@@ -197,11 +193,17 @@ NSString* const CBLCookieStorageCookiesChangedNotification = @"CookieStorageCook
             }
         }
 
-        NSError* error;
-        if (![self saveCookies: &error]) {
-            Warn(@"%@: Cannot save cookies with an error : %@", self, error.my_compactDescription);
-        }
+        [self saveCookies];
+        [self notifyCookiesChanged];
+    }
+}
 
+
+- (void) deleteCookiesForURL: (NSURL*)url {
+    NSArray* forURL = [self cookiesForURL: url];
+    if (forURL.count > 0) {
+        [_cookies removeObjectsInArray: forURL];
+        [self saveCookies];
         [self notifyCookiesChanged];
     }
 }
@@ -304,6 +306,14 @@ NSString* const CBLCookieStorageCookiesChangedNotification = @"CookieStorageCook
         return [_db.storage setInfo: str forKey: kDatabaseInfoCookiesKey] == kCBLStatusOK;
     else
         return NO;
+}
+
+
+- (void) saveCookies {
+    NSError* error;
+    if (![self saveCookies: &error]) {
+        Warn(@"%@: Cannot save cookies with an error : %@", self, error.my_compactDescription);
+    }
 }
 
 

--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -390,6 +390,46 @@
     AssertEqual(_cookieStore.cookies[0], cookie2);
 }
 
+- (void) test_DeleteCookiesByURL {
+    NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/supersweet",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie1];
+
+    NSHTTPCookie* cookie2 = [self cookie: @{ NSHTTPCookieName: @"oatmeal_raisin",
+                                             NSHTTPCookieDomain: @"mycookie.com",
+                                             NSHTTPCookiePath: @"/supersweet",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie2];
+
+    NSHTTPCookie* cookie3 = [self cookie: @{ NSHTTPCookieName: @"WhiteChoco",
+                                             NSHTTPCookieDomain: @"yourcookie.com",
+                                             NSHTTPCookiePath: @"/supersweet",
+                                             NSHTTPCookieValue: @"sweet",
+                                             NSHTTPCookieMaximumAge: @(3600),
+                                             NSHTTPCookieVersion: @"1"
+                                             }];
+    [_cookieStore setCookie: cookie3];
+    AssertEq(_cookieStore.cookies.count, 3u);
+
+    [_cookieStore deleteCookiesForURL: [NSURL URLWithString: @"http://kale.org/bitter"]];
+    AssertEq(_cookieStore.cookies.count, 3u);
+
+    [_cookieStore deleteCookiesForURL: [NSURL URLWithString: @"http://mycookie.com/supersweet"]];
+    AssertEq(_cookieStore.cookies.count, 1u);
+    AssertEqual(_cookieStore.cookies[0], cookie3);
+
+    [_cookieStore deleteCookiesForURL: [NSURL URLWithString: @"http://yourcookie.com/supersweet"]];
+    AssertEq(_cookieStore.cookies.count, 0u);
+}
+
 - (void) test_Reset {
     NSHTTPCookie* cookie1 = [self cookie: @{ NSHTTPCookieName: @"whitechoco",
                                              NSHTTPCookieDomain: @"mycookie.com",


### PR DESCRIPTION
Regression from the recent move of cookie storage to the database.