### PR TITLE
Implement subdocument

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -87,6 +87,9 @@
 		934F4CB81E241FB500F90659 /* CBLSymmetricKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 934F4CA51E241FB500F90659 /* CBLSymmetricKey.h */; };
 		934F4CB91E241FB500F90659 /* CBLSymmetricKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 934F4CA61E241FB500F90659 /* CBLSymmetricKey.m */; };
 		934F4CC41E24747E00F90659 /* CBLProperties.mm in Sources */ = {isa = PBXBuildFile; fileRef = 934F4CC31E24747E00F90659 /* CBLProperties.mm */; };
+		9352942B1E501055005CE4E8 /* CBLSubdocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 935294291E501055005CE4E8 /* CBLSubdocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9352942C1E501055005CE4E8 /* CBLSubdocument.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9352942A1E501055005CE4E8 /* CBLSubdocument.mm */; };
+		9352945F1E51708E005CE4E8 /* SubdocumentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9352945E1E51708E005CE4E8 /* SubdocumentTest.m */; };
 		936483B71E4431C6008D08B3 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 936483AC1E4431C6008D08B3 /* AppDelegate.m */; };
 		936483B81E4431C6008D08B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 936483AD1E4431C6008D08B3 /* Assets.xcassets */; };
 		936483B91E4431C6008D08B3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 936483AE1E4431C6008D08B3 /* LaunchScreen.storyboard */; };
@@ -353,6 +356,9 @@
 		934F4CA51E241FB500F90659 /* CBLSymmetricKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLSymmetricKey.h; sourceTree = "<group>"; };
 		934F4CA61E241FB500F90659 /* CBLSymmetricKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLSymmetricKey.m; sourceTree = "<group>"; };
 		934F4CC31E24747E00F90659 /* CBLProperties.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLProperties.mm; sourceTree = "<group>"; };
+		935294291E501055005CE4E8 /* CBLSubdocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLSubdocument.h; sourceTree = "<group>"; };
+		9352942A1E501055005CE4E8 /* CBLSubdocument.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLSubdocument.mm; sourceTree = "<group>"; };
+		9352945E1E51708E005CE4E8 /* SubdocumentTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SubdocumentTest.m; sourceTree = "<group>"; };
 		936483AB1E4431C6008D08B3 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		936483AC1E4431C6008D08B3 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		936483AD1E4431C6008D08B3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -659,6 +665,8 @@
 				93BFCD9F1E0385EA00E52F8A /* CBLDatabase.mm */,
 				9380C6ED1E15B8C20011E8CB /* CBLDocument.h */,
 				9380C6EE1E15B8C20011E8CB /* CBLDocument.mm */,
+				935294291E501055005CE4E8 /* CBLSubdocument.h */,
+				9352942A1E501055005CE4E8 /* CBLSubdocument.mm */,
 				2704F1C71E395F3300A3B405 /* CBLConflictResolver.h */,
 				2704F1C81E395F3300A3B405 /* CBLConflictResolver.m */,
 				27EF6A7E1E297BDF004748DF /* CBLQuery.h */,
@@ -685,6 +693,7 @@
 				9378C59D1E269F14001BB196 /* DocumentTest.m */,
 				72A87A0E1E32E858008466FF /* NotificationTest.m */,
 				27EF6A931E298E26004748DF /* QueryTest.m */,
+				9352945E1E51708E005CE4E8 /* SubdocumentTest.m */,
 				93BFCD951E0380A300E52F8A /* Info.plist */,
 				27EF6A951E2AC609004748DF /* names_100.json */,
 				273ADF7C1E36B514001E977F /* sentences.json */,
@@ -717,14 +726,19 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2704F1C91E395F3300A3B405 /* CBLConflictResolver.h in Headers */,
 				93A8434D1E3BB95200B4AF2D /* CBLBlob.h in Headers */,
-				9398D9FF1E03531A00464432 /* CouchbaseLite.h in Headers */,
+				2704F1C91E395F3300A3B405 /* CBLConflictResolver.h in Headers */,
+				9380C72A1E16E7D00011E8CB /* CBLDatabase.h in Headers */,
+				9380C6EF1E15B8C20011E8CB /* CBLDocument.h in Headers */,
+				9380C71C1E16E7CE0011E8CB /* CBLProperties.h in Headers */,
+				27EF6A821E297BDF004748DF /* CBLQuery.h in Headers */,
 				934F4CB81E241FB500F90659 /* CBLSymmetricKey.h in Headers */,
 				275FF6701E43E013005F90DD /* CBLQueryRow.h in Headers */,
 				934F4CA71E241FB500F90659 /* CBLBase64.h in Headers */,
 				934F4C101E1EF19000F90659 /* CollectionUtils.h in Headers */,
+				9352942B1E501055005CE4E8 /* CBLSubdocument.h in Headers */,
 				934F4CB11E241FB500F90659 /* CBLMisc.h in Headers */,
+				9398D9FF1E03531A00464432 /* CouchbaseLite.h in Headers */,
 				934F4CB51E241FB500F90659 /* CBLPrefix.h in Headers */,
 				934F4CA91E241FB500F90659 /* CBLCoreBridge.h in Headers */,
 				27A0C85E1E3E7AB600F68646 /* CBLSharedKeys.hh in Headers */,
@@ -732,12 +746,8 @@
 				9317621F1E2D439700563506 /* CBLQuery+Internal.h in Headers */,
 				934F4CAD1E241FB500F90659 /* CBLJSON.h in Headers */,
 				934F4CAB1E241FB500F90659 /* CBLInternal.h in Headers */,
-				9380C72A1E16E7D00011E8CB /* CBLDatabase.h in Headers */,
 				934F4CAF1E241FB500F90659 /* CBLLog.h in Headers */,
-				9380C6EF1E15B8C20011E8CB /* CBLDocument.h in Headers */,
 				934F4CB61E241FB500F90659 /* CBLStringBytes.h in Headers */,
-				9380C71C1E16E7CE0011E8CB /* CBLProperties.h in Headers */,
-				27EF6A821E297BDF004748DF /* CBLQuery.h in Headers */,
 				934F4C2B1E1EF19000F90659 /* MYLogging.h in Headers */,
 				275FF6B81E47B2FC005F90DD /* ExceptionUtils.h in Headers */,
 				934F4CB41E241FB500F90659 /* CBLParseDate.h in Headers */,
@@ -1191,6 +1201,7 @@
 				934F4C701E1EFAF600F90659 /* Test_Assertions.m in Sources */,
 				27EF6A831E297BDF004748DF /* CBLQuery.mm in Sources */,
 				934F4CB01E241FB500F90659 /* CBLLog.m in Sources */,
+				9352942C1E501055005CE4E8 /* CBLSubdocument.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1203,6 +1214,7 @@
 				9378C5971E25B473001BB196 /* CBLTestCase.m in Sources */,
 				9378C5911E25B3F0001BB196 /* DatabaseTest.m in Sources */,
 				9378C59E1E269F14001BB196 /* DocumentTest.m in Sources */,
+				9352945F1E51708E005CE4E8 /* SubdocumentTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Objective-C/CBLDocument.h
+++ b/Objective-C/CBLDocument.h
@@ -81,8 +81,6 @@ extern NSString* const kCBLDocumentIsExternalUserInfoKey;
     The purge will NOT be replicated to other databases. */
 - (BOOL) purge: (NSError**)error;
 
-/** Reverts unsaved changes made to the document's properties. */
-- (void) revert;
 
 @end
 

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -120,16 +120,13 @@ NSString* const kCBLDocumentIsExternalUserInfoKey = @"CBLDocumentIsExternalUserI
             if (![self loadDoc_mustExist: NO error: outError])
                 return NO;
             
-            [self resetChanges];
+            self.properties = nil;
+            [self resetChangesKeys];
+            
             return YES;
         }
     }
     return convertError(err, outError);
-}
-
-
-- (void) revert {
-    [self resetChanges];
 }
 
 
@@ -155,8 +152,8 @@ NSString* const kCBLDocumentIsExternalUserInfoKey = @"CBLDocumentIsExternalUserI
 
 
 // Called by CBLProperties superclass after a change is made to the properties.
-- (void) markChanges {
-    [super markChanges];
+- (void) markChangedKey: (NSString*)key {
+    [super markChangedKey: key];
     [[NSNotificationCenter defaultCenter] postNotificationName: kCBLDocumentChangeNotification
                                                         object: self];
 }
@@ -225,6 +222,7 @@ NSString* const kCBLDocumentIsExternalUserInfoKey = @"CBLDocumentIsExternalUserI
             [self setRootDict: root];
         }
     }
+    [self useNewRoot];
 }
 
 
@@ -406,9 +404,11 @@ static bool dictContainsBlob(__unsafe_unretained NSDictionary* dict) {
 
     // Update my state and post a notification:
     [self setC4Doc: newDoc];
-    self.hasChanges = NO;
-    if (deletion)
-        [self resetChanges];
+    if (deletion) {
+        self.properties = nil;
+    }
+    [self resetChangesKeys];
+    
     [self postChangedNotificationExternal:NO];
     return YES;
 }

--- a/Objective-C/CBLProperties.h
+++ b/Objective-C/CBLProperties.h
@@ -56,13 +56,23 @@ NS_ASSUME_NONNULL_BEGIN
     without milliseconds. */
 - (nullable NSDate*) dateForKey: (NSString*)key;
 
+/** Get a property's value as a Subdocument, which is a mapping object of a Dictionary
+    value to provide property type accessors.
+    Returns nil if the property doesn't exists, or its value is not a Dictionary. */
+- (nullable CBLSubdocument*) subdocumentForKey: (NSString*)key;
+
 #pragma mark - SETTERS
 
 /** Sets a property value by key.
-    Allowed value types are NSNull, NSNumber, NSString, NSArray, NSDictionary, NSDate, and CBLBlob.
-    (An NSDate object will be converted to an ISO-8601 format string.)
-    NSArrays and NSDictionaries must contain only the above types.
-    Setting a nil value will remove the property. */
+    Allowed value types are NSNull, NSNumber, NSString, NSArray, NSDictionary, NSDate, 
+    CBLSubdocument, CBLBlob. NSArrays and NSDictionaries must contain only the above types.
+    Setting a nil value will remove the property.
+ 
+    Note:
+    * An NSDate object will be converted to an ISO-8601 format string.
+    * When setting a subdocument, the subdocument will be set by reference. However,
+      if the subdocument has already been set to another key either on the same or different
+      document, the value of the subdocument will be copied instead. */
 - (void) setObject: (nullable id)value forKey: (NSString*)key;
 
 /** Sets a boolean value by key. */
@@ -95,6 +105,9 @@ NS_ASSUME_NONNULL_BEGIN
     NSObject for the property value. */
 - (BOOL) containsObjectForKey: (NSString*)key;
 
+/** Reverts unsaved changes made to the properties. */
+- (void) revert;
+
 @end
 
 
@@ -111,6 +124,5 @@ NS_ASSUME_NONNULL_END
 
 // TODO:
 // 1. Evaluate get/set Array of a specific type (new API)
-// 2. Subdocument (In progress)
 // 4. Property complex object (Can be deferred)
 // 5. Iterable or ObjC Equivalent (Can be deferred)

--- a/Objective-C/CBLProperties.mm
+++ b/Objective-C/CBLProperties.mm
@@ -142,8 +142,8 @@ static inline NSNumber* numberProperty(NSDictionary* dict, NSString* key) {
 
 - (BOOL) booleanForKey: (NSString*)key {
     id v = _properties[key];
-    if (v) {
-        if ([v isKindOfClass: [NSNull class]])
+    if (v || self.hasChanges) {
+        if (!v || [v isKindOfClass: [NSNull class]])
             return NO;
         else {
             id n = $castIf(NSNumber, v);
@@ -162,19 +162,19 @@ static inline NSNumber* numberProperty(NSDictionary* dict, NSString* key) {
 
 - (double) doubleForKey: (NSString*)key {
     id v = numberProperty(_properties, key);
-    return v ? [v doubleValue] : FLValue_AsDouble([self fleeceValueForKey: key]);
+    return v || self.hasChanges ? [v doubleValue] : FLValue_AsDouble([self fleeceValueForKey: key]);
 }
 
 
 - (float) floatForKey: (NSString*)key {
     id v = numberProperty(_properties, key);
-    return v ? [v floatValue] : FLValue_AsFloat([self fleeceValueForKey: key]);
+    return v || self.hasChanges ? [v floatValue] : FLValue_AsFloat([self fleeceValueForKey: key]);
 }
 
 
 - (NSInteger) integerForKey: (NSString*)key {
     id v = numberProperty(_properties, key);
-    return v ? [v integerValue] : FLValue_AsInt([self fleeceValueForKey: key]);
+    return v || self.hasChanges ? [v integerValue] : FLValue_AsInt([self fleeceValueForKey: key]);
 }
 
 
@@ -224,8 +224,8 @@ static inline NSNumber* numberProperty(NSDictionary* dict, NSString* key) {
 
 
 - (BOOL) containsObjectForKey: (NSString*)key {
-    if (_properties[key])
-        return YES;
+    if (self.hasChanges)
+        return _properties[key] != nil;
     else
         return [self fleeceValueForKey: key]  != nullptr;
 }

--- a/Objective-C/CBLSubdocument.h
+++ b/Objective-C/CBLSubdocument.h
@@ -1,0 +1,27 @@
+//
+//  CBLSubdocument.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 2/12/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CBLProperties.h"
+@class CBLDocument;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CBLSubdocument : CBLProperties
+
+@property (readonly, nonatomic, nullable) CBLDocument* document;
+
++ (instancetype) subdocument;
+
+- (instancetype) init;
+
+- (BOOL) exists;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/CBLSubdocument.mm
+++ b/Objective-C/CBLSubdocument.mm
@@ -1,0 +1,147 @@
+//
+//  CBLSubdocument.m
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 2/12/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLSubdocument.h"
+#import "CBLCoreBridge.h"
+#import "CBLDocument.h"
+#import "CBLInternal.h"
+#import "CBLSharedKeys.hh"
+#import "CBLStringBytes.h"
+
+
+@implementation CBLSubdocument {
+    CBLOnMutateBlock _onMutate;
+}
+
+
+@synthesize parent=_parent, key=_key;
+
+
+- (instancetype) init {
+    return [super initWithSharedKeys: cbl::SharedKeys()];
+}
+
+
++ (instancetype) subdocument {
+    return [[CBLSubdocument alloc] init];
+}
+
+
+- (instancetype) copyWithZone:(NSZone *)zone {
+    CBLSubdocument* o = [[self.class alloc] init];
+    o.properties = self.properties;
+    return o;
+}
+
+
+- (nullable CBLDocument*) document {
+    id p = _parent; // strong parent
+    return [p isKindOfClass: [CBLDocument class]] ? p : [p parent];
+}
+
+
+- (BOOL) exists {
+    return [self hasRoot];
+}
+
+
+#pragma mark - CBLProperties
+
+
+- (CBLBlob*) blobWithProperties: (NSDictionary*) properties error: (NSError **)error {
+    CBLDocument* doc = self.document;
+    if (doc)
+        return [[CBLBlob alloc] initWithDatabase: doc.database properties: properties error: error];
+    else {
+        // TODO: Create CBL Error:
+        CBLWarn(Database, @"Cannot read blob from the subdocument not attached to a document.");
+        return nil;
+    }
+}
+
+
+- (BOOL) storeBlob: (CBLBlob*)blob error: (NSError**)error {
+    CBLDocument* doc = self.document;
+    if (doc)
+        return [blob installInDatabase: doc.database error: error];
+    else {
+        // TODO: Create CBL Error:
+        CBLWarn(Database, @"Cannot store blob inside the subdocument not attached to a document.");
+        return NO;
+    }
+}
+
+
+- (void) setHasChanges: (BOOL)hasChanges {
+    if (self.hasChanges != hasChanges) {
+        [super setHasChanges: hasChanges];
+        if (_onMutate)
+            _onMutate();
+    }
+}
+
+
+#pragma mark - INTERNAL
+
+
+- (instancetype) initWithParent: (nullable CBLProperties*)parent
+                     sharedKeys: (cbl::SharedKeys)sharedKeys
+{
+    self = [super initWithSharedKeys: sharedKeys];
+    if (self) {
+        self.parent = parent;
+    }
+    return self;
+}
+
+
+- (void) setParent: (id)parent {
+    if (_parent != parent)
+        _parent = parent;
+}
+
+
+- (void) setOnMutate: (nullable CBLOnMutateBlock)onMutate {
+    _onMutate = onMutate;
+}
+
+
+- (void) invalidate {
+    self.parent = nil;
+    [self setOnMutate: nil];
+    [self setRootDict: nil];
+    self.properties = nil;
+    [self resetChangesKeys];
+}
+
+@end
+
+
+#pragma mark - FLEECE ENCODING FOR CBLJSONEncoding:
+
+
+@interface CBLSubdocument (CBLJSONEncoder)
+@end
+
+
+@implementation CBLSubdocument (CBJSONEncoder)
+
+
+- (void) fl_encodeTo:(FLEncoder)encoder {
+    NSDictionary* dict = self.properties ?: @{};
+    FLEncoder_BeginDict(encoder, dict.count);
+    [dict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+        CBLStringBytes bKey(key);
+        FLEncoder_WriteKey(encoder, bKey);
+        [obj fl_encodeTo: encoder];
+    }];
+    FLEncoder_EndDict(encoder);
+}
+
+
+@end

--- a/Objective-C/CouchbaseLite.exp
+++ b/Objective-C/CouchbaseLite.exp
@@ -16,6 +16,7 @@
 .objc_class_name_CBLProperties
 .objc_class_name_CBLQuery
 .objc_class_name_CBLQueryRow
+.objc_class_name_CBLSubdocument
 
 #  Public constants:
 _kCBLDatabaseChangeNotification

--- a/Objective-C/CouchbaseLite.h
+++ b/Objective-C/CouchbaseLite.h
@@ -21,3 +21,4 @@ FOUNDATION_EXPORT const unsigned char CouchbaseLiteVersionString[];
 #import "CBLProperties.h"
 #import "CBLQuery.h"
 #import "CBLQueryRow.h"
+#import "CBLSubdocument.h"

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -221,10 +221,12 @@
 
 - (void) testPropertyAccessors {
     // Premitives:
-    [doc setBoolean: YES forKey: @"bool"];
+    [doc setBoolean: YES forKey: @"yes"];
+    [doc setBoolean: NO forKey: @"no"];
     [doc setDouble: 1.1 forKey: @"double"];
     [doc setFloat: 1.2f forKey: @"float"];
     [doc setInteger: 2 forKey: @"integer"];
+    [doc setInteger: 0 forKey: @"zero"];
     
     // Objects:
     [doc setObject: @"str" forKey: @"string"];
@@ -232,6 +234,12 @@
     [doc setObject: @(1) forKey: @"number"];
     [doc setObject: @{@"foo": @"bar"} forKey: @"dict"];
     [doc setObject: @[@"1", @"2"] forKey: @"array"];
+    
+    // Subdocuments:
+    CBLSubdocument* subdoc = [CBLSubdocument subdocument];
+    [subdoc setObject: @"scottie" forKey: @"firstname"];
+    [subdoc setObject: @"zebra" forKey: @"lastname"];
+    [doc setObject: subdoc forKey: @"subdoc"];
     
     // NSNull:
     [doc setObject: [NSNull null] forKey: @"null"];
@@ -245,17 +253,29 @@
     Assert([doc save: &error], @"Error saving: %@", error);
     
     // Primitives:
-    AssertEqual([doc booleanForKey: @"bool"], YES);
+    AssertEqual([doc booleanForKey: @"yes"], YES);
+    AssertEqual([doc booleanForKey: @"no"], NO);
     AssertEqual([doc doubleForKey: @"double"], 1.1);
     AssertEqual([doc floatForKey: @"float"], @(1.2).floatValue);
     AssertEqual([doc integerForKey: @"integer"], 2);
+    AssertEqual([doc integerForKey: @"zero"], 0);
     
     // Objects:
-    AssertEqualObjects([doc stringForKey: @"string"], @"str");
+    AssertEqualObjects([doc objectForKey: @"string"], @"str");
     AssertEqualObjects([doc objectForKey: @"boolObj"], @(YES));
     AssertEqualObjects([doc objectForKey: @"number"], @(1));
-    AssertEqualObjects([doc objectForKey: @"dict"], @{@"foo": @"bar"});
     AssertEqualObjects([doc objectForKey: @"array"], (@[@"1", @"2"]));
+    AssertEqualObjects(((CBLSubdocument*)[doc objectForKey: @"dict"]).properties, @{@"foo": @"bar"});
+    
+    // String:
+    AssertEqualObjects([doc stringForKey: @"string"], @"str");
+    
+    // Subdocuments:
+    subdoc = [doc subdocumentForKey: @"subdoc"];
+    AssertNotNil(subdoc);
+    AssertEqualObjects(subdoc, [doc objectForKey: @"subdoc"]);
+    AssertEqualObjects([subdoc objectForKey: @"firstname"], @"scottie");
+    AssertEqualObjects([subdoc objectForKey: @"lastname"], @"zebra");
     
     // NSNull:
     AssertEqualObjects([doc objectForKey: @"null"], [NSNull null]);
@@ -265,33 +285,65 @@
     AssertEqualObjects([CBLJSON JSONObjectWithDate: [doc dateForKey: @"date"]],
                        [CBLJSON JSONObjectWithDate: date]);
     
+    // Boolean:
+    Assert([doc booleanForKey:@"double"]);
+    Assert([doc booleanForKey:@"float"]);
+    Assert([doc booleanForKey:@"integer"]);
+    Assert([doc booleanForKey:@"string"]);
+    Assert([doc booleanForKey:@"array"]);
+    Assert([doc booleanForKey:@"dict"]);
+    AssertFalse([doc booleanForKey:@"zero"]);
+    AssertFalse([doc booleanForKey:@"null"]);
+    
     ////// Reopen the database and get the document again:
 
     doc = nil;
     [self reopenDB];
     
-    CBLDocument* doc1 = [self.db documentWithID: @"doc1"];
+    doc = [self.db documentWithID: @"doc1"];
     
     // Primitives:
-    AssertEqual([doc1 booleanForKey: @"bool"], YES);
-    AssertEqual([doc1 doubleForKey: @"double"], 1.1);
-    AssertEqual([doc1 floatForKey: @"float"], @(1.2).floatValue);
-    AssertEqual([doc1 integerForKey: @"integer"], 2);
+    AssertEqual([doc booleanForKey: @"yes"], YES);
+    AssertEqual([doc booleanForKey: @"no"], NO);
+    AssertEqual([doc doubleForKey: @"double"], 1.1);
+    AssertEqual([doc floatForKey: @"float"], @(1.2).floatValue);
+    AssertEqual([doc integerForKey: @"integer"], 2);
+    AssertEqual([doc integerForKey: @"zero"], 0);
     
     // Objects:
-    AssertEqualObjects([doc1 stringForKey: @"string"], @"str");
-    AssertEqualObjects([doc1 objectForKey: @"boolObj"], @(YES));
-    AssertEqualObjects([doc1 objectForKey: @"number"], @(1));
-    AssertEqualObjects([doc1 objectForKey: @"dict"], @{@"foo": @"bar"});
-    AssertEqualObjects([doc1 objectForKey: @"array"], (@[@"1", @"2"]));
+    AssertEqualObjects([doc objectForKey: @"string"], @"str");
+    AssertEqualObjects([doc objectForKey: @"boolObj"], @(YES));
+    AssertEqualObjects([doc objectForKey: @"number"], @(1));
+    AssertEqualObjects([doc objectForKey: @"array"], (@[@"1", @"2"]));
+    AssertEqualObjects(((CBLSubdocument*)[doc objectForKey: @"dict"]).properties, @{@"foo": @"bar"});
+    
+    // String:
+    AssertEqualObjects([doc stringForKey: @"string"], @"str");
+    
+    // Subdocuments:
+    subdoc = [doc subdocumentForKey: @"subdoc"];
+    AssertNotNil(subdoc);
+    AssertEqualObjects(subdoc, [doc objectForKey: @"subdoc"]);
+    AssertEqualObjects([subdoc objectForKey: @"firstname"], @"scottie");
+    AssertEqualObjects([subdoc objectForKey: @"lastname"], @"zebra");
     
     // NSNull:
-    AssertEqualObjects([doc1 objectForKey: @"null"], [NSNull null]);
-    AssertEqualObjects([doc1 objectForKey: @"nullarray"], (@[[NSNull null], [NSNull null]]));
+    AssertEqualObjects([doc objectForKey: @"null"], [NSNull null]);
+    AssertEqualObjects([doc objectForKey: @"nullarray"], (@[[NSNull null], [NSNull null]]));
     
     // Date:
-    AssertEqualObjects([CBLJSON JSONObjectWithDate: [doc1 dateForKey: @"date"]],
+    AssertEqualObjects([CBLJSON JSONObjectWithDate: [doc dateForKey: @"date"]],
                        [CBLJSON JSONObjectWithDate: date]);
+    
+    // Boolean:
+    Assert([doc booleanForKey:@"double"]);
+    Assert([doc booleanForKey:@"float"]);
+    Assert([doc booleanForKey:@"integer"]);
+    Assert([doc booleanForKey:@"string"]);
+    Assert([doc booleanForKey:@"array"]);
+    Assert([doc booleanForKey:@"dict"]);
+    AssertFalse([doc booleanForKey:@"zero"]);
+    AssertFalse([doc booleanForKey:@"null"]);
 }
 
 
@@ -307,10 +359,11 @@
 }
 
 
-- (void) testRemoveProperties {
+- (void) testRemoveKeys {
     doc.properties = @{ @"type": @"profile",
                         @"name": @"Jason",
                         @"weight": @130.5,
+                        @"active": @YES,
                         @"address": @{
                                 @"street": @"1 milky way.",
                                 @"city": @"galaxy city",
@@ -321,34 +374,54 @@
     AssertEqual([doc doubleForKey: @"weight"], 130.5);
     AssertEqualObjects(doc[@"address"][@"city"], @"galaxy city");
     
-    doc[@"name"] = nil;
     doc[@"weight"] = nil;
+    doc[@"address"][@"city"] = nil;
     
-    NSMutableDictionary* address = [NSMutableDictionary dictionaryWithDictionary: doc[@"address"]];
-    address[@"city"] = nil;
-    doc[@"address"] = address;
-    
-    AssertNil(doc[@"name"]);
-    AssertNil(doc[@"weight"]);
     AssertEqual([doc doubleForKey: @"weight"], 0.0);
+    AssertNil(doc[@"weight"]);
     AssertNil(doc[@"address"][@"city"]);
+    
+    CBLSubdocument* address = doc[@"address"];
+    AssertEqualObjects(doc.properties, (@{ @"type": @"profile",
+                                           @"name": @"Jason",
+                                           @"active": @YES,
+                                           @"address": address
+                                           }));
+    AssertEqualObjects(address.properties, (@{ @"street": @"1 milky way.",
+                                               @"zip" : @12345
+                                               }));
 }
 
 
 - (void) testContainsKey {
-    doc.properties =
-    @{ @"type": @"profile",
-       @"name": @"Jason",
-       @"address": @{
-               @"street": @"1 milky way.",
-               }
-       };
+    doc.properties = @{ @"type": @"profile",
+                        @"name": @"Jason",
+                        @"address": @{
+                                @"street": @"1 milky way.",
+                                }
+                        };
+    
+    Assert([doc containsObjectForKey: @"type"]);
+    Assert([doc containsObjectForKey: @"name"]);
+    Assert([doc containsObjectForKey: @"address"]);
+    AssertFalse([doc containsObjectForKey: @"weight"]);
+    
+    NSError* error;
+    Assert([doc save: &error], @"Error saving: %@", error);
+    
+    doc = nil;
+    [self reopenDB];
+    
+    doc = [self.db documentWithID: @"doc1"];
+    
+    // Access a subdocument to load the subdocument into cache:
+    AssertNotNil(doc[@"address"]);
+    
     Assert([doc containsObjectForKey: @"type"]);
     Assert([doc containsObjectForKey: @"name"]);
     Assert([doc containsObjectForKey: @"address"]);
     AssertFalse([doc containsObjectForKey: @"weight"]);
 }
-
 
 
 - (void) testDelete {
@@ -403,28 +476,75 @@
 - (void) testRevert {
     doc[@"type"] = @"profile";
     doc[@"name"] = @"Scott";
+    CBLSubdocument* address = [CBLSubdocument subdocument];
+    address[@"street"] = @"1 Star Way.";
+    doc[@"address"] = address;
     
     // Revert before save:
     [doc revert];
     AssertNil(doc[@"type"]);
     AssertNil(doc[@"name"]);
+    AssertNil(doc[@"address"]);
+    AssertNil(address.parent);
+    AssertNil(address.document);
+    AssertNil(address.properties);
     
     // Save:
     doc[@"type"] = @"profile";
     doc[@"name"] = @"Scott";
+    address = [CBLSubdocument subdocument];
+    address[@"street"] = @"1 Star Way.";
+    doc[@"address"] = address;
+    
+    CBLSubdocument* phones = [CBLSubdocument subdocument];
+    phones[@"mobile"] = @"650-123-4567";
+    doc[@"phones"] = phones;
+    
+    CBLSubdocument* r1 = [CBLSubdocument subdocument];
+    r1[@"name"] = @"Jason";
+    CBLSubdocument* r2 = [CBLSubdocument subdocument];
+    r2[@"name"] = @"John";
+    doc[@"references"] = @[r1, r2];
+    
     NSError* error;
     Assert([doc save: &error], @"Saving error: %@", error);
     AssertEqualObjects(doc[@"type"], @"profile");
     AssertEqualObjects(doc[@"name"], @"Scott");
+    AssertEqualObjects(doc[@"address"][@"street"], @"1 Star Way.");
+    AssertEqualObjects(doc[@"phones"][@"mobile"], @"650-123-4567");
+    AssertEqualObjects(doc[@"references"][0][@"name"], @"Jason");
+    AssertEqualObjects(doc[@"references"][1][@"name"], @"John");
     
     // Make some changes:
     doc[@"type"] = @"user";
-    doc[@"name"] = @"Scottie";
+    doc[@"name"] = nil;
+    AssertNil(doc[@"name"]);
+    doc[@"address"][@"street"] = @"1 Space Dr.";
+    doc[@"address"][@"zip"] = @"88888";
+    doc[@"phones"] = nil;
+    
+    CBLSubdocument* r3 = [CBLSubdocument subdocument];
+    r3[@"name"] = @"Jack";
+    doc[@"references"] = @[r3, r2, r1];
+    
+    AssertEqualObjects(doc[@"type"], @"user");
+    AssertNil(doc[@"name"]);
+    AssertEqualObjects(doc[@"address"][@"street"], @"1 Space Dr.");
+    AssertEqualObjects(doc[@"address"][@"zip"], @"88888");
+    AssertNil(doc[@"phones"]);
+    AssertEqualObjects(doc[@"references"][0][@"name"], @"Jack");
+    AssertEqualObjects(doc[@"references"][1][@"name"], @"John");
+    AssertEqualObjects(doc[@"references"][2][@"name"], @"Jason");
     
     // Revert:
     [doc revert];
     AssertEqualObjects(doc[@"type"], @"profile");
     AssertEqualObjects(doc[@"name"], @"Scott");
+    AssertEqualObjects(doc[@"address"][@"street"], @"1 Star Way.");
+    AssertNil(doc[@"address"][@"zip"]);
+    AssertEqualObjects(doc[@"phones"][@"mobile"], @"650-123-4567");
+    AssertEqualObjects(doc[@"references"][0][@"name"], @"Jason");
+    AssertEqualObjects(doc[@"references"][1][@"name"], @"John");
 }
 
 

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -364,27 +364,34 @@
                         @"name": @"Jason",
                         @"weight": @130.5,
                         @"active": @YES,
+                        @"age": @30,
                         @"address": @{
                                 @"street": @"1 milky way.",
                                 @"city": @"galaxy city",
                                 @"zip" : @12345
                                 }
                         };
+    NSError* error;
+    Assert([doc save: &error], @"Error saving: %@", error);
     
-    AssertEqual([doc doubleForKey: @"weight"], 130.5);
-    AssertEqualObjects(doc[@"address"][@"city"], @"galaxy city");
-    
+    doc[@"name"] = nil;
     doc[@"weight"] = nil;
+    doc[@"age"] = nil;
+    doc[@"active"] = nil;
     doc[@"address"][@"city"] = nil;
     
     AssertEqual([doc doubleForKey: @"weight"], 0.0);
+    AssertEqual([doc integerForKey: @"age"], 0);
+    AssertEqual([doc booleanForKey: @"active"], NO);
+    
+    AssertNil(doc[@"name"]);
     AssertNil(doc[@"weight"]);
+    AssertNil(doc[@"age"]);
+    AssertNil(doc[@"active"]);
     AssertNil(doc[@"address"][@"city"]);
     
     CBLSubdocument* address = doc[@"address"];
     AssertEqualObjects(doc.properties, (@{ @"type": @"profile",
-                                           @"name": @"Jason",
-                                           @"active": @YES,
                                            @"address": address
                                            }));
     AssertEqualObjects(address.properties, (@{ @"street": @"1 milky way.",
@@ -392,10 +399,10 @@
                                                }));
 }
 
-
 - (void) testContainsKey {
     doc.properties = @{ @"type": @"profile",
                         @"name": @"Jason",
+                        @"age": @"30",
                         @"address": @{
                                 @"street": @"1 milky way.",
                                 }
@@ -413,13 +420,16 @@
     [self reopenDB];
     
     doc = [self.db documentWithID: @"doc1"];
+    doc[@"modified"] = @(YES);
     
     // Access a subdocument to load the subdocument into cache:
     AssertNotNil(doc[@"address"]);
     
     Assert([doc containsObjectForKey: @"type"]);
     Assert([doc containsObjectForKey: @"name"]);
+    Assert([doc containsObjectForKey: @"age"]);
     Assert([doc containsObjectForKey: @"address"]);
+    Assert([doc containsObjectForKey: @"modified"]);
     AssertFalse([doc containsObjectForKey: @"weight"]);
 }
 

--- a/Objective-C/Tests/SubdocumentTest.m
+++ b/Objective-C/Tests/SubdocumentTest.m
@@ -1,0 +1,508 @@
+//
+//  SubdocumentTest.m
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 2/13/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLTestCase.h"
+#import "CBLInternal.h"
+#import "CBLJSON.h"
+
+@interface SubdocumentTest : CBLTestCase
+
+@end
+
+@implementation SubdocumentTest
+{
+    CBLDocument* doc;
+}
+
+
+- (void) setUp {
+    [super setUp];
+
+    doc = [self.db documentWithID: @"doc1"];
+}
+
+
+- (void) tearDown {
+    // Avoid "Closing database with 1 unsaved docs" warning:
+    [doc revert];
+    
+    [super tearDown];
+}
+
+
+- (void) testNewSubdoc {
+    AssertNil([doc subdocumentForKey: @"address"]);
+    AssertNil(doc[@"address"]);
+    
+    CBLSubdocument* address = [[CBLSubdocument alloc] init];
+    AssertNil(address.document);
+    AssertNil(address.parent);
+    AssertNil(address.properties);
+    AssertFalse(address.exists);
+    
+    address[@"street"] = @"1 Space Ave.";
+    AssertEqualObjects(address[@"street"], @"1 Space Ave.");
+    AssertEqualObjects(address.properties, (@{@"street": @"1 Space Ave."}));
+    
+    doc[@"address"] = address;
+    AssertEqualObjects([doc subdocumentForKey: @"address"], address);
+    AssertEqualObjects(doc[@"address"], address);
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    Assert(address.exists);
+    AssertEqualObjects(address[@"street"], @"1 Space Ave.");
+    AssertEqualObjects(address.properties, (@{@"street": @"1 Space Ave."}));
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    AssertEqualObjects(doc.properties, (@{@"address": address}));
+    
+    [self reopenDB];
+    
+    doc = [self.db documentWithID: @"doc1"];
+    address = [doc subdocumentForKey: @"address"];
+    Assert(address.exists);
+    AssertEqualObjects(address[@"street"], @"1 Space Ave.");
+    AssertEqualObjects(address.properties, (@{@"street": @"1 Space Ave."}));
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    AssertEqualObjects(doc.properties, (@{@"address": address}));
+}
+
+
+- (void) testGetSubdoc {
+    CBLSubdocument* address = [doc subdocumentForKey: @"address"];
+    AssertNil(address);
+    
+    doc.properties = @{@"address": @{@"street": @"1 Space Ave."}};
+    
+    address = [doc subdocumentForKey: @"address"];
+    Assert(address);
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    AssertEqualObjects(address.properties, (@{@"street": @"1 Space Ave."}));
+    AssertEqualObjects(address[@"street"], @"1 Space Ave.");
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    [self reopenDB];
+    
+    doc = [self.db documentWithID: @"doc1"];
+    address = [doc subdocumentForKey: @"address"];
+    Assert(address);
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    Assert(address.exists);
+    AssertEqualObjects(address[@"street"], @"1 Space Ave.");
+    AssertEqualObjects(address.properties, (@{@"street": @"1 Space Ave."}));
+}
+
+
+- (void) testNestedSubdocs {
+    AssertNil(doc.properties);
+    
+    doc[@"level1"] = [CBLSubdocument subdocument];
+    doc[@"level1"][@"name"] = @"n1";
+    
+    doc[@"level1"][@"level2"] = [CBLSubdocument subdocument];
+    doc[@"level1"][@"level2"][@"name"] = @"n2";
+    
+    doc[@"level1"][@"level2"][@"level3"] = [CBLSubdocument subdocument];
+    doc[@"level1"][@"level2"][@"level3"][@"name"] = @"n3";
+    
+    CBLSubdocument *level1 = doc[@"level1"];
+    CBLSubdocument *level2 = doc[@"level1"][@"level2"];
+    CBLSubdocument *level3 = doc[@"level1"][@"level2"][@"level3"];
+    
+    AssertFalse(level1.exists);
+    AssertFalse(level2.exists);
+    AssertFalse(level3.exists);
+    
+    AssertEqualObjects(doc.properties, (@{@"level1": level1}));
+    AssertEqualObjects(level1.properties, (@{@"name": @"n1", @"level2": level2}));
+    AssertEqualObjects(level2.properties, (@{@"name": @"n2", @"level3": level3}));
+    AssertEqualObjects(level3.properties, (@{@"name": @"n3"}));
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    Assert(level1.exists);
+    Assert(level2.exists);
+    Assert(level3.exists);
+}
+
+
+- (void) testGetSetDictionary {
+    AssertNil(doc.properties);
+    AssertNil(doc[@"address"]);
+    doc[@"address"] = @{@"street": @"1 Space Ave."};
+    
+    CBLSubdocument* address = doc[@"address"];
+    AssertEqualObjects(address.properties, @{@"street": @"1 Space Ave."});
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    Assert(address.exists);
+    AssertEqualObjects(address, doc[@"address"]);
+    AssertEqualObjects(address.properties, @{@"street": @"1 Space Ave."});
+}
+
+
+- (void) testSetProperties {
+    doc.properties = @{ @"name": @"Jason",
+                        @"address": @{
+                                @"street": @"1 Star Way.",
+                                @"phones": @{@"mobile": @"650-123-4567"}
+                                },
+                        @"references": @[@{@"name": @"Scott"}, @{@"name": @"Sam"}]
+                        };
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    AssertEqualObjects(doc[@"name"], @"Jason");
+    
+    CBLSubdocument* address = doc[@"address"];
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    Assert([address exists]);
+    AssertEqualObjects(address[@"street"], @"1 Star Way.");
+    
+    CBLSubdocument* phones = address[@"phones"];
+    AssertEqualObjects(phones.document, doc);
+    AssertEqualObjects(phones.parent, address);
+    Assert([phones exists]);
+    AssertEqualObjects(phones[@"mobile"], @"650-123-4567");
+    
+    NSArray* references = doc[@"references"];
+    AssertEqual([references count], 2u);
+    
+    CBLSubdocument* r1 = references[0];
+    AssertEqualObjects(r1.document, doc);
+    AssertEqualObjects(r1.parent, doc);
+    Assert([r1 exists]);
+    AssertEqualObjects(r1[@"name"], @"Scott");
+    
+    CBLSubdocument* r2 = references[1];
+    AssertEqualObjects(r2.document, doc);
+    AssertEqualObjects(r2.parent, doc);
+    Assert([r2 exists]);
+    AssertEqualObjects(r2[@"name"], @"Sam");
+}
+
+
+- (void) testCopySubdocument {
+    doc.properties = @{ @"name": @"Jason",
+                        @"address": @{
+                                @"street": @"1 Star Way.",
+                                @"phones": @{@"mobile": @"650-123-4567"}
+                                }
+                        };
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    CBLSubdocument* address = doc[@"address"];
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    
+    CBLSubdocument* phones = address[@"phones"];
+    AssertEqualObjects(phones.document, doc);
+    AssertEqualObjects(phones.parent, address);
+    
+    CBLSubdocument* address2 = [address copy];
+    AssertFalse(address2 == address);
+    AssertNil(address2.document);
+    AssertNil(address2.parent);
+    AssertEqualObjects(address2[@"street"], address[@"street"]);
+    
+    CBLSubdocument* phones2 = address2[@"phones"];
+    AssertFalse(phones2 == phones);
+    AssertNil(phones2.document);
+    AssertEqualObjects(phones2.parent, address2);
+    AssertEqualObjects(phones2[@"mobile"], phones[@"mobile"]);
+}
+
+
+- (void) testSetSubdocumentFromAnotherKey {
+    doc.properties = @{ @"name": @"Jason",
+                        @"address": @{
+                                @"street": @"1 Star Way.",
+                                @"phones": @{@"mobile": @"650-123-4567"}
+                                }
+                        };
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    CBLSubdocument* address = doc[@"address"];
+    AssertEqualObjects(address.document, doc);
+    AssertEqualObjects(address.parent, doc);
+    
+    CBLSubdocument* phones = address[@"phones"];
+    AssertEqualObjects(phones.document, doc);
+    AssertEqualObjects(phones.parent, address);
+    
+    doc[@"address2"] = address;
+    CBLSubdocument* address2 = doc[@"address2"];
+    AssertFalse(address2 == address);
+    AssertEqualObjects(address2.document, doc);
+    AssertEqualObjects(address2.parent, doc);
+    AssertEqualObjects(address2[@"street"], address[@"street"]);
+    
+    CBLSubdocument* phones2 = address2[@"phones"];
+    AssertFalse(phones2 == phones);
+    AssertEqualObjects(phones2.document, doc);
+    AssertEqualObjects(phones2.parent, address2);
+    AssertEqualObjects(phones2[@"mobile"], phones[@"mobile"]);
+}
+
+
+- (void) testSubdocumentArray {
+    NSArray* dicts = @[@{@"name": @"1"}, @{@"name": @"2"}, @{@"name": @"3"}, @{@"name": @"4"}];
+    doc.properties = @{@"subdocs": dicts};
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    NSArray* subdocs = doc[@"subdocs"];
+    AssertEqual([subdocs count], 4u);
+    
+    CBLSubdocument* s1 = subdocs[0];
+    CBLSubdocument* s2 = subdocs[1];
+    CBLSubdocument* s3 = subdocs[2];
+    CBLSubdocument* s4 = subdocs[3];
+    
+    AssertEqualObjects(s1[@"name"], @"1");
+    AssertEqualObjects(s2[@"name"], @"2");
+    AssertEqualObjects(s3[@"name"], @"3");
+    AssertEqualObjects(s4[@"name"], @"4");
+    
+    // Make Changes:
+    
+    CBLSubdocument* s5 = [CBLSubdocument subdocument];
+    s5[@"name"] = @"5";
+    
+    NSArray* nuSubdocs1 = @[s5, @"dummy", s2, @{@"name": @"6"}, s1];
+    doc[@"subdocs"] = nuSubdocs1;
+    
+    NSArray* nuSubdocs2 = doc[@"subdocs"];
+    AssertEqual([nuSubdocs2 count], 5u);
+    AssertEqualObjects(nuSubdocs2[0], s5);
+    AssertEqualObjects(nuSubdocs2[1], @"dummy");
+    AssertEqualObjects(nuSubdocs2[2], s2);
+    AssertEqualObjects(nuSubdocs2[3], s4);
+    AssertEqualObjects(nuSubdocs2[4], s1);
+    
+    AssertEqualObjects(s1[@"name"], @"1");
+    AssertEqualObjects(s2[@"name"], @"2");
+    AssertNil(s3[@"name"]); // Invalidated
+    AssertNil(s3.document);
+    AssertEqualObjects(s4[@"name"], @"6");
+    AssertEqualObjects(s5[@"name"], @"5");
+}
+
+
+- (void) testNilSubdocument {
+    doc.properties = @{ @"name": @"Jason",
+                        @"address": @{
+                                @"street": @"1 Star Way.",
+                                @"phones": @{@"mobile": @"650-123-4567"}
+                                },
+                        @"references": @[@{@"name": @"Scott"}, @{@"name": @"Sam"}]
+                        };
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    CBLSubdocument* address = doc[@"address"];
+    CBLSubdocument* phones = address[@"phones"];
+    AssertNotNil(address);
+    AssertNotNil(phones);
+    
+    NSArray* references = doc[@"references"];
+    AssertEqual([references count], 2u);
+    CBLSubdocument* r1 = references[0];
+    CBLSubdocument* r2 = references[1];
+    AssertNotNil(r1);
+    AssertNotNil(r2);
+    
+    doc[@"address"] = nil;
+    AssertNil(address.document);
+    AssertNil(address.parent);
+    AssertFalse([address exists]);
+    AssertNil(address.properties);
+    AssertNil(address[@"street"]);
+    AssertNil(address[@"phones"]);
+    
+    AssertNil(phones.document);
+    AssertNil(phones.parent);
+    AssertFalse([phones exists]);
+    AssertNil(phones.properties);
+    AssertNil(phones[@"mobile"]);
+    
+    doc[@"references"] = nil;
+    
+    AssertNil(r1.document);
+    AssertNil(r1.parent);
+    AssertFalse([r1 exists]);
+    AssertNil(r1.properties);
+    AssertNil(r1[@"name"]);
+    
+    AssertNil(r2.document);
+    AssertNil(r2.parent);
+    AssertFalse([r2 exists]);
+    AssertNil(r2.properties);
+    AssertNil(r2[@"name"]);
+    
+    doc[@"name"] = nil;
+    AssertEqualObjects(doc.properties, @{});
+}
+
+
+- (void) testNilProperties {
+    doc.properties = @{ @"name": @"Jason",
+                        @"address": @{
+                                @"street": @"1 Star Way.",
+                                @"phones": @{@"mobile": @"650-123-4567"}
+                                },
+                        @"references": @[@{@"name": @"Scott"}, @{@"name": @"Sam"}]
+                        };
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    AssertNotNil(doc[@"name"]);
+    
+    CBLSubdocument* address = doc[@"address"];
+    CBLSubdocument* phones = address[@"phones"];
+    AssertNotNil(address);
+    AssertNotNil(phones);
+    
+    NSArray* references = doc[@"references"];
+    AssertEqual([references count], 2u);
+    CBLSubdocument* r1 = references[0];
+    CBLSubdocument* r2 = references[1];
+    AssertNotNil(r1);
+    AssertNotNil(r2);
+    
+    doc.properties = nil;
+    
+    AssertNil(doc.properties);
+    AssertNil(doc[@"name"]);
+    AssertNil(doc[@"addresses"]);
+    AssertNil(doc[@"references"]);
+    
+    AssertNil(address.document);
+    AssertNil(address.parent);
+    AssertFalse([address exists]);
+    AssertNil(address.properties);
+    AssertNil(address[@"street"]);
+    AssertNil(address[@"phones"]);
+    
+    AssertNil(phones.document);
+    AssertNil(phones.parent);
+    AssertFalse([phones exists]);
+    AssertNil(phones.properties);
+    AssertNil(phones[@"mobile"]);
+    
+    AssertNil(r1.document);
+    AssertNil(r1.parent);
+    AssertFalse([r1 exists]);
+    AssertNil(r1.properties);
+    AssertNil(r1[@"name"]);
+    
+    AssertNil(r2.document);
+    AssertNil(r2.parent);
+    AssertFalse([r2 exists]);
+    AssertNil(r2.properties);
+    AssertNil(r2[@"name"]);
+}
+
+
+- (void) testReplaceWithNonDict {
+    CBLSubdocument* address = [CBLSubdocument subdocument];
+    address[@"street"] = @"1 Star Way.";
+    AssertEqualObjects(address[@"street"], @"1 Star Way.");
+    AssertEqualObjects(address.properties, (@{@"street": @"1 Star Way."}));
+    
+    doc[@"address"] = address;
+    AssertEqualObjects(doc[@"address"], address);
+    AssertEqualObjects(address.document, doc);
+    
+    doc[@"address"] = @"123 Space Dr.";
+    AssertNil(address.document);
+    AssertNil(address.properties);
+    AssertEqualObjects(doc.properties, @{@"address": @"123 Space Dr."});
+    AssertEqualObjects(doc[@"address"], @"123 Space Dr.");
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+}
+
+
+- (void) testDeleteDocument {
+    doc.properties = @{ @"name": @"Jason",
+                        @"address": @{
+                                @"street": @"1 Star Way.",
+                                @"phones": @{@"mobile": @"650-123-4567"}
+                                },
+                        @"references": @[@{@"name": @"Scott"}, @{@"name": @"Sam"}]
+                        };
+    
+    NSError* error;
+    Assert([doc save: &error], @"Saving error: %@", error);
+    
+    AssertNotNil(doc[@"name"]);
+    
+    CBLSubdocument* address = doc[@"address"];
+    CBLSubdocument* phones = address[@"phones"];
+    AssertNotNil(address);
+    AssertNotNil(phones);
+    
+    NSArray* references = doc[@"references"];
+    AssertEqual([references count], 2u);
+    CBLSubdocument* r1 = references[0];
+    CBLSubdocument* r2 = references[1];
+    AssertNotNil(r1);
+    AssertNotNil(r2);
+
+    Assert([doc deleteDocument: &error], @"Deleting error: %@", error);
+    Assert(doc.exists);
+    AssertNil(doc.properties);
+    AssertNil(doc[@"name"]);
+    AssertNil(doc[@"addresses"]);
+    AssertNil(doc[@"references"]);
+    
+    AssertNil(address.document);
+    AssertNil(address.parent);
+    AssertFalse([address exists]);
+    AssertNil(address.properties);
+    AssertNil(address[@"street"]);
+    AssertNil(address[@"phones"]);
+    
+    AssertNil(phones.document);
+    AssertNil(phones.parent);
+    AssertFalse([phones exists]);
+    AssertNil(phones.properties);
+    AssertNil(phones[@"mobile"]);
+    
+    AssertNil(r1.document);
+    AssertNil(r1.parent);
+    AssertFalse([r1 exists]);
+    AssertNil(r1.properties);
+    AssertNil(r1[@"name"]);
+    
+    AssertNil(r2.document);
+    AssertNil(r2.parent);
+    AssertFalse([r2 exists]);
+    AssertNil(r2.properties);
+    AssertNil(r2[@"name"]);
+}
+
+
+@end


### PR DESCRIPTION
* When getting a property value that the raw value is Dictionary type, the value will be converted to Subdocument.

* When getting .properties, all dictionary values will be converted to Subdocument.

* By default, setting a Subdocument property will be by reference. However if the Subdocument has already been set to a key, the value of the Subdocument will be copied instead.

* Subdocument will be invalidated when the property doesn’t exist any more or the property value has been changed to non dictionary data. When the subdocument is validated, current implementation will set its parent, root, and properties to null value. The changesKeys and flag will be reset as well.

*  The Subdocument objects in an array could be re-ordered. However if the underlining dictionary are changed, the changes will be mapped to the Subdocuments in the array by index. See SubdocumentTest’s testSubdocumentArray as an example.

Known Issues:

* If subdocuments in an array are reordered but across nested arrays, the subdocuments moved into the nested array could be wrongly invalidated.

* Performance concern when saving a document as -useNewRoot and -setProperties: method currently require to iterate through the current .properties to find Subdocuments. Maybe we could store Subdocument and Array properties on another dictionary.

Discussions:

* Currently when a subdocument is invalidated, its properties are also cleared as well. I'm not sure if this behavior is always correct or not.