### PR TITLE
Fix for replicator notifications not getting posted

### DIFF
--- a/Source/CBLRemoteSession.m
+++ b/Source/CBLRemoteSession.m
@@ -12,6 +12,7 @@
 #import "CBLCookieStorage.h"
 #import "CBLMisc.h"
 #import "MYURLUtils.h"
+#import "MYBlockUtils.h"
 
 UsingLogDomain(Sync);
 
@@ -25,6 +26,7 @@ UsingLogDomain(Sync);
     NSURL* _baseURL;
     NSURLSession* _session;
     NSRunLoop* _runLoop;
+    NSThread *_thread;
     id<CBLRemoteRequestDelegate> _requestDelegate;
     NSMutableDictionary<NSNumber*, CBLRemoteRequest*>* _requestIDs; // Used on operation queue only
     NSMutableSet<CBLRemoteRequest*>* _allRequests;                  // Used on API thread only
@@ -71,6 +73,7 @@ UsingLogDomain(Sync);
                                             delegateQueue: queue];
         _session.sessionDescription = @"Couchbase Lite";
         _runLoop = [NSRunLoop currentRunLoop];
+        _thread = [NSThread currentThread];
         _requestIDs = [NSMutableDictionary new];
     }
     return self;
@@ -165,8 +168,7 @@ UsingLogDomain(Sync);
 
 
 - (void) doAsync: (void (^)())block {
-    CFRunLoopPerformBlock(_runLoop.getCFRunLoop, kCFRunLoopDefaultMode, block);
-    CFRunLoopWakeUp(_runLoop.getCFRunLoop);
+    MYOnThread(_thread, block);
 }
 
 


### PR DESCRIPTION
This works around an OS bug where NSNotificationQueue doesn't post its
notifications when called in PostASAP mode while the runloop is handling
a block.

The workaround is to not call CFRunLoopPerform, but instead use our
existing MYPerformOnThread utility, which schedules the block in a
different way that doesn't trigger the bug.

Fixes #1392