### PR TITLE
Fix #1429 crash in CBLRemoteSession

### DIFF
--- a/Source/CBLRemoteSession.m
+++ b/Source/CBLRemoteSession.m
@@ -216,8 +216,12 @@ UsingLogDomain(Sync);
     if (_requestIDs.count > 0)
         Warn(@"CBLRemoteSession closed but has leftover tasks: %@", _requestIDs.allValues);
     _session = nil;
-    _allRequests = nil;
     _requestIDs = nil;
+    
+    // Reset _allRequests on the API thread:
+    [self doAsync: ^{
+        _allRequests = nil;
+    }];
 }
 
 
@@ -318,8 +322,7 @@ UsingLogDomain(Sync);
         didCompleteWithError:(nullable NSError *)error
 {
     [self requestForTask: task do: ^(CBLRemoteRequest *request) {
-        NSMutableSet<CBLRemoteRequest*>* allRequests = _allRequests;
-        [allRequests removeObject: request];
+        [_allRequests removeObject: request];
         if (error)
             [request didFailWithError: error];
         else

--- a/Source/CBLRemoteSession.m
+++ b/Source/CBLRemoteSession.m
@@ -318,7 +318,8 @@ UsingLogDomain(Sync);
         didCompleteWithError:(nullable NSError *)error
 {
     [self requestForTask: task do: ^(CBLRemoteRequest *request) {
-        [_allRequests removeObject: request];
+        NSMutableSet<CBLRemoteRequest*>* allRequests = _allRequests;
+        [allRequests removeObject: request];
         if (error)
             [request didFailWithError: error];
         else


### PR DESCRIPTION
I couldn't reproduce the issue myself but from the crash log, it seems like _allRequests is gone while it's used. Applied the technique to ensure that _allRequests is retained inside the block.

#1429