### PR TITLE
Fixed #1572: race when setting session to nil in CBLRemoteSession

### DIFF
--- a/Source/CBLRemoteSession.m
+++ b/Source/CBLRemoteSession.m
@@ -215,11 +215,11 @@ UsingLogDomain(Sync);
     LogTo(RemoteRequest, @"CBLRemoteSession closed");
     if (_requestIDs.count > 0)
         Warn(@"CBLRemoteSession closed but has leftover tasks: %@", _requestIDs.allValues);
-    _session = nil;
     _requestIDs = nil;
     
     // Reset _allRequests on the API thread:
     [self doAsync: ^{
+        _session = nil;
         _allRequests = nil;
     }];
 }


### PR DESCRIPTION
_session can be also accessed from the database thread (e.g. close method). It is more thread safe to set the _session to nil on the database thread in the doAsync: block.

#1572