### PR TITLE
Fixed #1770 : Clear _docReader before retry in CBLBulkDownloader

### DIFF
--- a/Source/CBLBulkDownloader.m
+++ b/Source/CBLBulkDownloader.m
@@ -102,6 +102,7 @@
         // those docs again and confuse the replicator.
         return NO;
     }
+    _docReader = nil;
     return [super retry];
 }
 


### PR DESCRIPTION
The crash happened due to the Assert(!_docReader) in the -startParted: delegate called. Based on the log in #1770, the issue happened after a retry.

From the code review, we don’t reset the _docReader so if the retry is successful and if the -startParted: method is called again, the assertion will fail.

Note that I have also reviewed CBLMultipartReader but I couldn’t find a possible way that it would end up calling -startedPart method twice.