### PR TITLE
Fixed ability to store db encryption key in (macOS) Keychain

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -616,6 +616,18 @@ static void moveSQLiteDbFiles(NSString* oldDbPath, NSString* newDbPath) {
 }
 
 
+#if !TARGET_OS_IPHONE
+- (BOOL) forgetEncryptionKeyForDatabaseNamed: (NSString*)dbName
+                                       error: (NSError**)outError
+{
+    NSString* dir = _dir.stringByAbbreviatingWithTildeInPath;
+    NSString* itemName = $sprintf(@"%@ database in %@", dbName, dir);
+    return [CBLSymmetricKey deleteKeychainItemNamed: itemName error: outError];
+}
+#endif
+
+
+
 #if DEBUG
 - (CBLDatabase*) createEmptyDatabaseNamed: (NSString*)name error: (NSError**)outError {
     CBLDatabase* db = _databases[name];

--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -19,6 +19,9 @@
 #endif
 + (void) setWarningsRaiseExceptions: (BOOL)wre;
 @property NSUInteger defaultMaxRevTreeDepth;
+#if !TARGET_OS_IPHONE
+- (BOOL) forgetEncryptionKeyForDatabaseNamed: (NSString*)dbName error: (NSError**)outError;
+#endif
 @end
 
 

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -314,12 +314,14 @@ static BOOL sAutoCompact = YES;
     NSString* itemName = $sprintf(@"%@ database in %@", self.name, dir);
     NSError* error;
     CBLSymmetricKey* key = [[CBLSymmetricKey alloc] initWithKeychainItemNamed: itemName
-                                                                        error: outError];
+                                                                        error: &error];
     if (!key) {
         if (error.code == errSecItemNotFound) {
             key = [CBLSymmetricKey new];
             if (![key saveKeychainItemNamed: itemName error: outError])
                 key = nil;
+        } else {
+            if (outError) *outError = error;
         }
     }
     return key;

--- a/Source/CBLSymmetricKey.h
+++ b/Source/CBLSymmetricKey.h
@@ -49,6 +49,10 @@ typedef NSMutableData* (^CBLCryptorBlock)(NSData* input);
 - (instancetype) initWithKeychainItemNamed: (NSString*)itemName
                                      error: (NSError**)outError;
 
+/** Deletes a symmetric key from the Keychain. */
++ (BOOL) deleteKeychainItemNamed: (NSString*)itemName
+                           error: (NSError**)outError;
+
 /** Saves a key to the Keychain under the given name. */
 - (BOOL) saveKeychainItemNamed: (NSString*)itemName
                          error: (NSError**)outError;

--- a/Source/CBLSymmetricKey.m
+++ b/Source/CBLSymmetricKey.m
@@ -120,6 +120,21 @@
 }
 
 
++ (BOOL) deleteKeychainItemNamed: (NSString*)itemName
+                           error: (NSError**)outError
+{
+    NSDictionary *query = @{(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+                            (__bridge id)kSecAttrService: itemName };
+    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
+    if (status != noErr && status != errSecItemNotFound) {
+        if (outError)
+            *outError = [NSError errorWithDomain: NSOSStatusErrorDomain code: status userInfo: nil];
+        return NO;
+    }
+    return YES;
+}
+
+
 - (NSString*) hexData {
     return CBLHexFromBytes(_keyData.bytes, _keyData.length);
 }

--- a/Unit-Tests/DatabaseEncryption_Tests.m
+++ b/Unit-Tests/DatabaseEncryption_Tests.m
@@ -181,8 +181,10 @@
 
 - (void) test06_Keychain {
 #if !TARGET_OS_IPHONE
-    // Create encrypted DB:
     NSError* error;
+    Assert([dbmgr forgetEncryptionKeyForDatabaseNamed: @"seekrit" error: NULL]);
+    
+    // Create encrypted DB:
     seekrit = [self openSeekritDBWithKey: @YES error: &error];
     Assert(seekrit, @"Failed to create encrypted db: %@", error);
     [self createDocumentWithProperties: @{@"answer": @42} inDatabase: seekrit];


### PR DESCRIPTION
If in the CBL API you specify an encryption key of `@YES` when opening
a database, it'll generate a random key and store it in the Keychain.
Unfortunately the code to generate the key broke a while ago, but the
unit tests wouldn't reveal the problem if they had already been run
before, because the key would already exist.

I fixed this by:
* Correcting the bug in CBLDatabase that prevented the key from being
  generated if an existing one couldn't be found
* Adding a new private method on CBLManager to delete a database's key
  from the Keychain, which is now called before the unit test runs.