### PR TITLE
Fixed objective-c to swift bridging API

### DIFF
--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -111,7 +111,7 @@ typedef struct {
  of the batch operations. If the block returns NO, the batch is rolled back. 
  Use this when performing bulk write operations like multiple inserts/updates; it saves the
  overhead of multiple database commits, greatly improving performance. */
-- (bool) inBatch: (NSError**)outError do: (BOOL (^)())block;
+- (BOOL) inBatch: (NSError**)outError do: (BOOL (^)())block;
 
 /** Creates a new CBLDocument object with no properties and a new (random) UUID. 
  The document will be saved to the database when you call -save: on it. */
@@ -173,7 +173,7 @@ typedef struct {
                     or NSStrings that are expression format strings.
     @param error  If an error occurs, it will be stored here if this parameter is non-NULL.
     @return  True on success, false on failure. */
-- (bool) createIndexOn: (NSArray*)expressions
+- (BOOL) createIndexOn: (NSArray*)expressions
                  error: (NSError**)error;
 
 /** Creates an index on a given document property.
@@ -185,7 +185,7 @@ typedef struct {
     @param options  Options affecting the index, or NULL for default settings.
     @param error  If an error occurs, it will be stored here if this parameter is non-NULL.
     @return  True on success, false on failure. */
-- (bool) createIndexOn: (NSArray*)expressions
+- (BOOL) createIndexOn: (NSArray*)expressions
                   type: (CBLIndexType)type
                options: (nullable const CBLIndexOptions*)options
                  error: (NSError**)error;
@@ -195,7 +195,7 @@ typedef struct {
     @param type  Type of index.
     @param error  If an error occurs, it will be stored here if this parameter is non-NULL.
     @return  True if the index existed and was deleted, false if it did not exist. */
-- (bool) deleteIndexOn: (NSArray*)expressions
+- (BOOL) deleteIndexOn: (NSArray*)expressions
                   type: (CBLIndexType)type
                  error: (NSError**)error;
 

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -265,7 +265,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     _c4db = nullptr;
     c4dbobs_free(_obs);
     _obs = nullptr;
-    return true;
+    return YES;
 }
 
 
@@ -286,7 +286,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 }
 
 
-- (bool) inBatch: (NSError**)outError do: (BOOL (^)())block {
+- (BOOL) inBatch: (NSError**)outError do: (BOOL (^)())block {
     C4Transaction transaction(_c4db);
     if (outError)
         *outError = nil;
@@ -295,13 +295,13 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
         return convertError(transaction.error(), outError);
     
     if (!block())
-        return false;
+        return NO;
     
     if (!transaction.commit())
         return convertError(transaction.error(), outError);
     
     [self postDatabaseChanged];
-    return true;
+    return YES;
 }
 
 
@@ -475,14 +475,14 @@ static NSString* attachmentsPath(NSString* dir) {
 }
 
 
-- (bool) createIndexOn: (NSArray<NSExpression*>*)expressions
+- (BOOL) createIndexOn: (NSArray<NSExpression*>*)expressions
                  error: (NSError**)outError
 {
     return [self createIndexOn: expressions type: kCBLValueIndex options: NULL error: outError];
 }
 
 
-- (bool) createIndexOn: (NSArray*)expressions
+- (BOOL) createIndexOn: (NSArray*)expressions
                   type: (CBLIndexType)type
                options: (const CBLIndexOptions*)options
                  error: (NSError**)outError
@@ -490,7 +490,7 @@ static NSString* attachmentsPath(NSString* dir) {
     static_assert(sizeof(CBLIndexOptions) == sizeof(C4IndexOptions), "Index options incompatible");
     NSData* json = [CBLQuery encodeExpressionsToJSON: expressions error: outError];
     if (!json)
-        return false;
+        return NO;
     C4Error c4err;
     return c4db_createIndex(_c4db,
                             {json.bytes, json.length},
@@ -501,16 +501,16 @@ static NSString* attachmentsPath(NSString* dir) {
 }
 
 
-- (bool) deleteIndexOn: (NSArray<NSExpression*>*)expressions
+- (BOOL) deleteIndexOn: (NSArray<NSExpression*>*)expressions
                   type: (CBLIndexType)type
                  error: (NSError**)outError
 {
     NSData* json = [CBLQuery encodeExpressionsToJSON: expressions error: outError];
     if (!json)
-        return false;
+        return NO;
     C4Error c4err;
     return c4db_deleteIndex(_c4db, {json.bytes, json.length}, (C4IndexType)type, &c4err)
-                || convertError(c4err, outError);;
+            || convertError(c4err, outError);
 }
 
 

--- a/Objective-C/CBLDocument.h
+++ b/Objective-C/CBLDocument.h
@@ -55,6 +55,12 @@ extern NSString* const kCBLDocumentIsExternalUserInfoKey;
 /** Revert changes made to the document. */
 - (void) revert;
 
+/** Same as objectForKey: */
+- (nullable id) objectForKeyedSubscript: (NSString*)key;
+
+/** Same as setObject:forKey: */
+- (void) setObject: (nullable id)value forKeyedSubscript: (NSString*)key;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -160,6 +160,11 @@ NSString* const kCBLDocumentIsExternalUserInfoKey = @"CBLDocumentIsExternalUserI
 }
 
 
+- (id) objectForKeyedSubscript: (NSString*)key {
+    return [super objectForKeyedSubscript: key];
+}
+
+
 - (void)setProperties:(NSDictionary *)properties {
     [super setProperties:properties];
     [self noteChanged];
@@ -406,6 +411,7 @@ static bool dictContainsBlob(__unsafe_unretained NSDictionary* dict) {
     [self postChangedNotificationExternal:NO];
     return YES;
 }
+
 
 @end
 


### PR DESCRIPTION
* Make sure to use BOOL (not bool) and NSError** pattern to get convert to throws in Swift.

* Redeclare subscription methods, otherwise they don't get exposed to the Swift bridging APIs.