### PR TITLE
Fixed #1236 Implement longpoll and continuous _changes timeout

### DIFF
--- a/Source/CBLRouter+Changes.m
+++ b/Source/CBLRouter+Changes.m
@@ -282,16 +282,15 @@ NSTimeInterval kDefaultChangesTimeout = 60.0;
 - (void) startTimeout {
     assert(_changesTimeout > 0);
     [_changesTimeoutTimer invalidate];
-    CBL_Router* weakSelf = self;
+    __weak CBL_Router* weakSelf = self;
     _changesTimeoutTimer = [NSTimer scheduledTimerWithTimeInterval: _changesTimeout
                                                            repeats: NO block: ^(NSTimer *timer) {
         CBL_Router* strongSelf = weakSelf;
-        if (_changesMode == kLongPollFeed) {
-            [strongSelf sendLongpollResponseForChanges: @[] since: _changesSince];
-        } else {
-            [strongSelf sendContinuousLine: $dict({@"last_seq", @(_changesSince)})];
+        if (_changesMode == kLongPollFeed)
+            [strongSelf sendLongpollResponseForChanges: @[] since: strongSelf->_changesSince];
+        else
+            [strongSelf sendContinuousLine: $dict({@"last_seq", @(strongSelf->_changesSince)})];
             [strongSelf finished];
-        }
     }];
 }
 

--- a/Source/CBL_Router.h
+++ b/Source/CBL_Router.h
@@ -15,7 +15,8 @@ UsingLogDomain(Router);
 
 
 #if DEBUG
-extern NSTimeInterval kMinHeartbeat;    // Configurable for testing purposes only
+extern NSTimeInterval kMinHeartbeat;            // Configurable for testing purposes only
+extern NSTimeInterval kDefaultChangesTimeout;   // Configurable for testing purposes only
 #endif
 
 
@@ -71,6 +72,9 @@ enum {
     BOOL _changesIncludeDocs;
     BOOL _changesIncludeConflicts;
     NSTimer *_heartbeatTimer;
+    NSTimer *_changesTimeoutTimer;
+    NSTimeInterval _changesTimeout;
+    SequenceNumber _changesTimeoutSince;
 }
 
 - (instancetype) initWithServer: (CBL_Server*)server

--- a/Source/CBL_Router.h
+++ b/Source/CBL_Router.h
@@ -74,7 +74,7 @@ enum {
     NSTimer *_heartbeatTimer;
     NSTimer *_changesTimeoutTimer;
     NSTimeInterval _changesTimeout;
-    SequenceNumber _changesTimeoutSince;
+    SequenceNumber _changesSince;
 }
 
 - (instancetype) initWithServer: (CBL_Server*)server

--- a/Source/CBL_Router.m
+++ b/Source/CBL_Router.m
@@ -663,6 +663,7 @@ static NSArray* splitPath( NSURL* url ) {
 // Send a JSON object followed by a newline without closing the connection.
 // Used by the continuous mode of _changes and _active_tasks.
 - (void) sendContinuousLine: (NSDictionary*)changeDict {
+    Log(@"CBL_Router: Sending continous change chunk");
     NSMutableData* json = [[CBLJSON dataWithJSONObject: changeDict
                                                options: 0 error: NULL] mutableCopy];
     if (_changesMode == kEventSourceFeed) {
@@ -713,6 +714,8 @@ static NSArray* splitPath( NSURL* url ) {
 - (void) stopNow {
     _running = NO;
     [self stopHeartbeat];
+    [_changesTimeoutTimer invalidate];
+    _changesTimeoutTimer = nil;
     self.onResponseReady = nil;
     self.onDataAvailable = nil;
     self.onFinished = nil;


### PR DESCRIPTION
* Implement _changes timeout for longpoll and continuous feeds

* The default timeout of 60 seconds applied will be applied if there is no timeout as well as heartbeat param set.

#1236