### PR TITLE
Invalidate SQLite docNumericID cache after a transaction is aborted

### DIFF
--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -616,6 +616,9 @@ DefineLogDomain(SQL);
     if (!ok)
         Warn(@"Failed to end transaction!");
 
+    if (!commit)
+        [self invalidateDocNumericIDs]; // Forget the rowids of any aborted new docs
+
     [_delegate storageExitedTransaction: commit];
     return ok;
 }

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -1653,4 +1653,28 @@
     Assert(fabs([next timeIntervalSinceDate: future]) < 1.0);
 }
 
+
+- (void) test27_AbortedCommit {
+    // For https://github.com/couchbase/couchbase-lite-ios/issues/1437
+    // Test ported from https://github.com/couchbase/couchbase-lite-net/issues/732
+    [db inTransaction:^BOOL{
+        // Create a "rogue" document, then abort the transaction so it doesn't get saved:
+        NSError* error;
+        Assert([db[@"rogue"] putProperties: @{@"exists": @NO} error: &error]);
+        return NO; // Cancel the transaction!
+    }];
+
+    // Create a doc for real:
+    NSError* error;
+    CBLSavedRevision* rev = [db[@"proper"] putProperties: @{@"exists": @YES} error: &error];
+    Assert(rev);
+
+    // Verify the rogue doc doesn't exist:
+    AssertNil([db existingDocumentWithID: @"rogue"]);
+
+    // Try to create it:
+    rev = [db[@"rogue"] putProperties: @{@"exists": @3} error: &error];
+    Assert(rev);
+}
+
 @end


### PR DESCRIPTION
If the cache isn't invalidated, an entry can be left behind for a new
doc that was created inside the canceled transaction. Then that rowid
can be used for a different doc, and now the cache points to the wrong
doc...

Fixes #1437