### PR TITLE
Enable Application Extension API Only in Couchbase Lite framework target

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -5946,7 +5946,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FFFF151C973FB5001A70FC /* iOS framework_Debug.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 			};
 			name = Debug;
 		};
@@ -5954,7 +5953,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FFFF161C973FB5001A70FC /* iOS framework_Release.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 			};
 			name = Release;
 		};

--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -5946,6 +5946,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FFFF151C973FB5001A70FC /* iOS framework_Debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 			};
 			name = Debug;
 		};
@@ -5953,6 +5954,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FFFF161C973FB5001A70FC /* iOS framework_Release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 			};
 			name = Release;
 		};

--- a/xcconfigs/iOS framework.xcconfig
+++ b/xcconfigs/iOS framework.xcconfig
@@ -24,3 +24,4 @@ SKIP_INSTALL                      = YES
 TARGETED_DEVICE_FAMILY            = 1,2
 VERSION_INFO_FILE                 = 
 VERSION_INFO_PREFIX               =
+APPLICATION_EXTENSION_API_ONLY		= YES


### PR DESCRIPTION
Couchbase Lite is a database framework which can be embeded in Extensions. So I think Couchbase List should use only Extension APIs.
After testing I found that Couchbase List doesn't use any Application only APIs so that I enable the `APPLICATION_EXTENSION_API_ONLY` build setting and submit it as this PR.