### PR TITLE
Fixed #1596 and #1598 Ignore some SQLite errors

### DIFF
--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -117,10 +117,19 @@ static void errorLogCallback(void *pArg, int errCode, const char *msg) {
     if (baseCode == SQLITE_CONSTRAINT)
         return;     // This happens when we insert a rev that already exists; not a problem
 
-    if (baseCode == SQLITE_NOTICE || baseCode == SQLITE_READONLY)
+    if (baseCode == SQLITE_NOTICE || baseCode == SQLITE_READONLY) {
         Log(@"SQLite message: %s", msg);
-    else
-        Warn(@"SQLite error (code %d): %s", errCode, msg);
+        return;
+    } else if (baseCode == SQLITE_ERROR) {
+        NSString* m = [NSString stringWithUTF8String: msg];
+        if ([m hasPrefix: @"no such table"] ||     // https://github.com/couchbase/couchbase-lite-ios/issues/1596
+            [m hasPrefix: @"statement aborts"])    // https://github.com/couchbase/couchbase-lite-ios/issues/1598
+        {
+            Log(@"SQLite error: %s", msg);
+            return;
+        }
+    }
+    Warn(@"SQLite error (code %d): %s", errCode, msg);
 }
 
 

--- a/Source/CBL_SQLiteStorage.m
+++ b/Source/CBL_SQLiteStorage.m
@@ -117,19 +117,14 @@ static void errorLogCallback(void *pArg, int errCode, const char *msg) {
     if (baseCode == SQLITE_CONSTRAINT)
         return;     // This happens when we insert a rev that already exists; not a problem
 
-    if (baseCode == SQLITE_NOTICE || baseCode == SQLITE_READONLY) {
+    if (baseCode == SQLITE_NOTICE || baseCode == SQLITE_READONLY)
         Log(@"SQLite message: %s", msg);
-        return;
-    } else if (baseCode == SQLITE_ERROR) {
-        NSString* m = [NSString stringWithUTF8String: msg];
-        if ([m hasPrefix: @"no such table"] ||     // https://github.com/couchbase/couchbase-lite-ios/issues/1596
-            [m hasPrefix: @"statement aborts"])    // https://github.com/couchbase/couchbase-lite-ios/issues/1598
-        {
-            Log(@"SQLite error: %s", msg);
-            return;
-        }
+    else {
+        bool raises = gMYWarnRaisesException;
+        gMYWarnRaisesException = NO; // don't throw as it's invokded by SQLite.
+        Warn(@"SQLite error (code %d): %s", errCode, msg);
+        gMYWarnRaisesException = raises;
     }
-    Warn(@"SQLite error (code %d): %s", errCode, msg);
 }
 
 


### PR DESCRIPTION
* Ignore `no such table: cfurl_cache_response` as using an NSURLConnection to connect to a custom scheme URL before the scheme is registered will cause this error which is harmless. #1596

* The statement error could happen when using invalid FTS query strings . Instead of crash from the warning, the error should return appropriately. #1598