### PR TITLE
Fix crash in `-[CBLModel propertiesToSave]` for model objects with a deleted (or otherwise nil) document

### DIFF
--- a/Source/API/CBLModel.h
+++ b/Source/API/CBLModel.h
@@ -65,7 +65,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS  // Don't let compiler auto-synthesize properti
 @property (readonly) bool needsSave;
 
 /** The document's current properties (including unsaved changes) in externalized JSON format.
-    This is what will be written to the CBLDocument when the model is saved. */
+    This is what will be written to the CBLDocument when the model is saved.
+    It is not safe to send -[CBLModel propertiesToSave] to an instance whose document == nil. */
 - (NSDictionary*) propertiesToSave;
 
 /** Removes any changes made to properties and attachments since the last save. */

--- a/Source/API/CBLModel.m
+++ b/Source/API/CBLModel.m
@@ -429,6 +429,8 @@
 
 
 - (NSDictionary*) propertiesToSave {
+    NSAssert(_document, @"-propertiesToSave should not be called for model with no document (deleted document?)");
+    
     NSMutableDictionary* properties = [_document.properties mutableCopy];
     if (!properties)
         properties = [NSMutableDictionary dictionaryWithObject: _document.documentID


### PR DESCRIPTION
Addresses #1454 by adding an assertion + extending API documentation.
