### PR TITLE
Fixed the "Memory leak" issue of CBLRemoteRequest delegate object in CBL iOS 1.3

### DIFF
--- a/Source/CBLRemoteRequest.h
+++ b/Source/CBLRemoteRequest.h
@@ -30,7 +30,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
     NSMutableURLRequest* _request;
     id<CBLAuthorizer> _authorizer;
     CBLCookieStorage* _cookieStorage;
-    id<CBLRemoteRequestDelegate> _delegate;
+    __weak id<CBLRemoteRequestDelegate> _delegate;
     CBLRemoteRequestCompletionBlock _onCompletion;
     NSURLSessionTask* _task;
     int _status;
@@ -49,7 +49,7 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust);
 
 @property NSTimeInterval timeoutInterval;
 @property (strong, nonatomic) id<CBLAuthorizer> authorizer;
-@property (strong, nonatomic) id<CBLRemoteRequestDelegate> delegate;
+@property (weak, nonatomic) id<CBLRemoteRequestDelegate> delegate;
 @property (strong, nonatomic) CBLCookieStorage* cookieStorage;
 @property (nonatomic) bool autoRetry;   // Default value is YES
 @property (nonatomic) bool dontStop;

--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -353,8 +353,9 @@ void CBLWarnUntrustedCert(NSString* host, SecTrustRef trust) {
     NSURLProtectionSpace* space = challenge.protectionSpace;
     SecTrustRef trust = space.serverTrust;
     BOOL ok;
-    if (_delegate) {
-        ok = [_delegate checkSSLServerTrust: space];
+    id<CBLRemoteRequestDelegate> _strongDelegate = _delegate
+    if (_strongDelegate) {
+        ok = [_strongDelegate checkSSLServerTrust: space];
     } else {
         SecTrustResultType result;
         ok = (SecTrustEvaluate(trust, &result) == noErr) &&

--- a/Source/CBLRemoteSession.m
+++ b/Source/CBLRemoteSession.m
@@ -27,7 +27,7 @@ UsingLogDomain(Sync);
     NSURLSession* _session;
     NSRunLoop* _runLoop;
     NSThread *_thread;
-    id<CBLRemoteRequestDelegate> _requestDelegate;
+    __weak id<CBLRemoteRequestDelegate> _requestDelegate;
     NSMutableDictionary<NSNumber*, CBLRemoteRequest*>* _requestIDs; // Used on operation queue only
     NSMutableSet<CBLRemoteRequest*>* _allRequests;                  // Used on API thread only
     CBLCookieStorage* _cookieStorage;


### PR DESCRIPTION
**Issue:-**
- I encounter the memory leak while debugging in instrumentation tool and that is because, strong ownership of CBLRemoteRequestDelegate object.
- In below image, we have encountered the root cause for leak.

![screen shot 2016-09-14 at 2 19 21 pm](https://cloud.githubusercontent.com/assets/5706391/18505861/d191333a-7a86-11e6-9650-58d7f7ef02a1.png)

![screen shot 2016-09-14 at 2 19 51 pm](https://cloud.githubusercontent.com/assets/5706391/18505834/b1ce7e4a-7a86-11e6-9922-2b29d6a9e9b1.png)

**Solution:-**
- To avoid the "memory leak" for **retain cycle(Strong ownership)** for CBLRemoteRequest delegate object.
