### PR TITLE
Fixed #1343 rekey when there are multiple database handles

### DIFF
--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -25,6 +25,8 @@ extern NSString* const CBL_DatabaseWillCloseNotification;
 /** NSNotification posted when a database is about to be deleted (but before it closes). */
 extern NSString* const CBL_DatabaseWillBeDeletedNotification;
 
+/** NSNotification posted when a database is about to be rekeyed (but before it closes). */
+extern NSString* const CBL_DatabaseWillBeRekeyedNotification;
 
 /** A private runloop mode for waiting on. */
 extern NSString* const CBL_PrivateRunloopMode;


### PR DESCRIPTION
* Follow the same logic as deleting the database by closing all database handles first before rekeying. The database will be reopened and rekeyed.

* Add CBL_DatabaseWillBeRekeyedNotification to notify all database objects that the database will be rekey so that the database objects of the same database can be closed.

#1343