### PR TITLE
Allow SQLite read access concurrently with a write transaction

### DIFF
--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -392,8 +392,12 @@ DefineLogDomain(SQL);
         return NO;
     }
 
+    // Always make sure WAL is enabled because our concurrency support relies on it
+    if (![self initialize: @"PRAGMA journal_mode=WAL" error: outError])
+        return NO;
+
     BOOL isNew = (dbVersion == 0);
-    if (isNew && ![self initialize: @"PRAGMA journal_mode=WAL; BEGIN TRANSACTION" error: outError])
+    if (isNew && ![self initialize: @"BEGIN TRANSACTION" error: outError])
         return NO;
 
     if (dbVersion < 17) {


### PR DESCRIPTION
This is legal since our databases are in WAL mode. It greatly improves
concurrent access -- the ConcurrentWrites unit test (which has two
reader threads and two writers) runs 2.25x faster on my Mac!

I made a slight change to database opening to ensure that the db is
always set to WAL mode, instead of just setting the mode when the db is
first created.

Fixes #1389