### PR TITLE
Fixed #1464 : Session cookies are lost

### DIFF
--- a/Unit-Tests/CookieStorage_Tests.m
+++ b/Unit-Tests/CookieStorage_Tests.m
@@ -38,6 +38,8 @@
 }
 
 - (void) reloadCookieStore {
+    // Reopen the test db to clear the shared cookies in CBL_Shared:
+    [self reopenTestDB];
     _cookieStore = [[CBLCookieStorage alloc] initWithDB: db];
 }
 


### PR DESCRIPTION
Cookies are now kept in CBL_Shared and shared with all cookie storage of the same db name. All cookies storages will now see and operate over the same set of cookies. This will fix #1464 that the session cookies are lost when a new cookie storage is created.
