### PR TITLE
Workaround for getting wrong `Server:` response header on first request

### DIFF
--- a/Source/CBLRestPuller.m
+++ b/Source/CBLRestPuller.m
@@ -217,10 +217,7 @@
 
 
 - (void) changeTrackerReceivedHTTPHeaders:(NSDictionary *)headers {
-    if (!_serverType) {
-        _serverType = headers[@"Server"];
-        LogTo(Sync, @"%@: Server is %@", self, _serverType);
-    }
+    [self receivedResponseHeaders: headers];
 }
 
 

--- a/Source/CBLRestReplicator+Internal.h
+++ b/Source/CBLRestReplicator+Internal.h
@@ -20,7 +20,6 @@
     CBLDatabase* __weak _db;
     NSString* _lastSequence;
     CBLBatcher* _batcher;
-    NSString* _serverType;
     CBLRemoteSession* _remoteSession;
 #if TARGET_OS_IPHONE
     MYBackgroundMonitor *_bgMonitor;
@@ -34,6 +33,7 @@
 - (void) addToInbox: (CBL_Revision*)rev;
 - (void) addRevsToInbox: (CBL_RevisionList*)revs;
 - (void) processInbox: (CBL_RevisionList*)inbox;  // override this
+- (void) receivedResponseHeaders: (NSDictionary*)responseHeaders;
 - (BOOL) serverIsSyncGatewayVersion: (NSString*)minVersion;
 @property (readonly) BOOL canSendCompressedRequests;
 - (void) stopRemoteRequests;

--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -62,6 +62,9 @@ UsingLogDomain(Sync);
     // Now open the connection:
     LogTo(SyncPerf, @"%@: %@ %@", self, (_usePOST ?@"POST" :@"GET"), url.resourceSpecifier);
     LogVerbose(Sync, @"%@: %@ %@", self, (_usePOST ?@"POST" :@"GET"), url.resourceSpecifier);
+    LogTo(ChangeTracker, @"%@: %@ %@ %@",
+          self, (_usePOST ?@"POST" :@"GET"), url.resourceSpecifier,
+          CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(request)));
     CFReadStreamRef cfInputStream = CFReadStreamCreateForHTTPRequest(NULL, request);
     CFRelease(request);
     if (!cfInputStream)

--- a/Source/ChangeTracker/CBLWebSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLWebSocketChangeTracker.m
@@ -69,6 +69,8 @@ UsingLogDomain(Sync);
     request.timeoutInterval = _heartbeat * 1.5;
 
     LogVerbose(Sync, @"%@: %@ %@", self, request.HTTPMethod, request.URL.resourceSpecifier);
+    LogTo(ChangeTracker, @"%@: %@ %@ %@",
+          self, request.HTTPMethod, request.URL.resourceSpecifier, request.allHTTPHeaderFields);
     _ws = [PSWebSocket clientSocketWithRequest: request];
     _ws.delegate = self;
     NSDictionary* tls = self.TLSSettings;


### PR DESCRIPTION
It's possible for an initial HTTP request sent by the replicator to hit
some middleware that returns a different Server: header, instead of SG.
In this case the replicator shouldn't hang onto that first header,
since it'll never end up using replicator optimizations like bulk_get.

I changed the logic so that if the currently cached server header is
not from SG, and we receive a different value in a subsequent response,
we switch to the new value (presumably SG.) But once we've received a
response from SG, we keep that.

Also, this commit adds some extra `ChangeTracker` logging -- the full
request headers are now logged, in an attempt to figure out why the
Cookie header isn't getting sent for one developer (which is what
triggers the above situation.)

For #1464