### PR TITLE
Make CBLDatabaseChange’s isDeletion property public

### DIFF
--- a/Source/API/CouchbaseLitePrivate.h
+++ b/Source/API/CouchbaseLitePrivate.h
@@ -64,7 +64,6 @@
 
 @interface CBLDatabaseChange ()
 @property (readonly) UInt64 sequenceNumber;
-@property (readonly) BOOL isDeletion;
 /** The revID of the default "winning" revision, or nil if it did not change. */
 @property (nonatomic, readonly) CBL_RevID* winningRevisionID;
 /** The revision that is now the default "winning" revision of the document, or nil if not known

--- a/Source/CBLDatabaseChange.h
+++ b/Source/CBLDatabaseChange.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** YES if the document is in conflict. (The conflict might pre-date this change.) */
 @property (readonly) BOOL inConflict;
 
+/** YES of the document is deleted. */
+@property (readonly) BOOL isDeletion;
+
 /** The remote database URL that this change was pulled from, if any. */
 @property (readonly, nullable) NSURL* source;
 


### PR DESCRIPTION
Moved isDeletion property from private to public.

#1538