### PR TITLE
Changing the protocol scheme from git to https for better support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "vendor/CocoaHTTPServer"]
 	path = vendor/CocoaHTTPServer
-	url = git://github.com/couchbaselabs/CocoaHTTPServer.git
+	url = https://github.com/couchbaselabs/CocoaHTTPServer.git
 [submodule "vendor/MYUtilities"]
 	path = vendor/MYUtilities
-	url = git://github.com/snej/MYUtilities.git
+	url = https://github.com/snej/MYUtilities.git
 [submodule "vendor/oauthconsumer"]
 	path = vendor/oauthconsumer
-	url = git://github.com/couchbaselabs/ios-oauthconsumer.git
+	url = https://github.com/couchbaselabs/ios-oauthconsumer.git
 [submodule "vendor/JSON-Schema-Test-Suite"]
 	path = vendor/JSON-Schema-Test-Suite
-	url = git://github.com/json-schema/JSON-Schema-Test-Suite.git
+	url = https://github.com/json-schema/JSON-Schema-Test-Suite.git
 [submodule "vendor/WebSockets-Cocoa"]
 	path = vendor/WebSockets-Cocoa
-	url = git://github.com/couchbaselabs/WebSockets-Cocoa.git
+	url = https://github.com/couchbaselabs/WebSockets-Cocoa.git
 [submodule "vendor/CBForest"]
 	path = vendor/CBForest
-	url = git://github.com/couchbaselabs/cbforest.git
+	url = https://github.com/couchbaselabs/cbforest.git
 [submodule "vendor/fmdb"]
 	path = vendor/fmdb
-	url = git://github.com/couchbaselabs/fmdb.git
+	url = https://github.com/couchbaselabs/fmdb.git
 [submodule "vendor/BLIP"]
 	path = vendor/BLIP
-	url = git://github.com/couchbaselabs/BLIP-Cocoa.git
+	url = https://github.com/couchbaselabs/BLIP-Cocoa.git


### PR DESCRIPTION
carthage update on any sub-module of couchbase-lite-ios for iOS Development causes a timeout when checking out all dependancies.

Many companies restrict using the git:// scheme due to it using a specific port and not using proper authorization. Https is much more secure and more commonly unblocked.

Proposing this file be standardized to use https rather than git protocol.

This fixes the carthage update timeout issue.

Alternatively users cloning this project will need to run a command similar to:

git config --global url."https://".insteadOf git://

or remove --global and do it on a project-to-project basis.