### PR TITLE
Inline Swift Property Accessors with the Spec

### DIFF
--- a/Objective-C/CBLProperties.h
+++ b/Objective-C/CBLProperties.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+@class CBLBlob;
 @class CBLSubdocument;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -55,6 +56,10 @@ NS_ASSUME_NONNULL_BEGIN
     NOTE: This is not a generic date parser! It only recognizes the ISO-8601 format, with or
     without milliseconds. */
 - (nullable NSDate*) dateForKey: (NSString*)key;
+
+/** Get a property's value as a CBLBlob.
+    Returns nil if the property doesn't exist, or its value is not a CBLBlob. */
+- (nullable CBLBlob*) blobForKey: (NSString*)key;
 
 /** Get a property's value as a Subdocument, which is a mapping object of a Dictionary
     value to provide property type accessors.

--- a/Objective-C/CBLProperties.mm
+++ b/Objective-C/CBLProperties.mm
@@ -190,6 +190,11 @@ static inline NSNumber* numberProperty(NSDictionary* dict, NSString* key) {
 }
 
 
+- (nullable CBLBlob*) blobForKey: (NSString*)key {
+    return $castIf(CBLBlob, self[key]);
+}
+
+
 - (nullable CBLSubdocument*) subdocumentForKey: (NSString*)key {
     return $castIf(CBLSubdocument, self[key]);
 }

--- a/Swift/Document.swift
+++ b/Swift/Document.swift
@@ -85,6 +85,14 @@ public class Document : Properties {
     public static func == (doc1: Document, doc: Document) -> Bool {
         return doc._docimpl === doc._docimpl
     }
+    
+    // MARK: Properties
+    
+    @discardableResult public override func setValue(_ key: String, _ value: Any?) -> Self {
+        // Overriding to be able to return the right Self
+        super.setValue(key, value)
+        return self
+    }
 
     // MARK: Internal
     

--- a/Swift/Properties.swift
+++ b/Swift/Properties.swift
@@ -17,106 +17,164 @@ public class Properties {
         set {_impl.properties = convertProperties(newValue, isGetter: false)}
     }
 
-    /** Gets an property's value as an object. Returns types NSNull, Number, String, Array, 
-     Dictionary, and Blob, based on the underlying data type; or nil if the property doesn't
-     exist. */
-    public func property(_ key: String) -> Any? {
+    /** Gets an property's value as an object. Returns types NSNull, Number, String, Array,
+        Dictionary, and Blob, based on the underlying data type; or nil if the property doesn't
+        exist. */
+    public func getValue(_ key: String) -> Any? {
         return convertValue(_impl.object(forKey: key), isGetter: true)
     }
     
+    /** Gets a property's value as a boolean.
+        Returns YES if the value exists, and is either `true` or a nonzero number. */
+    public func getBool(_ key: String) -> Bool {
+        return _impl.boolean(forKey: key)
+    }
+    
+    /** Gets a property's value as an integer.
+        Floating point values will be rounded. The value `true` is returned as 1, `false` as 0.
+        Returns 0 if the property doesn't exist or does not have a numeric value. */
+    public func getInt(_ key: String) -> Int {
+        return _impl.integer(forKey: key)
+    }
+    
+    /** Gets a property's value as a float.
+        Integers will be converted to float. The value `true` is returned as 1.0, `false` as 0.0.
+        Returns 0.0 if the property doesn't exist or does not have a numeric value. */
+    public func getFloat(_ key: String) -> Float {
+        return _impl.float(forKey: key)
+    }
+    
+    /** Gets a property's value as a double.
+        Integers will be converted to double. The value `true` is returned as 1.0, `false` as 0.0.
+        Returns 0.0 if the property doesn't exist or does not have a numeric value. */
+    public func getDouble(_ key: String) -> Double {
+        return _impl.double(forKey: key)
+    }
+    
+    /** Gets a property's value as a string.
+        Returns nil if the property doesn't exist, or its value is not a string. */
+    public func getString(_ key: String) -> String? {
+        return _impl.string(forKey: key)
+    }
+    
+    /** Gets a property's value as an NSDate.
+        JSON does not directly support dates, so the actual property value must be a string, which is
+        then parsed according to the ISO-8601 date format (the default used in JSON.)
+        Returns nil if the value doesn't exist, is not a string, or is not parseable as a date.
+        NOTE: This is not a generic date parser! It only recognizes the ISO-8601 format, with or
+        without milliseconds. */
+    public func getDate(_ key: String) -> Date? {
+        return _impl.date(forKey: key)
+    }
+    
+    /** Get a property's value as a CBLBlob.
+        Returns nil if the property doesn't exist, or its value is not a CBLBlob. */
+    public func getBlob(_ key: String) -> Blob? {
+        return _impl.blob(forKey: key)
+    }
+    
+    /** Get a property's value as a Subdocument, which is a mapping object of a Dictionary
+        value to provide property type accessors.
+        Returns nil if the property doesn't exists, or its value is not a Dictionary. */
+    public func getSubdocument(_ key: String) -> Subdocument? {
+        return getValue(key) as? Subdocument
+    }
+    
     /** Sets a property value by key.
-     Allowed value types are NSNull, Number, String, Array, Dictionary, Date,
-     Subdocument, and Blob. Arrays and Dictionaries must contain only the above types.
-     Setting a nil value will remove the property.
+        Allowed value types are NSNull, Number, String, Array, Dictionary, Date,
+        Subdocument, and Blob. Arrays and Dictionaries must contain only the above types.
+        Setting a nil value will remove the property.
      
-     Note:
-     * A Date object will be converted to an ISO-8601 format string.
-     * When setting a subdocument, the subdocument will be set by reference. However,
-     if the subdocument has already been set to another key either on the same or different
-     document, the value of the subdocument will be copied instead. */
-    public func setProperty(_ key: String, _ value: Any?) {
-        return _impl.setObject(convertValue(value, isGetter: false), forKey: key)
+        Note:
+        * A Date object will be converted to an ISO-8601 format string.
+        * When setting a subdocument, the subdocument will be set by reference. However,
+        if the subdocument has already been set to another key either on the same or different
+        document, the value of the subdocument will be copied instead. */
+    @discardableResult public func setValue(_ key: String, _ value: Any?) -> Self {
+        _impl.setObject(convertValue(value, isGetter: false), forKey: key)
+        return self
     }
 
+
     /** Tests whether a property exists or not.
-     This can be less expensive than calling property(key):, because it does not have to allocate an
-     object for the property value. */
+        This can be less expensive than calling property(key):, because it does not have to allocate an
+        object for the property value. */
     public func contains(_ key: String) -> Bool {
         return _impl.containsObject(forKey: key)
     }
     
     /** Gets a property's value as a boolean.
-     Returns YES if the value exists, and is either `true` or a nonzero number. */
+        Returns YES if the value exists, and is either `true` or a nonzero number. */
     public subscript(key: String) -> Bool {
         get {return _impl.boolean(forKey: key)}
         set {_impl.setBoolean(newValue, forKey: key)}
     }
 
     /** Gets a property's value as an integer.
-     Floating point values will be rounded. The value `true` is returned as 1, `false` as 0.
-     Returns 0 if the property doesn't exist or does not have a numeric value. */
+        Floating point values will be rounded. The value `true` is returned as 1, `false` as 0.
+        Returns 0 if the property doesn't exist or does not have a numeric value. */
     public subscript(key: String) -> Int {
         get {return _impl.integer(forKey: key)}
         set {_impl.setInteger(newValue, forKey: key)}
     }
 
     /** Gets a property's value as a float.
-     Integers will be converted to float. The value `true` is returned as 1.0, `false` as 0.0.
-     Returns 0.0 if the property doesn't exist or does not have a numeric value. */
+        Integers will be converted to float. The value `true` is returned as 1.0, `false` as 0.0.
+        Returns 0.0 if the property doesn't exist or does not have a numeric value. */
     public subscript(key: String) -> Float {
         get {return _impl.float(forKey: key)}
         set {_impl.setFloat(newValue, forKey: key)}
     }
 
     /** Gets a property's value as a double.
-     Integers will be converted to double. The value `true` is returned as 1.0, `false` as 0.0.
-     Returns 0.0 if the property doesn't exist or does not have a numeric value. */
+        Integers will be converted to double. The value `true` is returned as 1.0, `false` as 0.0.
+        Returns 0.0 if the property doesn't exist or does not have a numeric value. */
     public subscript(key: String) -> Double {
         get {return _impl.double(forKey: key)}
         set {_impl.setDouble(newValue, forKey: key)}
     }
 
     /** Gets a property's value as a string.
-     Returns nil if the property doesn't exist, or its value is not a string. */
+        Returns nil if the property doesn't exist, or its value is not a string. */
     public subscript(key: String) -> String? {
         get {return _impl.string(forKey: key)}
     }
 
     /** Gets a property's value as an NSDate.
-     JSON does not directly support dates, so the actual property value must be a string, which is
-     then parsed according to the ISO-8601 date format (the default used in JSON.)
-     Returns nil if the value doesn't exist, is not a string, or is not parseable as a date.
-     NOTE: This is not a generic date parser! It only recognizes the ISO-8601 format, with or
-     without milliseconds. */
+        JSON does not directly support dates, so the actual property value must be a string, which is
+        then parsed according to the ISO-8601 date format (the default used in JSON.)
+        Returns nil if the value doesn't exist, is not a string, or is not parseable as a date.
+        NOTE: This is not a generic date parser! It only recognizes the ISO-8601 format, with or
+        without milliseconds. */
     public subscript(key: String) -> Date? {
         get {return _impl.date(forKey: key)}
     }
 
     /** Gets a property's value as a blob object.
-     Returns nil if the property doesn't exist, or its value is not a blob. */
+        Returns nil if the property doesn't exist, or its value is not a blob. */
     public subscript(key: String) -> Blob? {
         get {return _impl.object(forKey: key) as? Blob}
     }
     
     /** Get a property's value as an array object. 
-      Returns nil if the property doesn't exist, or its value is not an array. */
+        Returns nil if the property doesn't exist, or its value is not an array. */
     public subscript(key: String) -> [Any]? {
-        get {return property(key) as? [Any]}
+        get {return getValue(key) as? [Any]}
     }
     
     /** Get a property's value as a Subdocument, which is a mapping object of a Dictionary
-     value to provide property type accessors.
-     Returns nil if the property doesn't exists, or its value is not a Dictionary. */
+        value to provide property type accessors.
+        Returns nil if the property doesn't exists, or its value is not a Dictionary. */
     public subscript(key: String) -> Subdocument? {
-        get {return property(key) as? Subdocument}
+        get {return getValue(key) as? Subdocument}
     }
     
     /** Gets an property's value as an object. Returns types NSNull, Number, String, Array,
-     Dictionary, and Blob, based on the underlying data type; or nil if the property doesn't
-     exist. */
+        Dictionary, and Blob, based on the underlying data type; or nil if the property doesn't
+        exist. */
     public subscript(key: String) -> Any? {
-        get {return property(key)}
-        set {setProperty(key, newValue)}
+        get {return getValue(key)}
+        set {setValue(key, newValue)}
     }
     
     // MARK: Internal

--- a/Swift/Tests/DocumentTest.swift
+++ b/Swift/Tests/DocumentTest.swift
@@ -40,7 +40,7 @@ class DocumentTest: CBLTestCase {
         let s: String? = doc["prop"]
         XCTAssertNil(s)
 
-        let a: Any? = doc.property("prop")
+        let a: Any? = doc.getValue("prop")
         XCTAssertNil(a)
 
         try doc.save()
@@ -79,8 +79,8 @@ class DocumentTest: CBLTestCase {
             XCTAssertEqual(dict?.properties?.count, 3)
             XCTAssert(dict?["miney"] == "moe")
             
-            XCTAssert(self.doc.property("null") as? NSNull != nil)
-            XCTAssertNil(self.doc.property("none"))
+            XCTAssert(self.doc.getValue("null") as? NSNull != nil)
+            XCTAssertNil(self.doc.getValue("none"))
             XCTAssertFalse(self.doc.contains("none"))
         }
 
@@ -121,13 +121,13 @@ class DocumentTest: CBLTestCase {
         doc["name"] = nil
 
         XCTAssert(!doc.contains("name"))
-        XCTAssertNil(doc.property("name"))
+        XCTAssertNil(doc.getValue("name"))
 
         try doc.save()
         try reopenDB()
 
         XCTAssert(!doc.contains("name"))
-        XCTAssertNil(doc.property("name"))
+        XCTAssertNil(doc.getValue("name"))
     }
 
     func testBlob() throws {
@@ -140,7 +140,7 @@ class DocumentTest: CBLTestCase {
         try reopenDB()
 
         XCTAssertEqual(doc["name"], "Jim")
-        XCTAssert(doc.property("data") as? Blob != nil)
+        XCTAssert(doc.getValue("data") as? Blob != nil)
         let data2: Blob? = doc["data"]
         XCTAssert(data2 != nil)
         XCTAssertEqual(data2?.contentType, "text/plain")

--- a/Swift/Tests/SubdocumentTest.swift
+++ b/Swift/Tests/SubdocumentTest.swift
@@ -31,7 +31,7 @@ class SubdocumentTest: CBLTestCase {
     func testNewSubdoc() throws {
         let s: Subdocument? = doc["address"]
         XCTAssertNil(s)
-        XCTAssertNil(doc.property("address"))
+        XCTAssertNil(doc.getValue("address"))
         
         var address = Subdocument()
         XCTAssertFalse(address.exists)
@@ -43,7 +43,7 @@ class SubdocumentTest: CBLTestCase {
         XCTAssertEqual(address.properties?["street"] as? String, "1 Space Ave.")
         
         doc["address"] = address
-        XCTAssert(doc.property("address") as? Subdocument === address)
+        XCTAssert(doc.getValue("address") as? Subdocument === address)
         XCTAssert(address.document === doc)
         
         try doc.save()
@@ -63,13 +63,13 @@ class SubdocumentTest: CBLTestCase {
     func testGetSubdocument() throws {
         var address: Subdocument? = doc["address"]
         XCTAssertNil(address)
-        XCTAssertNil(doc.property("address"))
+        XCTAssertNil(doc.getValue("address"))
         
         doc.properties = ["address": ["street": "1 Space Ave."]]
         
         address = doc["address"]
         XCTAssertNotNil(address)
-        XCTAssert(address! === doc.property("address") as? Subdocument)
+        XCTAssert(address! === doc.getValue("address") as? Subdocument)
         XCTAssertFalse(address!.exists)
         XCTAssert(address!.document === doc)
         XCTAssertEqual(address!["street"], "1 Space Ave.")
@@ -83,7 +83,7 @@ class SubdocumentTest: CBLTestCase {
         
         try reopenDB()
         address = doc["address"]!
-        XCTAssert(address! === doc.property("address") as? Subdocument)
+        XCTAssert(address! === doc.getValue("address") as? Subdocument)
         XCTAssert(address!.exists)
         XCTAssert(address!.document === doc)
         XCTAssertEqual(address!["street"], "1 Space Ave.")
@@ -113,9 +113,9 @@ class SubdocumentTest: CBLTestCase {
         XCTAssertFalse(level3!.exists)
         
         XCTAssertEqual(level1!["name"], "n1")
-        XCTAssert(level1!.property("level2") as? Subdocument === level2)
+        XCTAssert(level1!.getValue("level2") as? Subdocument === level2)
         XCTAssertEqual(level2!["name"], "n2")
-        XCTAssert(level2!.property("level3") as? Subdocument === level3)
+        XCTAssert(level2!.getValue("level3") as? Subdocument === level3)
         XCTAssertEqual(level3!["name"], "n3")
     }
     
@@ -182,12 +182,12 @@ class SubdocumentTest: CBLTestCase {
         XCTAssertNotNil(address2);
         XCTAssert(address !== address2)
         XCTAssertNil(address2!.document)
-        XCTAssertEqual(street, address2!.property("street") as? String)
+        XCTAssertEqual(street, address2!.getValue("street") as? String)
         
         let phone2: Subdocument? = address2!["phones"]
         XCTAssertNotNil(phone2)
         XCTAssertNil(phone2?.document)
-        XCTAssertEqual(mobile, phone2?.property("mobile") as? String)
+        XCTAssertEqual(mobile, phone2?.getValue("mobile") as? String)
     }
     
     func testSetSubdocumentFromAnotherKey() {
@@ -209,13 +209,13 @@ class SubdocumentTest: CBLTestCase {
         XCTAssertNotNil(address2)
         XCTAssert(address !== address2)
         XCTAssert(address2?.document === doc)
-        XCTAssertEqual(street, address2?.property("street") as? String)
+        XCTAssertEqual(street, address2?.getValue("street") as? String)
         
         let phones2: Subdocument? = address2?["phones"];
         XCTAssertNotNil(phones2)
         XCTAssert(phones !== phones2)
         XCTAssert(phones2?.document === doc)
-        XCTAssertEqual(mobile, phones2?.property("mobile") as? String)
+        XCTAssertEqual(mobile, phones2?.getValue("mobile") as? String)
     }
     
     func testSubdocumentArray() {
@@ -230,10 +230,10 @@ class SubdocumentTest: CBLTestCase {
         let s3 = subdocs?[2] as? Subdocument
         let s4 = subdocs?[3] as? Subdocument
         
-        XCTAssertEqual(s1?.property("name") as? String, "1")
-        XCTAssertEqual(s2?.property("name") as? String, "2")
-        XCTAssertEqual(s3?.property("name") as? String, "3")
-        XCTAssertEqual(s4?.property("name") as? String, "4")
+        XCTAssertEqual(s1?.getValue("name") as? String, "1")
+        XCTAssertEqual(s2?.getValue("name") as? String, "2")
+        XCTAssertEqual(s3?.getValue("name") as? String, "3")
+        XCTAssertEqual(s4?.getValue("name") as? String, "4")
         
         // Make changes
         
@@ -273,25 +273,25 @@ class SubdocumentTest: CBLTestCase {
         doc["references"] = nil
         
         // Check address:
-        XCTAssertNil(doc.property("address"))
+        XCTAssertNil(doc.getValue("address"))
         XCTAssertNil(address.document)
         XCTAssertNil(address.properties)
-        XCTAssertNil(address.property("street"))
-        XCTAssertNil(address.property("phones"))
+        XCTAssertNil(address.getValue("street"))
+        XCTAssertNil(address.getValue("phones"))
         
         // Check phones:
         XCTAssertNil(phones.document)
         XCTAssertNil(phones.properties)
-        XCTAssertNil(phones.property("mobile"))
+        XCTAssertNil(phones.getValue("mobile"))
         
         // Check references:
-        XCTAssertNil(doc.property("references"))
+        XCTAssertNil(doc.getValue("references"))
         XCTAssertNil(r1.document)
         XCTAssertNil(r1.properties)
-        XCTAssertNil(r1.property("name"))
+        XCTAssertNil(r1.getValue("name"))
         XCTAssertNil(r2.document)
         XCTAssertNil(r2.properties)
-        XCTAssertNil(r2.property("name"))
+        XCTAssertNil(r2.getValue("name"))
     }
     
     func testSetDocumentPropertiesNil() {
@@ -314,25 +314,25 @@ class SubdocumentTest: CBLTestCase {
         doc.properties = nil
         
         // Check address:
-        XCTAssertNil(doc.property("address"))
+        XCTAssertNil(doc.getValue("address"))
         XCTAssertNil(address.document)
         XCTAssertNil(address.properties)
-        XCTAssertNil(address.property("street"))
-        XCTAssertNil(address.property("phones"))
+        XCTAssertNil(address.getValue("street"))
+        XCTAssertNil(address.getValue("phones"))
         
         // Check phones:
         XCTAssertNil(phones.document)
         XCTAssertNil(phones.properties)
-        XCTAssertNil(phones.property("mobile"))
+        XCTAssertNil(phones.getValue("mobile"))
         
         // Check references:
-        XCTAssertNil(doc.property("references"))
+        XCTAssertNil(doc.getValue("references"))
         XCTAssertNil(r1.document)
         XCTAssertNil(r1.properties)
-        XCTAssertNil(r1.property("name"))
+        XCTAssertNil(r1.getValue("name"))
         XCTAssertNil(r2.document)
         XCTAssertNil(r2.properties)
-        XCTAssertNil(r2.property("name"))
+        XCTAssertNil(r2.getValue("name"))
     }
     
     func testReplaceWithNonDict() {
@@ -340,7 +340,7 @@ class SubdocumentTest: CBLTestCase {
         address["street"] = "1 Star Way."
         
         doc["address"] = address
-        XCTAssert(doc.property("address") as? Subdocument === address)
+        XCTAssert(doc.getValue("address") as? Subdocument === address)
         XCTAssert(address.document === doc)
         
         doc["address"] = "123 Space Dr."
@@ -354,14 +354,14 @@ class SubdocumentTest: CBLTestCase {
         address["street"] = "1 Star Way."
         
         doc["address"] = address
-        XCTAssert(doc.property("address") as? Subdocument === address)
+        XCTAssert(doc.getValue("address") as? Subdocument === address)
         XCTAssert(address.document === doc)
         
         let nuAddress = Subdocument()
         nuAddress["street"] = "123 Space Dr."
         doc["address"] = nuAddress
         
-        XCTAssert(doc.property("address") as? Subdocument === nuAddress)
+        XCTAssert(doc.getValue("address") as? Subdocument === nuAddress)
         XCTAssertNil(address.document)
         XCTAssertNil(address.properties)
     }
@@ -404,16 +404,16 @@ class SubdocumentTest: CBLTestCase {
         XCTAssertNil(phones.document)
         XCTAssertNil(phones.properties)
         
-        XCTAssert(doc.property("work") as? Subdocument === work)
+        XCTAssert(doc.getValue("work") as? Subdocument === work)
         XCTAssertEqual(work["company"], "Couchbase")
         XCTAssertEqual(work["position"], "Engineer")
         
-        XCTAssert(doc.property("subscription") as? Subdocument === nuSubscription)
+        XCTAssert(doc.getValue("subscription") as? Subdocument === nuSubscription)
         XCTAssertNil(subscription.document)
         XCTAssertNil(subscription.properties)
         
-        XCTAssertNotNil(doc.property("expiration"))
-        XCTAssertNil(doc.property("expiration") as? Subdocument)
+        XCTAssertNotNil(doc.getValue("expiration"))
+        XCTAssertNil(doc.getValue("expiration") as? Subdocument)
         XCTAssertNil(expiration.document)
         XCTAssertNil(expiration.properties)
         
@@ -448,33 +448,33 @@ class SubdocumentTest: CBLTestCase {
         
         // Check doc:
         XCTAssertNil(doc.properties)
-        XCTAssertNil(doc.property("name"))
-        XCTAssertNil(doc.property("address"))
-        XCTAssertNil(doc.property("references"))
+        XCTAssertNil(doc.getValue("name"))
+        XCTAssertNil(doc.getValue("address"))
+        XCTAssertNil(doc.getValue("references"))
         
         // Check address:
-        XCTAssertNil(doc.property("address"))
+        XCTAssertNil(doc.getValue("address"))
         XCTAssertNil(address.document)
         XCTAssertFalse(address.exists)
         XCTAssertNil(address.properties)
-        XCTAssertNil(address.property("street"))
-        XCTAssertNil(address.property("phones"))
+        XCTAssertNil(address.getValue("street"))
+        XCTAssertNil(address.getValue("phones"))
         
         // Check phones:
         XCTAssertNil(phones.document)
         XCTAssertFalse(phones.exists)
         XCTAssertNil(phones.properties)
-        XCTAssertNil(phones.property("mobile"))
+        XCTAssertNil(phones.getValue("mobile"))
         
         // Check references:
-        XCTAssertNil(doc.property("references"))
+        XCTAssertNil(doc.getValue("references"))
         XCTAssertNil(r1.document)
         XCTAssertFalse(r1.exists)
         XCTAssertNil(r1.properties)
-        XCTAssertNil(r1.property("name"))
+        XCTAssertNil(r1.getValue("name"))
         XCTAssertNil(r2.document)
         XCTAssertFalse(r2.exists)
         XCTAssertNil(r2.properties)
-        XCTAssertNil(r2.property("name"))
+        XCTAssertNil(r2.getValue("name"))
     }
 }


### PR DESCRIPTION
* Renamed property() and setProperty(key, value) to getValue() and setValue(key, value).
* Made setValue(key, value) chainable API
* Added the missing CBLProperties’s -blobForKey: method.