### PR TITLE
Fix converting fleece root to dictionary

### DIFF
--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -222,12 +222,12 @@ NSString* const kCBLDocumentIsExternalUserInfoKey = @"CBLDocumentIsExternalUserI
 - (void) setC4Doc: (nullable C4Document*)doc {
     c4doc_free(_c4doc);
     _c4doc = doc;
-    [self setRootDict: nullptr orProperties: nil];
+    [self setRootDict: nullptr];
     if (_c4doc) {
         C4Slice body = _c4doc->selectedRev.body;
         if (body.size > 0) {
             FLDict root = FLValue_AsDict(FLValue_FromTrustedData({body.buf, body.size}));
-            [self setRootDict: root orProperties: nil];
+            [self setRootDict: root];
         }
     }
 }

--- a/Objective-C/Internal/CBLInternal.h
+++ b/Objective-C/Internal/CBLInternal.h
@@ -45,9 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
 // Having changes flag
 @property (nonatomic) BOOL hasChanges;
 
-// Set the root or the original properties. After calling this method, the current changes will
+// Set the root properties. After calling this method, the current changes will
 // be on top of the new root properties and the hasChanges flag will be reset.
-- (void) setRootDict: (nullable FLDict)root orProperties: (nullable NSDictionary*) props;
+- (void) setRootDict: (nullable FLDict)root;
 
 // Reset both current changes and hasChanges flag.
 - (void) resetChanges;

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -565,6 +565,29 @@
     }
 }
 
+- (void)testReadExistingBlob {
+    CBLDocument* doc = [self.db documentWithID: @"doc1"];
+    NSData* content = [@"12345" dataUsingEncoding:NSUTF8StringEncoding];
+    NSError* error;
+    CBLBlob *data = [[CBLBlob alloc] initWithContentType:@"text/plain" data:content error:&error];
+    Assert(data, @"Failed to create blob: %@", error);
+    doc[@"data"] = data;
+    doc[@"name"] = @"Jim";
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    doc = [[self.db copy] documentWithID: @"doc1"];
+    Assert([doc[@"data"] isKindOfClass:[CBLBlob class]]);
+    data = doc[@"data"];
+    AssertEqualObjects(data.content, content);
+    
+    doc = [[self.db copy] documentWithID: @"doc1"];
+    doc[@"foo"] = @"bar";
+    Assert([doc save: &error], @"Saving error: %@", error);
+    Assert([doc[@"data"] isKindOfClass:[CBLBlob class]]);
+    data = doc[@"data"];
+    AssertEqualObjects(data.content, content);
+}
+
 - (CBLBlob *)createBlob:(NSString *)contentType withData:(NSData *)data error:(NSError **)outError {
     return [[CBLBlob alloc] initWithContentType:contentType data:data error:outError];
 }


### PR DESCRIPTION
* Calling -fleeceValueToObject: to convert _root directly will end up always converting the whole _root into dictionary as checking dictionary tyle (_cbltype) will always be null at the _root level. Instead, constructing the dictionary by looping through each key/value at the root level and calling fleeceValueToObject() to convert each value.

* Removed unused variable.

#1590