### PR TITLE
Fixed #1551 Implement timeout in ChangeTracker for longpoll and websocket mode

### DIFF
--- a/Source/ChangeTracker/CBLChangeTracker.h
+++ b/Source/ChangeTracker/CBLChangeTracker.h
@@ -68,6 +68,7 @@ typedef enum CBLChangeTrackerMode {
     BOOL _caughtUp;
     BLIPHTTPLogic* _http;
     BOOL _usePOST;
+    NSTimer* _timeoutTimer;
 }
 
 - (instancetype) initWithDatabaseURL: (NSURL*)databaseURL
@@ -120,5 +121,12 @@ typedef enum CBLChangeTrackerMode {
 - (void) stopped; // override this
 - (BOOL) parseBytes: (const void*)bytes length: (size_t)length;
 - (NSInteger) endParsingData;
+
+/** Start and stop read timeout only for longpoll and websocket mode. Calling this method from
+ the other modes will be no ops. If timeout occurs while change tracker is in paused state, 
+ the timeout timer will be restarted. */
+- (void) startTimeout;
+- (void) stopTimeout;
+- (void) handleTimeout; // override this
 
 @end

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -402,7 +402,7 @@ DefineLogDomain(ChangeTracker);
              LogVerbose(ChangeTracker, @"%@: Timeout but paused, restart timeout", strongSelf);
              [strongSelf startTimeout];
          } else {
-             LogVerbose(ChangeTracker, @"%@: Timeout ...", self);
+             LogVerbose(ChangeTracker, @"%@: Timeout ...", strongSelf);
              [strongSelf handleTimeout];
          }
      }];
@@ -415,6 +415,8 @@ DefineLogDomain(ChangeTracker);
     }
 }
 
-- (void) handleTimeout {  }
+- (void) handleTimeout {
+    [self failedWithErrorDomain: NSURLErrorDomain code: NSURLErrorTimedOut message: @"Timeout"];
+}
 
 @end

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -38,7 +38,7 @@ DefineLogDomain(ChangeTracker);
 #define kInitialRetryDelay 2.0      // Initial retry delay (doubles after every subsequent failure)
 #define kMaxRetryDelay (10*60.0)    // ...but will never get longer than this
 
-#define kMinTimeout (2 * 60.0)      // Minimum read timeout value for longpoll and websocket mode
+#define kMinTimeout 60.0            // Minimum read timeout value for longpoll and websocket mode
 
 
 @interface CBLChangeTracker ()

--- a/Source/ChangeTracker/CBLSocketChangeTracker.m
+++ b/Source/ChangeTracker/CBLSocketChangeTracker.m
@@ -36,7 +36,6 @@ UsingLogDomain(Sync);
 
 #define kReadLength 4096u
 
-#define _kCFStreamPropertyReadTimeout CFSTR("_kCFStreamPropertyReadTimeout")
 
 @implementation CBLSocketChangeTracker
 {
@@ -46,7 +45,6 @@ UsingLogDomain(Sync);
     bool _gotResponseHeaders;
     bool _readyToRead;
     NSString* _serverName;
-    NSTimer* timeoutTimer;
 }
 
 - (BOOL) start {
@@ -355,11 +353,6 @@ UsingLogDomain(Sync);
             LogTo(ChangeTracker, @"%@: Event %lx on %@", self, (long)eventCode, stream);
             break;
     }
-}
-
-
-- (void) handleTimeout {
-    [self failedWithErrorDomain: NSURLErrorDomain code: NSURLErrorTimedOut message: @"Timeout"];
 }
 
 


### PR DESCRIPTION
* Implement timeout in ChangeTracker only for longpoll and websocket mode.
* Timeout value is greater than the heartbeat value 10%.
* When timeout occurs, both socket and websocket ChangeTracker will be failed with NSURLErrorTimedOut and the errors will be handled by the puller replicator with the retry logic.

#1551