### PR TITLE
Fix replication retry is still active when the replicator is offline

### DIFF
--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -390,10 +390,9 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
         LogTo(Sync, @"%@ RETRYING, to transfer missed revisions...", self);
         _revisionsFailed = 0;
         [NSObject cancelPreviousPerformRequestsWithTarget: self
-                                                 selector: @selector(retryIfReady) object: nil];
+                                                 selector: @selector(retryIfReady)
+                                                   object: nil];
         [self retry];
-    } else {
-        [self performSelector: @selector(retryIfReady) withObject: nil afterDelay: kRetryDelay];
     }
 }
 
@@ -405,6 +404,9 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
     _online = NO;
     [self updateStatus];
     [self stopRemoteRequests];
+    [NSObject cancelPreviousPerformRequestsWithTarget: self
+                                             selector: @selector(retryIfReady)
+                                               object: nil];
     [self postProgressChanged];
     return YES;
 }


### PR DESCRIPTION
* When the replicator is offline, also cancel the retryIfRetry delayed call. When the replication becomes online, the same retry logic will be done automatically.

* This also fixes #794 issue caused by a race condition when a pull replicator becomes online and the retryIfRetry is called about at the same time but before fetchRemoteCheckpoint is done. If this condition happens, two beginReplicating() will be called (one from retry() and another one from fetchRemoteCheckpoint) and result to a crash as the changeTracker will be started twice.