### PR TITLE
2.0: Remove changed notification from sub objects to parents

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -2447,7 +2447,7 @@
 				DEVELOPMENT_TEAM = N2Q372V7W2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = "";
 			};
 			name = Debug;
 		};
@@ -2459,7 +2459,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = N2Q372V7W2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = "";
 			};
 			name = Release;
 		};

--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -84,6 +84,11 @@ extern NSString* const kCBLReplicatorAuthPassword; ///< Auth key for password st
     or the connection will fail. */
 @property (nonatomic, nullable) SecCertificateRef pinnedServerCertificate;
 
+/** HTTP cookies to send to the server.
+    These are assumed to be valid to send with the request; they are not checked to ensure that
+    their hostname/path/etc. are compatible, or that they haven't expired. */
+@property (nonatomic, nullable) NSArray<NSHTTPCookie*>* cookies;
+
 /** Extra options that can affect replication. */
 @property (nonatomic, nullable) NSDictionary<NSString*,id>* options;
 

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -77,6 +77,7 @@ NSString* const kCBLReplicatorAuthPassword         = @"" kC4ReplicatorAuthPasswo
 @synthesize options=_options;
 @synthesize conflictResolver=_conflictResolver;
 @synthesize pinnedServerCertificate=_pinnedServerCertificate;
+@synthesize cookies=_cookies;
 
 
 - (instancetype) init {
@@ -97,6 +98,7 @@ NSString* const kCBLReplicatorAuthPassword         = @"" kC4ReplicatorAuthPasswo
     c.conflictResolver = _conflictResolver;
     c.continuous = _continuous;
     c.pinnedServerCertificate = _pinnedServerCertificate;
+    c.cookies = _cookies;
     return c;
 }
 
@@ -111,9 +113,21 @@ NSString* const kCBLReplicatorAuthPassword         = @"" kC4ReplicatorAuthPasswo
         auth[kCBLReplicatorAuthPassword] = _target.url.password;
         options[kCBLReplicatorAuthOption] = auth;
     }
+    // Add the pinned certificate if any:
     if (_pinnedServerCertificate) {
         NSData* certData = CFBridgingRelease(SecCertificateCopyData(_pinnedServerCertificate));
         options[@kC4ReplicatorOptionPinnedServerCert] = certData;
+    }
+    // Add custom cookies if any:
+    if (_cookies.count > 0) {
+        NSMutableString *cookieStr = [NSMutableString new];
+        for (NSHTTPCookie* cookie in _cookies) {
+            if (cookieStr.length > 0)
+                [cookieStr appendString: @"; "];
+            Assert([cookie isKindOfClass: [NSHTTPCookie class]]);
+            [cookieStr appendFormat: @"%@=%@", cookie.name, cookie.value];
+        }
+        options[@kC4ReplicatorOptionCookies] = cookieStr;
     }
     return options;
 }

--- a/Objective-C/Internal/CBLData.h
+++ b/Objective-C/Internal/CBLData.h
@@ -18,7 +18,7 @@ extern NSObject * const kCBLRemovedValue;
 
 @interface CBLData : NSObject
 
-+ (id) convertValue: (id)value listener: (id<CBLObjectChangeListener>)listener;
++ (id) convertValue: (id)value;
 
 + (BOOL) booleanValueForObject: (id)object;
 

--- a/Objective-C/Internal/CBLData.mm
+++ b/Objective-C/Internal/CBLData.mm
@@ -22,32 +22,26 @@ NSObject *const kCBLRemovedValue = [[NSObject alloc] init];
 @implementation CBLData
 
 
-+ (id) convertValue: (id)value listener: (id<CBLObjectChangeListener>)listener {
++ (id) convertValue: (id)value {
     if ([value isKindOfClass: [CBLDictionary class]]) {
-        [value addChangeListener: listener];
         return value;
     } else if ([value isKindOfClass: [CBLArray class]]) {
-        [value addChangeListener: listener];
         return value;
     } else if ([value isKindOfClass: [CBLReadOnlyDictionary class]]) {
         CBLReadOnlyDictionary* readonly = (CBLReadOnlyDictionary*)value;
         CBLDictionary* dict = [[CBLDictionary alloc] initWithFleeceData: readonly.data];
-        [dict addChangeListener: listener];
         return dict;
     } else if ([value isKindOfClass: [CBLReadOnlyArray class]]) {
         CBLReadOnlyArray* readonly = (CBLReadOnlyArray*)value;
         CBLArray* array = [[CBLArray alloc] initWithFleeceData: readonly.data];
-        [array addChangeListener: listener];
         return array;
     } else if ([value isKindOfClass: [NSDictionary class]]) {
         CBLDictionary* dict = [[CBLDictionary alloc] init];
         [dict setDictionary: value];
-        [dict addChangeListener: listener];
         return dict;
     } else if ([value isKindOfClass: [NSArray class]]) {
         CBLArray* array = [[CBLArray alloc] init];
         [array setArray: value];
-        [array addChangeListener: listener];
         return array;
     } else if ([value isKindOfClass: [NSDate class]]) {
         return [CBLJSON JSONObjectWithDate: value];

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -34,13 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-//////////////////
-
-@protocol CBLObjectChangeListener <NSObject>
-
-- (void) objectDidChange: (id)object;
-
-@end
 
 //////////////////
 
@@ -79,27 +72,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 //////////////////
 
-@interface CBLArray () <CBLObjectChangeListener>
-
-- (void) addChangeListener: (id<CBLObjectChangeListener>)listener;
-
-- (void) removeChangeListener: (id<CBLObjectChangeListener>)listener;
-
-@end
-
 @interface CBLBlob() <CBLFleeceEncodable>
 
 @end
 
 //////////////////
 
-@interface CBLDictionary () <CBLObjectChangeListener>
+@interface CBLDictionary ()
 
 @property (nonatomic) BOOL changed;
-
-- (void) addChangeListener: (id<CBLObjectChangeListener>)listener;
-
-- (void) removeChangeListener: (id<CBLObjectChangeListener>)listener;
 
 @end
 

--- a/Objective-C/Internal/Replicator/CBLHTTPLogic.h
+++ b/Objective-C/Internal/Replicator/CBLHTTPLogic.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) setValue: (nullable NSString*)value forHTTPHeaderField:(NSString*)header;
 - (void) setObject: (nullable NSString*)value forKeyedSubscript: (NSString*)key;
 
+/** Can be used to add multiple instances of a header. */
+- (void) addValue: (nullable NSString*)value forHTTPHeaderField:(NSString*)header;
+
 /** Set this to YES to handle redirects.
     If enabled, redirects are handled by updating the URL and setting shouldRetry. */
 @property (nonatomic) BOOL handleRedirects;

--- a/Objective-C/Internal/Replicator/CBLHTTPLogic.m
+++ b/Objective-C/Internal/Replicator/CBLHTTPLogic.m
@@ -97,6 +97,10 @@
     [_urlRequest setValue: value forHTTPHeaderField: header];
 }
 
+- (void) addValue: (NSString*)value forHTTPHeaderField:(NSString*)header {
+    [_urlRequest addValue: value forHTTPHeaderField: header];
+}
+
 - (void) setObject: (NSString*)value forKeyedSubscript: (NSString*)key {
     [_urlRequest setValue: value forHTTPHeaderField: key];
 }

--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -35,7 +35,7 @@ ENABLE_STRICT_OBJC_MSGSEND         = YES
 GCC_C_LANGUAGE_STANDARD            = gnu99
 GCC_NO_COMMON_BLOCKS               = YES
 
-SWIFT_VERSION = 3.0
+SWIFT_VERSION                      = 3.2
 
 VERSION_INFO_PREFIX                = 
 VERSIONING_SYSTEM                  = apple-generic

--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -82,7 +82,9 @@ GCC_WARN_UNUSED_FUNCTION                                   = YES
 GCC_WARN_UNUSED_VARIABLE                                   = YES
 WARNING_CFLAGS                                             = -Wall -Wformat-security -Wmissing-declarations -Woverriding-method-mismatch -Weffc++
 
+// Sanitizer Behaviors:
 CLANG_ADDRESS_SANITIZER_CONTAINER_OVERFLOW                 = YES    // range-check C++ STL containers
+CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY             = YES
 
 // Static Analyzer - Analysis Policy
 RUN_CLANG_STATIC_ANALYZER                                  = YES // Run during 'Build' as well as 'Analyze'


### PR DESCRIPTION
* No longer notifying parent objects when sub dictionaries or arrays are changed.
* In document, when save, detect whether the document is changed by comparing the encoded binaries.