### PR TITLE
Make cookies shared across cookie storages

### DIFF
--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -38,6 +38,8 @@
 }
 
 - (void) reloadCookieStore {
+    // Reopen the test db to clear the shared cookies in CBL_Shared:
+    [self reopenTestDB];
     _cookieStore = [[CBLCookieStorage alloc] initWithDB: db];
 }
 


### PR DESCRIPTION
Cookies is now kept in CBL_Shared and shared with all cookie storage of the same db name. All cookies storages will now see and operate over the same set of cookies.
