### PR TITLE
2.0: LiveQuery

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -47,6 +47,10 @@
 		27BE3B521E4E916B0012B74A /* names_100.json in Resources */ = {isa = PBXBuildFile; fileRef = 27EF6A951E2AC609004748DF /* names_100.json */; };
 		27BE3B541E4E92210012B74A /* Database+Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BE3B531E4E92210012B74A /* Database+Query.swift */; };
 		27BE3B561E4E93000012B74A /* PredicateQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BE3B551E4E93000012B74A /* PredicateQuery.swift */; };
+		27DF4BD81ECA442400EE6B8D /* CBLLiveQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 27DF4BD61ECA442400EE6B8D /* CBLLiveQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27DF4BD91ECA442400EE6B8D /* CBLLiveQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 27DF4BD61ECA442400EE6B8D /* CBLLiveQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27DF4BDA1ECA442400EE6B8D /* CBLLiveQuery.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27DF4BD71ECA442400EE6B8D /* CBLLiveQuery.mm */; };
+		27DF4BDB1ECA442400EE6B8D /* CBLLiveQuery.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27DF4BD71ECA442400EE6B8D /* CBLLiveQuery.mm */; };
 		27E35A821E8B3B3A00E103F9 /* ReplicationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27E35A811E8B3B3A00E103F9 /* ReplicationTest.m */; };
 		27E35A921E8C4F4300E103F9 /* Replication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E35A911E8C4F4300E103F9 /* Replication.swift */; };
 		27E35A9C1E8C522200E103F9 /* CBLReplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 275229C51E776BC100E630FA /* CBLReplication.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -521,6 +525,8 @@
 		27BE3B501E4E8F6F0012B74A /* PredicateQueryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredicateQueryTest.swift; sourceTree = "<group>"; };
 		27BE3B531E4E92210012B74A /* Database+Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Database+Query.swift"; sourceTree = "<group>"; };
 		27BE3B551E4E93000012B74A /* PredicateQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredicateQuery.swift; sourceTree = "<group>"; };
+		27DF4BD61ECA442400EE6B8D /* CBLLiveQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLLiveQuery.h; sourceTree = "<group>"; };
+		27DF4BD71ECA442400EE6B8D /* CBLLiveQuery.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLLiveQuery.mm; sourceTree = "<group>"; };
 		27E35A811E8B3B3A00E103F9 /* ReplicationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicationTest.m; sourceTree = "<group>"; };
 		27E35A911E8C4F4300E103F9 /* Replication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Replication.swift; sourceTree = "<group>"; };
 		27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryResultsArray.h; sourceTree = "<group>"; };
@@ -1092,6 +1098,8 @@
 			children = (
 				933208101E77415E000D9993 /* CBLQuery.h */,
 				933208111E77415E000D9993 /* CBLQuery.mm */,
+				27DF4BD61ECA442400EE6B8D /* CBLLiveQuery.h */,
+				27DF4BD71ECA442400EE6B8D /* CBLLiveQuery.mm */,
 				933208081E77415E000D9993 /* CBLQueryDataSource.h */,
 				933208091E77415E000D9993 /* CBLQueryDataSource.m */,
 				9332080A1E77415E000D9993 /* CBLQueryExpression.h */,
@@ -1169,6 +1177,7 @@
 				93B5037A1E64B0E3002C4680 /* CBLPrefix.h in Headers */,
 				9381960B1EC112010032CC51 /* CBLDictionary.h in Headers */,
 				9381960D1EC112130032CC51 /* CBLReadOnlyArray.h in Headers */,
+				27DF4BD91ECA442400EE6B8D /* CBLLiveQuery.h in Headers */,
 				93B503691E64B08E002C4680 /* CBLBase64.h in Headers */,
 				9381961F1EC11A8C0032CC51 /* CBLReadOnlyDictionary+Swift.h in Headers */,
 				9308F40A1E64B23300F53EE4 /* Test.h in Headers */,
@@ -1222,6 +1231,7 @@
 				2704F1C91E395F3300A3B405 /* CBLConflictResolver.h in Headers */,
 				933208161E77415E000D9993 /* CBLQueryOrderBy.h in Headers */,
 				9332082A1E774171000D9993 /* CBLQuery+Internal.h in Headers */,
+				27DF4BD81ECA442400EE6B8D /* CBLLiveQuery.h in Headers */,
 				9380C72A1E16E7D00011E8CB /* CBLDatabase.h in Headers */,
 				93CD02721EA0004500AFB3FA /* CBLReadOnlyDocument.h in Headers */,
 				27A8B5021EC5350A00BB4C07 /* CBLQueryEnumerator.h in Headers */,
@@ -1673,6 +1683,7 @@
 				27BE3B541E4E92210012B74A /* Database+Query.swift in Sources */,
 				938CDF201E807F45002EE790 /* DataSource.swift in Sources */,
 				9308F4071E64B22A00F53EE4 /* MYErrorUtils.m in Sources */,
+				27DF4BDB1ECA442400EE6B8D /* CBLLiveQuery.mm in Sources */,
 				933F45F51EC29EF100863ECB /* Fragment.swift in Sources */,
 				938196161EC113650032CC51 /* CBLDocumentFragment.m in Sources */,
 				93AF51CA1E80C42C00E200F0 /* CouchbaseLiteError.swift in Sources */,
@@ -1818,6 +1829,7 @@
 				275229C81E776BC100E630FA /* CBLReplication.mm in Sources */,
 				72A87A061E2E0E70008466FF /* CBLBlobStream.mm in Sources */,
 				93655B7A1EB8F85B00AC7E2A /* CBLFLArray.mm in Sources */,
+				27DF4BDA1ECA442400EE6B8D /* CBLLiveQuery.mm in Sources */,
 				27A8B5131EC5351000BB4C07 /* CBLQueryEnumerator.mm in Sources */,
 				934F4CB71E241FB500F90659 /* CBLStringBytes.mm in Sources */,
 				2704F1CA1E395F3300A3B405 /* CBLConflictResolver.m in Sources */,

--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -51,6 +51,10 @@
 		27E35A921E8C4F4300E103F9 /* Replication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E35A911E8C4F4300E103F9 /* Replication.swift */; };
 		27E35A9C1E8C522200E103F9 /* CBLReplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 275229C51E776BC100E630FA /* CBLReplication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27E35A9D1E8C539600E103F9 /* CBLReplication.mm in Sources */ = {isa = PBXBuildFile; fileRef = 275229C61E776BC100E630FA /* CBLReplication.mm */; };
+		27E673941EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */; };
+		27E673951EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */; };
+		27E673961EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */; };
+		27E673971EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */; };
 		27EF6A941E298E26004748DF /* PredicateQueryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27EF6A931E298E26004748DF /* PredicateQueryTest.m */; };
 		27EF6A971E2AC61B004748DF /* names_100.json in Resources */ = {isa = PBXBuildFile; fileRef = 27EF6A951E2AC609004748DF /* names_100.json */; };
 		72A879F01E2DD51C008466FF /* CBLBlob.mm in Sources */ = {isa = PBXBuildFile; fileRef = 72A879EF1E2DD51C008466FF /* CBLBlob.mm */; };
@@ -519,6 +523,8 @@
 		27BE3B551E4E93000012B74A /* PredicateQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredicateQuery.swift; sourceTree = "<group>"; };
 		27E35A811E8B3B3A00E103F9 /* ReplicationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicationTest.m; sourceTree = "<group>"; };
 		27E35A911E8C4F4300E103F9 /* Replication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Replication.swift; sourceTree = "<group>"; };
+		27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryResultsArray.h; sourceTree = "<group>"; };
+		27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLQueryResultsArray.mm; sourceTree = "<group>"; };
 		27EF6A931E298E26004748DF /* PredicateQueryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PredicateQueryTest.m; sourceTree = "<group>"; };
 		27EF6A951E2AC609004748DF /* names_100.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = names_100.json; sourceTree = "<group>"; };
 		27EF6AF11E32D12C004748DF /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -1095,6 +1101,8 @@
 				275FF66E1E43E013005F90DD /* CBLQueryRow.h */,
 				275FF66F1E43E013005F90DD /* CBLQueryRow.mm */,
 				27A8B5121EC5351000BB4C07 /* CBLQueryEnumerator.mm */,
+				27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */,
+				27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */,
 				9332080E1E77415E000D9993 /* CBLQuerySelect.h */,
 				9332080F1E77415E000D9993 /* CBLQuerySelect.m */,
 				937441D01E7B8B0500CB8F11 /* CBLPredicateQuery.h */,
@@ -1164,6 +1172,7 @@
 				93B503691E64B08E002C4680 /* CBLBase64.h in Headers */,
 				9381961F1EC11A8C0032CC51 /* CBLReadOnlyDictionary+Swift.h in Headers */,
 				9308F40A1E64B23300F53EE4 /* Test.h in Headers */,
+				27E673951EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */,
 				938196171EC1136E0032CC51 /* CBLFragment.h in Headers */,
 				938196251EC122F20032CC51 /* CBLDictionary+Swift.h in Headers */,
 				93B503671E64B085002C4680 /* CBLSharedKeys.hh in Headers */,
@@ -1223,6 +1232,7 @@
 				272850A81E99CAA4009CA22F /* CBLReplication+Internal.h in Headers */,
 				275FF6701E43E013005F90DD /* CBLQueryRow.h in Headers */,
 				934F4CA71E241FB500F90659 /* CBLBase64.h in Headers */,
+				27E673941EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */,
 				93CD02661E9FFEC500AFB3FA /* CBLArray.h in Headers */,
 				934F4C101E1EF19000F90659 /* CollectionUtils.h in Headers */,
 				931C14681EAAD6730094F9B2 /* CBLArrayFragment.h in Headers */,
@@ -1697,6 +1707,7 @@
 				938196061EC10E890032CC51 /* DictionaryObject.swift in Sources */,
 				938196021EC10BA40032CC51 /* ReadOnlyDictionaryObject.swift in Sources */,
 				93B5035B1E64B053002C4680 /* CBLDatabase.mm in Sources */,
+				27E673971EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */,
 				938196101EC1121F0032CC51 /* CBLReadOnlyDictionary.mm in Sources */,
 				9308F4051E64B22500F53EE4 /* ExceptionUtils.m in Sources */,
 				93B503701E64B0A3002C4680 /* CBLMisc.m in Sources */,
@@ -1814,6 +1825,7 @@
 				93CD02731EA0004500AFB3FA /* CBLReadOnlyDocument.mm in Sources */,
 				934F4CB91E241FB500F90659 /* CBLSymmetricKey.m in Sources */,
 				93CD02671E9FFEC500AFB3FA /* CBLArray.m in Sources */,
+				27E673961EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */,
 				934F4CAC1E241FB500F90659 /* CBLInternal.mm in Sources */,
 				275FF6B91E47B2FC005F90DD /* ExceptionUtils.m in Sources */,
 				275FF6711E43E013005F90DD /* CBLQueryRow.mm in Sources */,

--- a/Objective-C/CBLLiveQuery.h
+++ b/Objective-C/CBLLiveQuery.h
@@ -1,0 +1,44 @@
+//
+//  CBLLiveQuery.h
+//  CouchbaseLite
+//
+//  Created by Jens Alfke on 5/15/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLQuery.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+// *** WARNING ***  This is an unofficial placeholder API. It WILL change.
+
+
+/** A CBLQuery subclass that automatically refreshes the result rows every time the database
+    changes. All you need to do is use KVO to observe changes to the .rows property. */
+@interface CBLLiveQuery : CBLQuery
+
+/** The shortest interval at which the query will update, regardless of how often the
+    database changes. Defaults to 0.2 sec. Increase this if the query is expensive and
+    the database updates frequently, to limit CPU consumption. */
+@property (nonatomic) NSTimeInterval updateInterval;
+
+/** Starts observing database changes. The .rows property will now update automatically. (You 
+    usually don't need to call this yourself, since accessing or observing the .rows property will
+    call -start for you.) */
+- (void) start;
+
+/** Stops observing database changes. Calling -start or .rows will restart it. */
+- (void) stop;
+
+/** The current query results; this updates as the database changes, and can be observed using KVO.
+    Its value will be nil until the initial asynchronous query finishes. */
+@property (readonly, nullable, nonatomic) NSArray<CBLQueryRow*>* rows;
+
+/** If non-nil, the error of the last execution of the query.
+    If nil, the last execution of the query was successful. */
+@property (readonly, nullable, nonatomic) NSError* lastError;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/CBLLiveQuery.mm
+++ b/Objective-C/CBLLiveQuery.mm
@@ -1,0 +1,179 @@
+//
+//  CBLLiveQuery.mm
+//  CouchbaseLite
+//
+//  Created by Jens Alfke on 5/15/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLLiveQuery.h"
+#import "CBLQuery+Internal.h"
+#import "CBLQueryEnumerator.h"
+#import "CBLLog.h"
+#import "c4.h"
+
+
+// Default value of CBLLiveQuery.updateInterval
+static const NSTimeInterval kDefaultLiveQueryUpdateInterval = 0.2;
+
+
+@interface CBLLiveQuery ()
+@property (readwrite, nullable, nonatomic) NSArray* rows;
+@property (readwrite, nullable, nonatomic) NSError* lastError;
+@end
+
+
+@implementation CBLLiveQuery
+{
+    bool _observing, _willUpdate, _forceReload;
+    NSUInteger _observerCount;
+    CFAbsoluteTime _lastUpdatedAt;
+    CBLQueryEnumerator* _enum;
+    NSArray* _rows;
+}
+
+
+@synthesize lastError=_lastError, updateInterval=_updateInterval;
+
+
+- (instancetype) initWithSelect: (CBLQuerySelect*)select
+                       distinct: (BOOL)distinct
+                           from: (CBLQueryDataSource*)from
+                          where: (CBLQueryExpression*)where
+                        orderBy: (CBLQueryOrderBy*)orderBy
+{
+    self = [super initWithSelect: select distinct: distinct from: from where: where orderBy: orderBy];
+    if (self) {
+        _updateInterval = kDefaultLiveQueryUpdateInterval;
+    }
+    return self;
+}
+
+
+- (void) dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver: self];
+}
+
+
+- (void) start {
+    if (!_observing) {
+        _observing = YES;
+        [[NSNotificationCenter defaultCenter] addObserver: self 
+                                                 selector: @selector(databaseChanged:)
+                                                     name: kCBLDatabaseChangeNotification 
+                                                   object: self.database];
+        [self update];
+    }
+}
+
+
+- (void) stop {
+    if (_observing) {
+        _observing = NO;
+        [[NSNotificationCenter defaultCenter] removeObserver: self];
+    }
+    _willUpdate = NO; // cancels the delayed update started by -databaseChanged
+}
+
+
+- (NSArray*) rows {
+    [self start];
+    return _rows;
+}
+
+
+- (void) setRows:(NSArray*)rows {
+    _rows = rows;
+}
+
+
+- (void) addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath
+             options:(NSKeyValueObservingOptions)options context:(void *)context
+{
+    if ([keyPath isEqualToString: @"rows"]) {
+        if (++_observerCount == 1)
+            [self start];
+    }
+    [super addObserver: observer forKeyPath: keyPath options: options context: context];
+}
+
+
+- (void) removeObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath {
+    if ([keyPath isEqualToString: @"rows"]) {
+        if (--_observerCount == 0)
+            [self stop];
+    }
+    [super removeObserver: observer forKeyPath: keyPath];
+}
+
+
+- (void) databaseChanged: (NSNotification*)n {
+    if (_willUpdate)
+        return;  // Already a pending update scheduled
+
+    // Use double the update interval if this is a remote change (coming from a pull replication):
+    NSTimeInterval updateInterval = _updateInterval;
+    if ([n.userInfo[kCBLDatabaseIsExternalUserInfoKey] boolValue])
+        updateInterval *= 2;
+
+    // Schedule an update, respecting the updateInterval:
+    NSTimeInterval updateDelay = (_lastUpdatedAt + updateInterval) - CFAbsoluteTimeGetCurrent();
+    updateDelay = MAX(0, MIN(_updateInterval, updateDelay));
+    [self updateAfter: updateDelay];
+}
+
+
+- (void) updateAfter: (NSTimeInterval)updateDelay {
+    if (_willUpdate)
+        return;  // Already a pending update scheduled
+    _willUpdate = YES;
+    CBLLog(Query, @"%@: Will update after %g sec...", self, updateDelay);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(updateDelay * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{        //FIX: Use a different queue
+        if (_willUpdate)
+            [self update];
+    });
+}
+
+
+- (void) update {
+    //TODO: Make this asynchronous (as in 1.x)
+    NSError *error;
+    CBLQueryEnumerator* oldEnum = _enum;
+    CBLQueryEnumerator* newEnum;
+    if (oldEnum == nil || _forceReload)
+        newEnum = (CBLQueryEnumerator*) [self run: &error];
+    else
+        newEnum = [oldEnum refresh: &error];
+
+    _willUpdate = _forceReload = false;
+    _lastUpdatedAt = CFAbsoluteTimeGetCurrent();
+
+    if (newEnum != oldEnum) {
+        CBLLog(Query, @"%@: Changed!", self);
+        _enum = newEnum;
+        self.rows = newEnum.allObjects;     // triggers KVO
+    }
+
+    if (error || _lastError) {
+        if (error)
+            CBLWarnError(Query, @"%@: Update failed: %@", self, error.localizedDescription);
+        self.lastError = error;             // triggers KVO
+    }
+}
+
+
+- (BOOL) waitForRows {
+    if (!_rows && !_lastError)
+        [self update];
+    return _rows != nil;
+}
+
+ 
+- (void) queryOptionsChanged {
+    _forceReload = true;
+    [self updateAfter: 0.0];
+}
+
+
+@end

--- a/Objective-C/CBLQueryEnumerator.h
+++ b/Objective-C/CBLQueryEnumerator.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id) objectAtIndex: (NSUInteger)index;
 
+// If query results have changed, returns a new enumerator, else nil.
 - (nullable CBLQueryEnumerator*) refresh: (NSError**)outError;
 
 @end

--- a/Objective-C/CBLQueryEnumerator.h
+++ b/Objective-C/CBLQueryEnumerator.h
@@ -20,10 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
                     enumerator: (C4QueryEnumerator*)e
                returnDocuments: (bool)returnDocuments;
 
-@property (readonly, nonatomic) CBLDatabase* database;
+@property (readonly, weak, nonatomic) CBLDatabase* database;
 @property (readonly, nonatomic) C4Query* c4Query;
 
 - (id) objectAtIndex: (NSUInteger)index;
+
+- (nullable CBLQueryEnumerator*) refresh: (NSError**)outError;
 
 @end
 

--- a/Objective-C/CBLQueryEnumerator.h
+++ b/Objective-C/CBLQueryEnumerator.h
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) CBLDatabase* database;
 @property (readonly, nonatomic) C4Query* c4Query;
 
+- (id) objectAtIndex: (NSUInteger)index;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/CBLQueryEnumerator.mm
+++ b/Objective-C/CBLQueryEnumerator.mm
@@ -22,7 +22,7 @@ extern "C" {
 
 @implementation CBLQueryEnumerator
 {
-    id<CBLQueryInternal> _query;
+    __weak id<CBLQueryInternal> _query;
     C4Query *_c4Query;
     C4QueryEnumerator* _c4enum;
     __weak CBLQueryRow *_currentRow;
@@ -123,6 +123,24 @@ extern "C" {
     NSError* error;
     convertError(_error, &error);
     return error;
+}
+
+
+- (CBLQueryEnumerator*) refresh: (NSError**)outError {
+    auto query = _query;
+    if (!query)
+        return nil;
+
+    C4Error c4error;
+    C4QueryEnumerator *newEnum = c4queryenum_refresh(_c4enum, &c4error);
+    if (!newEnum) {
+        convertError(c4error, outError);
+        return nil;
+    }
+    return [[CBLQueryEnumerator alloc] initWithQuery: query
+                                             c4Query: _c4Query
+                                          enumerator: newEnum
+                                     returnDocuments: _returnDocuments];
 }
 
 

--- a/Objective-C/CBLQueryEnumerator.mm
+++ b/Objective-C/CBLQueryEnumerator.mm
@@ -127,6 +127,7 @@ extern "C" {
 
 
 - (CBLQueryEnumerator*) refresh: (NSError**)outError {
+    if (outError) *outError = nil;
     auto query = _query;
     if (!query)
         return nil;
@@ -134,7 +135,8 @@ extern "C" {
     C4Error c4error;
     C4QueryEnumerator *newEnum = c4queryenum_refresh(_c4enum, &c4error);
     if (!newEnum) {
-        convertError(c4error, outError);
+        if (c4error.code)
+            convertError(c4error, outError);
         return nil;
     }
     return [[CBLQueryEnumerator alloc] initWithQuery: query

--- a/Objective-C/CBLQueryResultsArray.h
+++ b/Objective-C/CBLQueryResultsArray.h
@@ -1,0 +1,18 @@
+//
+//  CBLQueryResultsArray.h
+//  CouchbaseLite
+//
+//  Created by Jens Alfke on 5/13/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+@class CBLQueryEnumerator;
+
+
+@interface CBLQueryResultsArray : NSArray
+
+- (instancetype) initWithEnumerator: (CBLQueryEnumerator*)enumerator
+                              count: (NSUInteger)count;
+
+@end

--- a/Objective-C/CBLQueryResultsArray.mm
+++ b/Objective-C/CBLQueryResultsArray.mm
@@ -1,0 +1,64 @@
+//
+//  CBLQueryResultsArray.m
+//  CouchbaseLite
+//
+//  Created by Jens Alfke on 5/13/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLQueryResultsArray.h"
+#import "CBLQueryEnumerator.h"
+#import "CBLQuery+Internal.h"
+#import "CBLQueryRow.h"
+#import "CBLDatabase.h"
+#import "CBLCoreBridge.h"
+
+
+@implementation CBLQueryResultsArray
+{
+    CBLQueryEnumerator* _enum;
+    NSUInteger _count;
+}
+
+- (instancetype) initWithEnumerator: (CBLQueryEnumerator*)enumerator
+                              count: (NSUInteger)count
+{
+    self = [super init];
+    if (self) {
+        _enum = enumerator;
+        _count = count;
+    }
+    return self;
+}
+
+
+- (NSUInteger) count {
+    return _count;
+}
+
+
+- (id) objectAtIndex: (NSUInteger)index {
+    return [_enum objectAtIndex: index];
+}
+
+
+- (id) copyWithZone:(NSZone *)zone {
+    return self;
+}
+
+
+- (NSMutableArray*) mutableCopy {
+    NSMutableArray* m = [[NSMutableArray alloc] initWithCapacity: _count];
+    for (NSUInteger i = 0; i < _count; ++i)
+        [m addObject: [self objectAtIndex: i]];
+    return m;
+}
+
+
+// This is what the %@ substitution calls.
+- (NSString *)descriptionWithLocale:(id)locale indent:(NSUInteger)level {
+    return [NSString stringWithFormat: @"%@[%lu rows]", [self class], (unsigned long)_count];
+}
+
+
+@end

--- a/Objective-C/CBLQueryRow.mm
+++ b/Objective-C/CBLQueryRow.mm
@@ -30,7 +30,8 @@
 
 
 - (instancetype) initWithEnumerator: (CBLQueryEnumerator*)enumerator
-                       c4Enumerator: (C4QueryEnumerator*)e {
+                       c4Enumerator: (C4QueryEnumerator*)e
+{
     self = [super init];
     if (self) {
         _enum = enumerator;
@@ -48,8 +49,18 @@
 }
 
 
+#if 0 //TEMP
+- (BOOL) isEqual: (id)other {
+    CBLQueryRow *otherRow = $cast(CBLQueryRow, other);
+    if (!otherRow)
+        return NO;
+    return _enum == otherRow->_enum;
+}
+#endif
+
+
 - (CBLDocument*) document {
-    return [_enum.database documentWithID: _documentID];
+    return _documentID ? [_enum.database documentWithID: _documentID] : nil;
 }
 
 

--- a/Objective-C/CBLReadOnlyDocument.mm
+++ b/Objective-C/CBLReadOnlyDocument.mm
@@ -18,6 +18,7 @@
                               c4Doc: (nullable CBLC4Document*)c4Doc
                          fleeceData: (nullable CBLFLDict*)data
 {
+    NSParameterAssert(documentID != nil);
     self = [super initWithFleeceData: data];
     if (self) {
         _documentID = documentID;

--- a/Objective-C/CouchbaseLite.h
+++ b/Objective-C/CouchbaseLite.h
@@ -29,6 +29,7 @@ FOUNDATION_EXPORT const unsigned char CouchbaseLiteVersionString[];
 #import "CBLQueryOrderBy.h"
 #import "CBLQuerySelect.h"
 #import "CBLQueryRow.h"
+#import "CBLLiveQuery.h"
 #import "CBLReadOnlyArray.h"
 #import "CBLReadOnlyDictionary.h"
 #import "CBLReadOnlyDocument.h"

--- a/Objective-C/Internal/CBLLog.m
+++ b/Objective-C/Internal/CBLLog.m
@@ -39,7 +39,7 @@ static C4LogLevel string2level(NSString* value) {
         return kC4LogWarning;
     switch (value.length > 0 ? toupper([value characterAtIndex: 0]) : 'Y') {
         case 'N': case 'F': case '0':
-            return kC4LogError + 1;
+            return kC4LogNone;
         case 'V': case '2':
             return kC4LogVerbose;
         case 'D': case '3'...'9':


### PR DESCRIPTION
Implementation of CBLLiveQuery, with provisional API. NOTE: Creating a LiveQuery is different. Instead of using a -asLiveQuery method to convert a query, you directly instantiate a CBLLiveQuery.

The implementation is adapted from the 1.x sources, but I simplified it to run the query on the main thread, since we don't have a mechanism to run things in the background yet.

The first commit is about creating a lazy NSArray class for the query's `rows` property, so it doesn't have to instantiate every row as Cocoa objects all at once.

Fixes #1759