### PR TITLE
Query: Added support for indexing expressions (not just properties)

### DIFF
--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -149,31 +149,33 @@ typedef struct {
 /** Creates a value index (type kCBLValueIndex) on a given document property.
     This will speed up queries that test that property, at the expense of making database writes a
     little bit slower.
-    @param propertyPath  JSON path to the property, e.g. "color" or "name.last".
+    @param expressions  Expressions to index, typically key-paths.
     @param error  If an error occurs, it will be stored here if this parameter is non-NULL.
     @return  True on success, false on failure. */
-- (bool) createIndexOn: (NSString*)propertyPath
+- (bool) createIndexOn: (NSArray<NSExpression*>*)expressions
                  error: (NSError**)error;
 
 /** Creates an index on a given document property.
     This will speed up queries that test that property, at the expense of making database writes a
     little bit slower.
-    @param propertyPath  JSON path to the property, e.g. "color" or "name.last".
+    @param expressions  Expressions to index, typically key-paths.
     @param type  Type of index to create (value, full-text or geospatial.)
     @param options  Options affecting the index, or NULL for default settings.
     @param error  If an error occurs, it will be stored here if this parameter is non-NULL.
     @return  True on success, false on failure. */
-- (bool) createIndexOn: (NSString*)propertyPath
+- (bool) createIndexOn: (NSArray<NSExpression*>*)expressions
                   type: (CBLIndexType)type
                options: (nullable const CBLIndexOptions*)options
                  error: (NSError**)error;
 
 /** Deletes an existing index. Returns NO if the index did not exist.
-    @param propertyPath  Property path that the index was created on.
+    @param expressions  Expressions indexed (same parameter given to -createIndexOn:.)
     @param type  Type of index.
+    @param error  If an error occurs, it will be stored here if this parameter is non-NULL.
     @return  True if the index existed and was deleted, false if it did not exist. */
-- (bool) deleteIndexOn: (NSString*)propertyPath
-                  type: (CBLIndexType)type;
+- (bool) deleteIndexOn: (NSArray<NSExpression*>*)expressions
+                  type: (CBLIndexType)type
+                 error: (NSError**)error;
 
 @end
 

--- a/Objective-C/CBLQuery+Predicates.mm
+++ b/Objective-C/CBLQuery+Predicates.mm
@@ -78,6 +78,21 @@ static NSDictionary* const  kFunctionNames = @{ @"sum:":           @"ARRAY_SUM()
 }
 
 
+// Translates an NSExpression into its JSON equivalent
++ (NSData*) encodeIndexExpressions: (NSArray<NSExpression*>*)expressions
+                             error: (NSError**)outError
+{
+    NSMutableArray *array = [NSMutableArray new];
+    for (NSExpression* expr in expressions) {
+        id encoded = EncodeExpression(expr, outError);
+        if (!encoded)
+            return nil;
+        [array addObject: encoded];
+    }
+    return [NSJSONSerialization dataWithJSONObject: array options: 0 error: outError];
+}
+
+
 // Encodes an NSPredicate.
 static id EncodePredicate(NSPredicate* pred, NSError** outError) {
     if ([pred isKindOfClass: [NSComparisonPredicate class]]) {

--- a/Objective-C/Internal/CBLQuery+Internal.h
+++ b/Objective-C/Internal/CBLQuery+Internal.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Just encodes the query into the JSON form parsed by LiteCore. (Exposed for testing.) */
 + (nullable NSData*) encodeQuery: (nullable id)where
                          orderBy: (nullable NSArray*)sortDescriptors
-                           error: (NSError**)outError;
+                           error: (NSError**)error;
 
 @end
 
@@ -35,12 +35,16 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CBLQuery (Predicates)
 
 /** Converts an NSPredicate into a JSON-compatible object tree of a LiteCore query. */
-+ (id) encodePredicate: (NSPredicate*)pred
-                 error: (NSError**)outError;
++ (nullable id) encodePredicate: (NSPredicate*)pred
+                          error: (NSError**)error;
+
+/** Translates an array of NSExpressions into the JSON equivalent. */
++ (nullable NSData*) encodeIndexExpressions: (NSArray<NSExpression*>*)expressions
+                                      error: (NSError**)error;
 
 #if DEBUG // these methods are only for tests
 + (void) dumpPredicate: (NSPredicate*)pred;
-+ (NSString*) json5ToJSON: (const char*)json5;
++ (nullable NSString*) json5ToJSON: (const char*)json5;
 #endif
 
 @end

--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -95,6 +95,7 @@
     }
 
     // Try a query involving a property. The first pass will be unindexed, the 2nd indexed.
+    NSArray* indexSpec = @[ [NSExpression expressionForKeyPath: @"name.first"] ];
     for (int pass = 0; pass < 2; ++pass) {
         CBLQuery *q = [self.db createQuery: @"name.first == $FIRSTNAME" error: &error];
         XCTAssert(q, @"Couldn't create query: %@", error);
@@ -116,10 +117,10 @@
         XCTAssertEqual(n, 1);
 
         if (pass == 0) {
-            XCTAssert([self.db createIndexOn: @"name.first" type: kCBLValueIndex options: NULL error: &error]);
+            XCTAssert([self.db createIndexOn: indexSpec type: kCBLValueIndex options: NULL error: &error]);
         }
     }
-    XCTAssert([self.db deleteIndexOn: @"name.first" type: kCBLValueIndex]);
+    XCTAssert([self.db deleteIndexOn: indexSpec type: kCBLValueIndex error: &error]);
 }
 
 


### PR DESCRIPTION
Exposing the new LiteCore feature (and API change) in the Obj-C API.