### PR TITLE
Fixed ForestDB iteration issue

### DIFF
--- a/Source/CBL_ForestDBQueryEnumerator.mm
+++ b/Source/CBL_ForestDBQueryEnumerator.mm
@@ -249,6 +249,12 @@ extern "C" {
         return row;
     }
 
+    if (c4err.code) {
+        C4SliceResult msg = c4error_getMessage(c4err);
+        Warn(@"Error enumerating query: %.*s", (int)msg.size, msg.buf);
+        c4slice_free(msg);
+    }
+
     // End of enumeration:
     [self freeEnum];
     return nil;

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -59,12 +59,13 @@ static void FDBLogCallback(C4LogLevel level, C4Slice message) {
             LogTo(Database, @"ForestDB: %.*s", (int)message.size, message.buf);
             break;
         case kC4LogWarning:
-            Warn(@"%.*s", (int)message.size, message.buf);
-            break;
         case kC4LogError: {
             bool raises = gMYWarnRaisesException;
             gMYWarnRaisesException = NO;    // don't throw from a ForestDB callback!
-            Warn(@"ForestDB error: %.*s", (int)message.size, message.buf);
+            if (level == kC4LogWarning)
+                Warn(@"%.*s", (int)message.size, message.buf);
+            else
+                Warn(@"ForestDB error: %.*s", (int)message.size, message.buf);
             gMYWarnRaisesException = raises;
             break;
         }


### PR DESCRIPTION
* Added a unit test that reproduces the issue found in ToDoLite during testathon.
* Incorporated ForestDB fix for [MB-20196](https://issues.couchbase.com/browse/MB-20196)
* Added a check in query enumeration code to warn about errors returned from the CBForest enumerator (since the CBL API doesn't provide a way to return them.)
* Turn off gMYWarnRaisesException while logging a warning from CBForest; otherwise we end up throwing an exception from within a call to CBForest, which is Very Bad.

Fixes #1370