### PR TITLE
Fix/file protection

### DIFF
--- a/CBL Test.entitlements
+++ b/CBL Test.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionComplete</string>
+</dict>
+</plist>

--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -1415,6 +1415,20 @@
 			remoteGlobalIDString = 27E66A571A7305B10091DA3F;
 			remoteInfo = "CBL SQLite Storage";
 		};
+		27F370771DC00C4D0096F717 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 27B7E0FA18F8FE2800044EBA /* CBForest.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 72EFA6141D8A392600D17CFE;
+			remoteInfo = "Tokenizer-Interop";
+		};
+		27F370791DC00C4D0096F717 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 27B7E0FA18F8FE2800044EBA /* CBForest.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 72EFA6631D8A5FA000D17CFE;
+			remoteInfo = "Tokenizer-Interop Static";
+		};
 		27FA99EF1917FFD000912F96 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 27B7E0FA18F8FE2800044EBA /* CBForest.xcodeproj */;
@@ -1527,6 +1541,7 @@
 		2701C2121C4D5C82006D7A99 /* libsqlcipher.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsqlcipher.a; path = vendor/SQLCipher/libs/osx/libsqlcipher.a; sourceTree = "<group>"; };
 		2701FD2E1C642669004D89FA /* CBLRemoteSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLRemoteSession.h; sourceTree = "<group>"; };
 		2701FD2F1C642669004D89FA /* CBLRemoteSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLRemoteSession.m; sourceTree = "<group>"; };
+		270849C11DE4B28B00414F33 /* CBL Test.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "CBL Test.entitlements"; sourceTree = "<group>"; };
 		270A3A821CAB1B3200EC3D99 /* CBLDynamicObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLDynamicObject.h; sourceTree = "<group>"; };
 		270A3A831CAB1B3200EC3D99 /* CBLDynamicObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLDynamicObject.m; sourceTree = "<group>"; };
 		270B3DEA1489359000E0A926 /* CouchbaseLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CouchbaseLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2423,6 +2438,7 @@
 		08FB7794FE84155DC02AAC07 /* CouchLite */ = {
 			isa = PBXGroup;
 			children = (
+				270849C11DE4B28B00414F33 /* CBL Test.entitlements */,
 				270B3E28148940C000E0A926 /* README.md */,
 				27DA4300158F9D7A00F9E7B5 /* API */,
 				08FB7795FE84155DC02AAC07 /* Source */,
@@ -3184,6 +3200,10 @@
 				27B7E10D18F8FE2800044EBA /* libforestdb.a */,
 				2773D0241DF7459B00880394 /* libTokenizer-Interop.dylib */,
 				2773D0261DF7459B00880394 /* libTokenizer.a */,
+				2747355C1CCE983000515EB2 /* SwiftForest.framework */,
+				2747355E1CCE983000515EB2 /* SwiftForestTests.xctest */,
+				27F370781DC00C4D0096F717 /* libTokenizer-Interop.dylib */,
+				27F3707A1DC00C4D0096F717 /* libTokenizer.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -4452,6 +4472,11 @@
 					};
 					27B0B80A1492C16300A817AD = {
 						DevelopmentTeam = N2Q372V7W2;
+						SystemCapabilities = {
+							com.apple.DataProtection = {
+								enabled = 1;
+							};
+						};
 					};
 					930FE55D1C58562B008107A0 = {
 						CreatedOnToolsVersion = 7.2;
@@ -4599,6 +4624,21 @@
 			fileType = "compiled.mach-o.dylib";
 			path = "libCBForest-Interop.dylib";
 			remoteRef = 27E11A5B1BD0646E00D8DB7D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		27F370781DC00C4D0096F717 /* libTokenizer-Interop.dylib */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			name = "libTokenizer-Interop.dylib";
+			path = libTokenizer.dylib;
+			remoteRef = 27F370771DC00C4D0096F717 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		27F3707A1DC00C4D0096F717 /* libTokenizer.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libTokenizer.a;
+			remoteRef = 27F370791DC00C4D0096F717 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		27FA99F01917FFD000912F96 /* libCBForest.a */ = {
@@ -6046,6 +6086,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FFFF1B1C973FB5001A70FC /* iOS Test App_Debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "CBL Test.entitlements";
+				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.TestApp;
 			};
 			name = Debug;
 		};
@@ -6053,6 +6095,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FFFF1C1C973FB5001A70FC /* iOS Test App_Release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "CBL Test.entitlements";
+				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.TestApp;
 			};
 			name = Release;
 		};

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -96,6 +96,7 @@ extern NSArray* CBL_RunloopModes;
 @property (nonatomic, readonly) BOOL exists;
 @property (nonatomic, readonly) UInt64 totalDataSize;
 @property (nonatomic, readonly) NSDate* startTime;
+@property (nonatomic, readonly) NSFileProtectionType fileProtection;
 
 @property (nonatomic, readonly) NSString* privateUUID;
 @property (nonatomic, readonly) NSString* publicUUID;

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -135,12 +135,24 @@ static BOOL sAutoCompact = YES;
     return self;
 }
 
+
 - (NSString*) description {
     return $sprintf(@"%@[<%p>%@]", [self class], self, self.name);
 }
 
+
 - (BOOL) exists {
     return [[NSFileManager defaultManager] fileExistsAtPath: _dir];
+}
+
+
+- (NSFileProtectionType) fileProtection {
+#if TARGET_OS_IPHONE
+    NSDictionary* attrs = [NSFileManager.defaultManager attributesOfItemAtPath: _dir error: NULL];
+    return attrs[NSFileProtectionKey] ?: NSFileProtectionNone;
+#else
+    return nil;
+#endif
 }
 
 

--- a/Source/CBLRestReplicator+Internal.h
+++ b/Source/CBLRestReplicator+Internal.h
@@ -23,6 +23,8 @@
     CBLRemoteSession* _remoteSession;
 #if TARGET_OS_IPHONE
     MYBackgroundMonitor *_bgMonitor;
+    BOOL _deepBackground;
+    BOOL _filesystemUnavailable;
 #endif
 }
 

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -498,6 +498,14 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
 - (void) updateActive {
     BOOL active = _batcher.count > 0 || _asyncTaskCount > 0;
     if (active != _active) {
+        // If I'm otherwise inactive, but haven't saved my checkpoint, do that first:
+        if (!active && _lastSequenceChanged) {
+            LogTo(Sync, @"%@ Progress: going inactive, after saving checkpoint...", self);
+            [self saveLastSequence];
+            if (_savingCheckpoint)
+                return;
+        }
+
         LogTo(Sync, @"%@ Progress: set active = %d", self, active);
         _active = active;
         [self updateStatus];
@@ -804,18 +812,18 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
     [body setValue: [lastSequence description] forKey: @"lastSequence"]; // always save as a string
     
     _savingCheckpoint = YES;
+    [self asyncTaskStarted];
     NSString* checkpointID = self.remoteCheckpointDocID;
-    CBLRemoteRequest* request =
-        [_remoteSession startRequest: @"PUT"
+    CBLRemoteRequest* request = [_remoteSession startRequest: @"PUT"
                           path: [@"_local/" stringByAppendingString: checkpointID]
                           body: body
-                  onCompletion: ^(id response, NSError* error) {
+                  onCompletion: ^(id response, NSError* error)
+    {
                       _savingCheckpoint = NO;
                       if (error)
                           Warn(@"%@: Unable to save remote checkpoint: %@", self, error.my_compactDescription);
                       CBLDatabase* db = _db;
-                      if (!db)
-                          return;
+        if (db) {
                       if (error) {
                           // Failed to save checkpoint:
                           switch(CBLStatusFromNSError(error, 0)) {
@@ -845,7 +853,8 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
                       if (_overdueForSave)
                           [self saveLastSequence];      // start a save that was waiting on me
                   }
-         ];
+        [self asyncTasksFinished: 1];
+    }];
     // This request should not be canceled when the replication is told to stop:
     request.dontStop = YES;
 }

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -434,9 +434,11 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
 
     [self stopCheckRequest];
 
-    if (!_suspended && [_settings isHostReachable: host]) {
+    if (_suspended) {
+        [self goOffline];
+    } else if ([_settings isHostReachable: host]) {
         [self goOnline];
-    } else if (host.reachabilityKnown || _suspended) {
+    } else if (host.reachabilityKnown) {
         if (_settings.trustReachability)
             [self goOffline];
         else
@@ -489,6 +491,7 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
 // This is used by the iOS backgrounding support (see CBLReplication+Backgrounding.m)
 - (void) setSuspended: (BOOL)suspended {
     if (suspended != _suspended) {
+        LogTo(Sync, @"%@: %@", self, (suspended ? @"SUSPENDING" : @"RESUMING"));
         _suspended = suspended;
         [self reachabilityChanged: _host];
     }
@@ -819,40 +822,40 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
                           body: body
                   onCompletion: ^(id response, NSError* error)
     {
-                      _savingCheckpoint = NO;
-                      if (error)
-                          Warn(@"%@: Unable to save remote checkpoint: %@", self, error.my_compactDescription);
-                      CBLDatabase* db = _db;
+        _savingCheckpoint = NO;
+        if (error)
+            Warn(@"%@: Unable to save remote checkpoint: %@", self, error.my_compactDescription);
+        CBLDatabase* db = _db;
         if (db) {
-                      if (error) {
-                          // Failed to save checkpoint:
-                          switch(CBLStatusFromNSError(error, 0)) {
-                              case kCBLStatusNotFound:
-                                  self.remoteCheckpoint = nil; // doc deleted or db reset
-                                  _overdueForSave = YES; // try saving again
-                                  break;
-                              case kCBLStatusConflict:
-                                  [self refreshRemoteCheckpointDoc];
-                                  break;
-                              default:
-                                  break;
-                                  // TODO: On 401 or 403, and this is a pull, remember that remote
-                                  // is read-only & don't attempt to read its checkpoint next time.
-                          }
-                      } else {
-                          // Saved checkpoint:
-                          id rev = response[@"rev"];
-                          if (rev)
-                              body.cbl_revStr = rev;
-                          self.remoteCheckpoint = body;
-                          [db setLastSequence: [lastSequence description]
-                             withCheckpointID: checkpointID];
-                          LogTo(Sync, @"%@ saved remote checkpoint '%@' (_rev=%@)",
-                                self, lastSequence, rev);
-                      }
-                      if (_overdueForSave)
-                          [self saveLastSequence];      // start a save that was waiting on me
-                  }
+            if (error) {
+                // Failed to save checkpoint:
+                switch(CBLStatusFromNSError(error, 0)) {
+                    case kCBLStatusNotFound:
+                        self.remoteCheckpoint = nil; // doc deleted or db reset
+                        _overdueForSave = YES; // try saving again
+                        break;
+                    case kCBLStatusConflict:
+                        [self refreshRemoteCheckpointDoc];
+                        break;
+                    default:
+                        break;
+                        // TODO: On 401 or 403, and this is a pull, remember that remote
+                        // is read-only & don't attempt to read its checkpoint next time.
+                }
+            } else {
+                // Saved checkpoint:
+                id rev = response[@"rev"];
+                if (rev)
+                    body.cbl_revStr = rev;
+                self.remoteCheckpoint = body;
+                [db setLastSequence: [lastSequence description]
+                   withCheckpointID: checkpointID];
+                LogTo(Sync, @"%@ saved remote checkpoint '%@' (_rev=%@)",
+                      self, lastSequence, rev);
+            }
+            if (_overdueForSave)
+                [self saveLastSequence];      // start a save that was waiting on me
+        }
         [self asyncTasksFinished: 1];
     }];
     // This request should not be canceled when the replication is told to stop:

--- a/Source/CBLStatus.h
+++ b/Source/CBLStatus.h
@@ -40,6 +40,7 @@ typedef enum {
     kCBLStatusBadParam       = 495,
     kCBLStatusDeleted        = 496,      // Document deleted
     kCBLStatusInvalidStorageType = 497,
+    kCBLStatusFilesystemLocked = 498,    // iOS file protection in effect; can't access file
 
     kCBLStatusBadChangesFeed = 587,
     kCBLStatusChangesFeedTruncated = 588,

--- a/Source/CBL_ForestDBStorage.mm
+++ b/Source/CBL_ForestDBStorage.mm
@@ -110,6 +110,7 @@ static void onCompactCallback(void *context, bool compacting) {
                                                  selector: @selector(checkStillCompacting)
                                                    object: nil];
         };
+        [bgMonitor start];
 #endif
     }
 }

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -565,6 +565,10 @@ DefineLogDomain(SQL);
             return kCBLStatusCorruptError;
         case SQLITE_NOTADB:
             return kCBLStatusUnauthorized; // DB is probably encrypted (SQLCipher)
+#if TARGET_OS_IPHONE
+        case SQLITE_CANTOPEN:
+            return kCBLStatusFilesystemLocked;
+#endif
         default:
             LogTo(Database, @"Other _fmdb.lastErrorCode %d", _fmdb.lastErrorCode);
             return kCBLStatusDBError;

--- a/Test-iOS/iOS Demo-Info.plist
+++ b/Test-iOS/iOS Demo-Info.plist
@@ -42,7 +42,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
#### Better support for iOS file protection and backgrounding:

* Enabled file protection in the iOS test app (note: only takes effect on a real device; simulator does not implement file protection!)
* The test app logs when app state changes in various ways, like going into/out of the background or files becoming inaccessible.
* Made MYBackgroundMonitor work better if the app is already backgrounded and if the background task expires. (See MYUtilities commit)
* Added CBLDatabase.fileProtection property
* REST replicator monitors when files become inaccessible and suspends the replicator for the duration.
* Thread-safety improvements in CBLRestReplicator+Backgrounding: make sure UIApplication is only called on the main thread.
* Defined new internal status kCBLStatusFilesystemLocked for when we know that file I/O failed due to file protection. It gets reported as a 500 status with message “Device locked”.

#### Replicator should save checkpoint _before_ going idle

Otherwise it doesn’t save the checkpoint if it’s finishing a replication in a background task (the process will be suspended before the timer goes off.)

#### Replicator: Fixed some logic in -reachabilityChanged handling _suspended

When _suspended is true it should always call goOffline regardless of trustReachability.