### PR TITLE
Fixed #1655 : Race causing the change tracker to start twice

### DIFF
--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -727,6 +727,14 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
                           path: [@"_local/" stringByAppendingString: checkpointID]
                           body: nil
                   onCompletion: ^(id response, NSError* error) {
+                  if (!_online) {
+                      // FIX: https://github.com/couchbase/couchbase-lite-ios/issues/1655
+                      // Prevent a race condition between aborting the request when putting the
+                      // replicator offine and the request is completed.
+                      [self asyncTasksFinished: 1];
+                      return;
+                  }
+                      
                   // Got the response:
                   LogTo(SyncPerf, @"%@ Got remote checkpoint", self);
                   if (error && error.code != kCBLStatusNotFound) {


### PR DESCRIPTION
The issue couldn’t reproduce but here is what is speculated to happen:

There could be a race scenario between stopping the fetch remote checkpoint request when putting the replicator offine and the request itself is completed. If stopping the request is too late, the onComplete will be called in the next runloop, and that will cause a change tracker to start in offline mode.

To prevent above scenario, when the request is completed, check whether the replicator is still online or not. If the replicator is not online, just finish the request and return.

#1655