### PR TITLE
Document/Properties improvements

### DIFF
--- a/Objective-C/CBLDocument.h
+++ b/Objective-C/CBLDocument.h
@@ -84,6 +84,11 @@ extern NSString* const kCBLDocumentIsExternalUserInfoKey;
 /** Reverts unsaved changes made to the document's properties. */
 - (void) revert;
 
+@end
+
+
+@interface CBLDocument (Subscripts)
+
 /** Same as objectForKey: */
 - (nullable id) objectForKeyedSubscript: (NSString*)key;
 

--- a/Objective-C/CBLProperties.h
+++ b/Objective-C/CBLProperties.h
@@ -102,6 +102,9 @@ NS_ASSUME_NONNULL_BEGIN
     like an NSMutableDictionary but with type-safe accessors.
     Abstract superclass of CBLDocument and (soon) CBLSubdocument. */
 @interface CBLProperties: NSObject <CBLProperties>
+
+- (instancetype) init NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/CBLInternal.h
+++ b/Objective-C/Internal/CBLInternal.h
@@ -65,6 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
 // Having changes flag
 @property (nonatomic) BOOL hasChanges;
 
+// Called after a change occurs
+- (void) markChanges;
+
 // Set the root properties. After calling this method, the current changes will
 // be on top of the new root properties and the hasChanges flag will be reset.
 - (void) setRootDict: (nullable FLDict)root;


### PR DESCRIPTION
- Moved the subscript operator overrides in CBLDocument to a category, so they don’t actually have to be implemented (the runtime will just use the inherited implementations.)
- Cleaned up some method names in CBLDocument (NSError** parameters should always come last.)
- Cleaned up change notification handling in CBLDocument.
- Cleanup/optimizations in CBLProperties.