### PR TITLE
Fix tvOS Unit Tests build failure when testing on device

### DIFF
--- a/xcconfigs/tvOS Test App.xcconfig
+++ b/xcconfigs/tvOS Test App.xcconfig
@@ -12,3 +12,4 @@ LD_RUNPATH_SEARCH_PATHS                = $(inherited) @executable_path/Framework
 PRODUCT_NAME                           = $(TARGET_NAME)
 SDKROOT                                = appletvos
 TARGETED_DEVICE_FAMILY                 = 3
+DEAD_CODE_STRIPPING                    = NO


### PR DESCRIPTION
This fix unblocks running unit tests on the tvOS device.

#1387