### PR TITLE
Restored iOS 7 / macOS 10.9 compatibility

### DIFF
--- a/Source/CBLOpenIDConnectAuthorizer.m
+++ b/Source/CBLOpenIDConnectAuthorizer.m
@@ -316,12 +316,25 @@ UsingLogDomain(Sync);
 
 
 static NSURL* extractRedirectURL(NSURL* loginURL) {
-    NSURLComponents* comp = [NSURLComponents componentsWithURL: loginURL resolvingAgainstBaseURL: YES];
-    for (NSURLQueryItem* query in comp.queryItems) {
-        if ([query.name isEqualToString: @"redirect_uri"])
-            return [NSURL URLWithString: query.value];
+    NSString* uri = nil;
+    NSURLComponents* comp = [NSURLComponents componentsWithURL: loginURL
+                                       resolvingAgainstBaseURL: YES];
+    if ([comp respondsToSelector: @selector(queryItems)]) {     // iOS 8, macOS 10.10
+        for (NSURLQueryItem* query in comp.queryItems) {
+            if ([query.name isEqualToString: @"redirect_uri"]) {
+                uri = query.value;
+                break;
+            }
+        }
+    } else {
+        for (NSString* item in [comp.query componentsSeparatedByString: @"&"]) {
+            if ([item hasPrefix: @"redirect_uri="]) {
+                uri = [[item substringFromIndex: 13] stringByRemovingPercentEncoding];
+                break;
+            }
+        }
     }
-    return nil;
+    return uri ? $url(uri) : nil;
 }
 
 

--- a/Unit-Tests/Misc_Tests.m
+++ b/Unit-Tests/Misc_Tests.m
@@ -329,7 +329,14 @@ static int collateRevs(const char* rev1, const char* rev2) {
 
 
 - (void) testMYURLUtils {
-    NSURL* url = $url(@"https://example.com/path/here?query#fragment");
+    NSURL* url = $url(@"https://example.com/path/here");
+    AssertEq(url.my_effectivePort, 443);
+    AssertEqual(url.my_baseURL, $url(@"https://example.com"));
+    AssertEqual(url.my_URLByRemovingUser, url);
+    AssertEqual(url.my_sanitizedString, @"https://example.com/path/here");
+    AssertEqual(url.my_sanitizedPath, @"/path/here");
+
+    url = $url(@"https://example.com/path/here?query#fragment");
     AssertEq(url.my_effectivePort, 443);
     AssertEqual(url.my_baseURL, $url(@"https://example.com"));
     AssertEqual(url.my_URLByRemovingUser, url);


### PR DESCRIPTION
Conditionalized some usages of NSURLComponents methods that were only
added later.
Tested both the old and new code paths.
Clean bill of health from Deploymate.

Fixes #1362