### PR TITLE
Fix #1491 change file protection level not effected

### DIFF
--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -241,7 +241,10 @@ static CBLManager* sInstance;
                 NSArray* paths = [[fmgr subpathsAtPath: _dir] arrayByAddingObject: @"."];
                 for (NSString* path in paths) {
                     NSString* absPath = [_dir stringByAppendingPathComponent: path];
-                    if (![absPath hasSuffix:@"-shm"]) { // Not changing -shm file
+                    if (![absPath hasSuffix:@"-shm"]) {
+                        // Not changing -shm file as it has NSFileProtectionNone by default
+                        // regardless of its parent directory projection level. The -shm file
+                        // contains non-sensitive information.
                         if (![fmgr setAttributes: attributes ofItemAtPath: absPath error: outError])
                             return nil;
                     }

--- a/Source/API/CBLManager.m
+++ b/Source/API/CBLManager.m
@@ -217,22 +217,38 @@ static CBLManager* sInstance;
         }
         attributes = @{NSFileProtectionKey: protection};
 #endif
-        if (![[NSFileManager defaultManager] createDirectoryAtPath: _dir
-                                       withIntermediateDirectories: YES
-                                                        attributes: attributes
-                                                             error: &error]) {
+        NSFileManager* fmgr = [NSFileManager defaultManager];
+        if (![fmgr createDirectoryAtPath: _dir
+             withIntermediateDirectories: YES
+                              attributes: attributes
+                                   error: &error]) {
             if (!CBLIsFileExistsError(error)) {
                 if (outError) *outError = error;
                 return nil;
             }
-            if (attributes) {
-                if (![[NSFileManager defaultManager] setAttributes: attributes
-                                                      ofItemAtPath: _dir
-                                                             error: outError]) {
-                    return nil;
+        }
+        
+        if (attributes) {
+            BOOL needChange = NO;
+            for (NSString* key in attributes) {
+                id prot = [[fmgr attributesOfItemAtPath: _dir error: nil] objectForKey: key];
+                if (![attributes[key] isEqual: prot]) {
+                    needChange = YES;
+                    break;
+                }
+            }
+            if (needChange) {
+                NSArray* paths = [[fmgr subpathsAtPath: _dir] arrayByAddingObject: @"."];
+                for (NSString* path in paths) {
+                    NSString* absPath = [_dir stringByAppendingPathComponent: path];
+                    if (![absPath hasSuffix:@"-shm"]) { // Not changing -shm file
+                        if (![fmgr setAttributes: attributes ofItemAtPath: absPath error: outError])
+                            return nil;
+                    }
                 }
             }
         }
+        
         [self upgradeOldDatabaseFiles];
     }
     return self;

--- a/Unit-Tests/DatabaseInternal_Tests.m
+++ b/Unit-Tests/DatabaseInternal_Tests.m
@@ -913,8 +913,24 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
 - (void) test25_FileProtection {
     // Check that every file has the file protection set for the CBLManager (which defaults to
     // NSFileProtectionCompleteUnlessOpen.)
+    [self verifyFileProtection: NSFileProtectionCompleteUnlessOpen forDir: db.dir];
+    
+    
+    
+    // Change file protection to NSFileProtectionNone:
+    NSError* error;
+    CBLManagerOptions options = {.fileProtection=NSDataWritingFileProtectionNone};
+    CBLManager* manager = [[CBLManager alloc] initWithDirectory: db.manager.directory
+                                                        options: &options
+                                                          error: &error];
+    Assert(manager, @"Error when creating a new manager: %@", error);
+    [self verifyFileProtection: NSFileProtectionNone forDir: db.dir];
+    [manager close];
+}
+
+
+- (void) verifyFileProtection: (NSFileProtectionType)protection forDir: (NSString*)dir {
     NSFileManager* fmgr = [NSFileManager defaultManager];
-    NSString* dir = db.dir;
     NSArray* paths = [[fmgr subpathsAtPath: dir] arrayByAddingObject: @"."];
     for (NSString* path in paths) {
         NSString* absPath = [dir stringByAppendingPathComponent: path];
@@ -923,11 +939,12 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
         // Not checking -shm file as it will have NSFileProtectionNone by default regardless of its
         // parent directory projection level. However, the -shm file contains non-sensitive information.
         if (![path hasSuffix:@"-shm"])
-            AssertEqual(prot, NSFileProtectionCompleteUnlessOpen);
+            AssertEqual(prot, protection);
     }
 }
 #endif
 #endif
+
 
 -(void) test26_ReAddAfterPurge {
 


### PR DESCRIPTION
File protection was set only when first creating the manager directory. Need to ensure that the file protection level is set (if specified) even when the manager directory already exists.

#1491