### PR TITLE
Make Database, Document, Dictionary, Array thread safe

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		9322DCE21F14603400C4ACF7 /* CBLQueryLimit.m in Sources */ = {isa = PBXBuildFile; fileRef = 9322DCDE1F14603400C4ACF7 /* CBLQueryLimit.m */; };
 		9322DCF51F14654E00C4ACF7 /* Limit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9322DCF41F14654E00C4ACF7 /* Limit.swift */; };
 		9322DCF71F14671F00C4ACF7 /* LimitRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9322DCF61F14671F00C4ACF7 /* LimitRouter.swift */; };
+		9322DD9F1F1D28C100C4ACF7 /* ConcurrentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9322DD9E1F1D28C100C4ACF7 /* ConcurrentTest.m */; };
+		9322DDB11F1D28CE00C4ACF7 /* ConcurrentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9322DD9E1F1D28C100C4ACF7 /* ConcurrentTest.m */; };
 		933207AE1E773CFB000D9993 /* CBLJSONCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 933207AD1E773CFB000D9993 /* CBLJSONCoding.h */; };
 		933207AF1E773CFB000D9993 /* CBLJSONCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 933207AD1E773CFB000D9993 /* CBLJSONCoding.h */; };
 		933208121E77415E000D9993 /* CBLQueryDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 933208081E77415E000D9993 /* CBLQueryDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -433,6 +435,8 @@
 		93E17F0F1ED3BA7500671CA1 /* CBLDatabaseChange.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E17F0A1ED3AC8100671CA1 /* CBLDatabaseChange.m */; };
 		93E17F101ED3BA7800671CA1 /* CBLDocumentChange.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E17EF71ED3ABE200671CA1 /* CBLDocumentChange.m */; };
 		93E17F151ED4ED4000671CA1 /* NotificationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E17F141ED4ED4000671CA1 /* NotificationTest.swift */; };
+		93F1026C1F1E6BCE00E32CAA /* CBLThreadSafe.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F1026B1F1E6BCE00E32CAA /* CBLThreadSafe.h */; };
+		93F1026D1F1E6BCE00E32CAA /* CBLThreadSafe.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F1026B1F1E6BCE00E32CAA /* CBLThreadSafe.h */; };
 		93F5D19F1EFAE90200E2DF53 /* CBLBasicAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F5D19D1EFAE90200E2DF53 /* CBLBasicAuthenticator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93F5D1A01EFAE90200E2DF53 /* CBLBasicAuthenticator.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F5D19E1EFAE90200E2DF53 /* CBLBasicAuthenticator.m */; };
 		93F5D1A61EFAEA2400E2DF53 /* CBLSessionAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F5D1A41EFAEA2400E2DF53 /* CBLSessionAuthenticator.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -721,6 +725,7 @@
 		9322DCDE1F14603400C4ACF7 /* CBLQueryLimit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLQueryLimit.m; sourceTree = "<group>"; };
 		9322DCF41F14654E00C4ACF7 /* Limit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Limit.swift; sourceTree = "<group>"; };
 		9322DCF61F14671F00C4ACF7 /* LimitRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitRouter.swift; sourceTree = "<group>"; };
+		9322DD9E1F1D28C100C4ACF7 /* ConcurrentTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConcurrentTest.m; sourceTree = "<group>"; };
 		933207AD1E773CFB000D9993 /* CBLJSONCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLJSONCoding.h; sourceTree = "<group>"; };
 		933208081E77415E000D9993 /* CBLQueryDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryDataSource.h; sourceTree = "<group>"; };
 		933208091E77415E000D9993 /* CBLQueryDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLQueryDataSource.m; sourceTree = "<group>"; };
@@ -908,6 +913,7 @@
 		93E17F091ED3AC8100671CA1 /* CBLDatabaseChange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLDatabaseChange.h; sourceTree = "<group>"; };
 		93E17F0A1ED3AC8100671CA1 /* CBLDatabaseChange.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLDatabaseChange.m; sourceTree = "<group>"; };
 		93E17F141ED4ED4000671CA1 /* NotificationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationTest.swift; sourceTree = "<group>"; };
+		93F1026B1F1E6BCE00E32CAA /* CBLThreadSafe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLThreadSafe.h; sourceTree = "<group>"; };
 		93F5D19D1EFAE90200E2DF53 /* CBLBasicAuthenticator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLBasicAuthenticator.h; sourceTree = "<group>"; };
 		93F5D19E1EFAE90200E2DF53 /* CBLBasicAuthenticator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLBasicAuthenticator.m; sourceTree = "<group>"; };
 		93F5D1A41EFAEA2400E2DF53 /* CBLSessionAuthenticator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLSessionAuthenticator.h; sourceTree = "<group>"; };
@@ -1204,6 +1210,7 @@
 				9381959B1EB9A6FC0032CC51 /* CBLStatus.mm */,
 				934F4CA51E241FB500F90659 /* CBLSymmetricKey.h */,
 				934F4CA61E241FB500F90659 /* CBLSymmetricKey.m */,
+				93F1026B1F1E6BCE00E32CAA /* CBLThreadSafe.h */,
 			);
 			name = Support;
 			sourceTree = "<group>";
@@ -1408,6 +1415,7 @@
 				9378C5951E25B473001BB196 /* CBLTestCase.h */,
 				9378C5961E25B473001BB196 /* CBLTestCase.m */,
 				93DD9BA71EB419BB00E502A2 /* ArrayTest.m */,
+				9322DD9E1F1D28C100C4ACF7 /* ConcurrentTest.m */,
 				27FDBF411F02FE5C0087CC1C /* ConflictTest.h */,
 				93384F731EB14ABA00976B41 /* ConflictTest.m */,
 				9378C5901E25B3F0001BB196 /* DatabaseTest.m */,
@@ -1554,6 +1562,7 @@
 				93B41D7F1F05B60000A7F114 /* CBLQueryJoin.h in Headers */,
 				93B5037A1E64B0E3002C4680 /* CBLPrefix.h in Headers */,
 				9381960B1EC112010032CC51 /* CBLDictionary.h in Headers */,
+				93F1026D1F1E6BCE00E32CAA /* CBLThreadSafe.h in Headers */,
 				9381960D1EC112130032CC51 /* CBLReadOnlyArray.h in Headers */,
 				27DF4BD91ECA442400EE6B8D /* CBLLiveQuery.h in Headers */,
 				93B503691E64B08E002C4680 /* CBLBase64.h in Headers */,
@@ -1647,6 +1656,7 @@
 				934F4CA71E241FB500F90659 /* CBLBase64.h in Headers */,
 				93B41D641F0580E700A7F114 /* CBLQueryJoin.h in Headers */,
 				937F02551EFC62B200060D64 /* CBLLiveQueryChange.h in Headers */,
+				93F1026C1F1E6BCE00E32CAA /* CBLThreadSafe.h in Headers */,
 				93CD02661E9FFEC500AFB3FA /* CBLArray.h in Headers */,
 				934F4C101E1EF19000F90659 /* CollectionUtils.h in Headers */,
 				931C14681EAAD6730094F9B2 /* CBLArrayFragment.h in Headers */,
@@ -2288,6 +2298,7 @@
 				93CD018C1E95546200AFB3FA /* NotificationTest.m in Sources */,
 				938CFA2F1E442B5700291631 /* DatabaseTest.m in Sources */,
 				938CFA2D1E442B4200291631 /* DocumentTest.m in Sources */,
+				9322DDB11F1D28CE00C4ACF7 /* ConcurrentTest.m in Sources */,
 				93CD018D1E95546200AFB3FA /* PredicateQueryTest.m in Sources */,
 				93CD01901E95546200AFB3FA /* DictionaryTest.m in Sources */,
 				93CD018E1E95546200AFB3FA /* QueryTest.m in Sources */,
@@ -2377,6 +2388,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				27EF6A941E298E26004748DF /* PredicateQueryTest.m in Sources */,
+				9322DD9F1F1D28C100C4ACF7 /* ConcurrentTest.m in Sources */,
 				72A87A0F1E32E858008466FF /* NotificationTest.m in Sources */,
 				93384F8C1EB151C100976B41 /* MiscTest.m in Sources */,
 				9378C5971E25B473001BB196 /* CBLTestCase.m in Sources */,

--- a/Objective-C/CBLBlob.h
+++ b/Objective-C/CBLBlob.h
@@ -48,23 +48,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Gets the contents of a CBLBlob as a block of memory.
     Not recommended for very large blobs, as it may be slow and use up lots of RAM. */
-@property (readonly, nonatomic, nullable) NSData* content;
+@property (atomic, readonly, nullable) NSData* content;
 
 /** A stream of the content of a CBLBlob.
     The caller is responsible for opening the stream, and closing it when finished. */
-@property (readonly, nonatomic, nullable) NSInputStream *contentStream;
+@property (atomic, readonly, nullable) NSInputStream *contentStream;
 
 /** The type of content this CBLBlob represents; by convention this is a MIME type. */
-@property (readonly, nonatomic, nullable) NSString* contentType;
+@property (atomic, readonly, nullable) NSString* contentType;
 
 /** The binary length of this CBLBlob. */
-@property (readonly, nonatomic) uint64_t length;
+@property (atomic, readonly) uint64_t length;
 
 /** The cryptographic digest of this CBLBlob's contents, which uniquely identifies it. */
-@property (readonly, nonatomic, nullable) NSString* digest;
+@property (atomic, readonly, nullable) NSString* digest;
 
 /** The metadata associated with this CBLBlob */
-@property (readonly, nonatomic) NSDictionary<NSString*,id>* properties;
+@property (atomic, readonly) NSDictionary<NSString*,id>* properties;
 
 @end
 

--- a/Objective-C/CBLConflictResolver.h
+++ b/Objective-C/CBLConflictResolver.h
@@ -13,11 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLConflict : NSObject
 
-@property (nonatomic, readonly) CBLReadOnlyDocument* mine;
+@property (atomic, readonly) CBLReadOnlyDocument* mine;
 
-@property (nonatomic, readonly) CBLReadOnlyDocument* theirs;
+@property (atomic, readonly) CBLReadOnlyDocument* theirs;
 
-@property (nonatomic, readonly, nullable) CBLReadOnlyDocument* base;
+@property (atomic, readonly, nullable) CBLReadOnlyDocument* base;
 
 @end
 

--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -37,13 +37,13 @@ typedef struct {
 /** Path to the directory to store the database in. If the directory doesn't already exist it will
     be created when the database is opened. The default directory will be in Application Support. 
     You won't usually need to change this. */
-@property (nonatomic, copy, nullable) NSString* directory;
+@property (atomic, copy, nullable) NSString* directory;
 
 
 /** The conflict resolver for this database. The default value is nil, which means the default
     algorithm will be used, where the revision with more history wins.
     An individual document can override this for itself by setting its own property. */
-@property (nonatomic, nullable) id<CBLConflictResolver> conflictResolver;
+@property (atomic, nullable) id<CBLConflictResolver> conflictResolver;
 
 
 /** A key to encrypt the database with. If the database does not exist and is being created, it
@@ -55,7 +55,7 @@ typedef struct {
     * Alternatively, the value may be an NSString containing a passphrase. This will be run through
     64,000 rounds of the PBKDF algorithm to securely convert it into an AES-256 key.
     * A default nil value, of course, means the database is unencrypted. */
-@property (nonatomic, strong, nullable) id encryptionKey;
+@property (atomic, strong, nullable) id encryptionKey;
 
 
 /** File protection/encryption options (iOS only.)
@@ -67,7 +67,7 @@ typedef struct {
     or respond to push notifications. The default value is 
     NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication which is the same default 
     protection level as the iOS application data. */
-@property (nonatomic) NSDataWritingOptions fileProtection;
+@property (atomic) NSDataWritingOptions fileProtection;
 
 - (instancetype) init;
 
@@ -78,17 +78,17 @@ typedef struct {
 @interface CBLDatabase : NSObject
 
 /** The database's name. */
-@property (readonly, nonatomic) NSString* name;
+@property (atomic, readonly) NSString* name;
 
 /** The database's path. If the database is closed or deleted, nil value will be returned. */
-@property (readonly, nonatomic, nullable) NSString* path;
+@property (atomic, readonly, nullable) NSString* path;
 
 /** The number of documents in the database. */
-@property (readonly, nonatomic) uint64_t count;
+@property (atomic, readonly) uint64_t count;
 
 /** The database's configuration. If the configuration is not specify when initializing 
     the database, the default configuration will be returned. */
-@property (readonly, copy, nonatomic) CBLDatabaseConfiguration *config;
+@property (atomic, readonly, copy) CBLDatabaseConfiguration *config;
 
 
 #pragma mark - INITIALIZER
@@ -132,7 +132,7 @@ typedef struct {
 - (BOOL) contains: (NSString*)documentID;
 
 
-#pragma mark - SUBSCRIPTION
+#pragma mark - SUBSCRIPT
 
 
 /** Gets a document fragment with the given document ID. */

--- a/Objective-C/CBLDatabaseChange.h
+++ b/Objective-C/CBLDatabaseChange.h
@@ -12,9 +12,9 @@
 @interface CBLDatabaseChange : NSObject
 
 /** The ID of the document that changed. */
-@property (readonly, nonatomic) NSArray* documentIDs;
+@property (atomic, readonly) NSArray* documentIDs;
 
 /** check whether the changes are from the current database object or not. */
-@property (readonly, nonatomic) BOOL isExternal;
+@property (atomic, readonly) BOOL isExternal;
 
 @end

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -28,9 +28,9 @@
 #import "CBLStatus.h"
 
 
-@implementation CBLDocument {
-    CBLDictionary* _dict;
-}
+@implementation CBLDocument
+
+@synthesize dict=_dict;
 
 
 + (instancetype) document {
@@ -50,7 +50,7 @@
 {
     self = [super initWithDatabase: database documentID: documentID c4Doc: c4Doc fleeceData: data];
     if (self) {
-        _dict = [[CBLDictionary alloc] initWithFleeceData: self.data];
+        self.dict = [[CBLDictionary alloc] initWithFleeceData: self.data];
     }
     return self;
 }
@@ -93,77 +93,77 @@
 
 
 - (NSUInteger) count {
-    return _dict.count;
+    return self.dict.count;
 }
 
 
 - (NSArray*) keys {
-    return _dict.keys;
+    return self.dict.keys;
 }
 
 
 - (nullable id) objectForKey: (NSString*)key {
-    return [_dict objectForKey: key];
+    return [self.dict objectForKey: key];
 }
 
 
 - (BOOL) booleanForKey: (NSString*)key {
-    return [_dict booleanForKey: key];
+    return [self.dict booleanForKey: key];
 }
 
 
 - (NSInteger) integerForKey: (NSString*)key {
-    return [_dict integerForKey: key];
+    return [self.dict integerForKey: key];
 }
 
 
 - (float) floatForKey: (NSString*)key {
-    return [_dict floatForKey: key];
+    return [self.dict floatForKey: key];
 }
 
 
 - (double) doubleForKey: (NSString*)key {
-    return [_dict doubleForKey: key];
+    return [self.dict doubleForKey: key];
 }
 
 
 - (nullable NSString*) stringForKey: (NSString*)key {
-    return [_dict stringForKey: key];
+    return [self.dict stringForKey: key];
 }
 
 
 - (nullable NSNumber*) numberForKey: (NSString*)key {
-    return [_dict numberForKey: key];
+    return [self.dict numberForKey: key];
 }
 
 
 - (nullable NSDate*) dateForKey: (NSString*)key {
-    return [_dict dateForKey: key];
+    return [self.dict dateForKey: key];
 }
 
 
 - (nullable CBLBlob*) blobForKey: (NSString*)key {
-    return [_dict blobForKey: key];
+    return [self.dict blobForKey: key];
 }
 
 
 - (nullable CBLDictionary*) dictionaryForKey: (NSString*)key {
-    return [_dict dictionaryForKey: key];
+    return [self.dict dictionaryForKey: key];
 }
 
 
 - (nullable CBLArray*) arrayForKey: (NSString*)key {
-    return [_dict arrayForKey: key];
+    return [self.dict arrayForKey: key];
 }
 
 
 - (BOOL) containsObjectForKey: (NSString*)key {
-    return [_dict containsObjectForKey: key];
+    return [self.dict containsObjectForKey: key];
 }
 
 
 - (NSDictionary<NSString*,id>*) toDictionary {
-    return [_dict toDictionary];
+    return [self.dict toDictionary];
 }
 
 
@@ -171,24 +171,27 @@
 
 
 - (void) setC4Doc: (CBLC4Document*)c4doc {
-    [super setC4Doc: c4doc];
-    // Update delegate dictionary:
-    _dict = [[CBLDictionary alloc] initWithFleeceData: self.data];
+    CBL_LOCK(self.lock) {
+        [super setC4Doc: c4doc];
+        
+        // Update delegate dictionary:
+        self.dict = [[CBLDictionary alloc] initWithFleeceData: self.data];
+    }
 }
 
 
 - (void) setDictionary: (NSDictionary<NSString *,id> *)dictionary {
-    [_dict setDictionary: dictionary];
+    [self.dict setDictionary: dictionary];
 }
 
 
 - (void) setObject: (nullable id)value forKey: (NSString*)key {
-    [_dict setObject: value forKey: key];
+    [self.dict setObject: value forKey: key];
 }
 
 
 - (void) removeObjectForKey:(NSString *)key {
-    [_dict removeObjectForKey: key];
+    [self.dict removeObjectForKey: key];
 }
 
 
@@ -199,7 +202,7 @@
                                   objects: (id __unsafe_unretained [])buffer
                                     count: (NSUInteger)len
 {
-    return [_dict countByEnumeratingWithState: state objects: buffer count: len];
+    return [self.dict countByEnumeratingWithState: state objects: buffer count: len];
 }
 
 
@@ -207,7 +210,7 @@
 
 
 - (CBLFragment*) objectForKeyedSubscript: (NSString*)key {
-    return [_dict objectForKeyedSubscript: key];
+    return [self.dict objectForKeyedSubscript: key];
 }
 
 
@@ -215,51 +218,65 @@
 
 
 - (NSUInteger) generation {
-    return super.generation + !!self.changed;
+    CBL_LOCK(self.lock) {
+        return super.generation + !!self.changed;
+    }
 }
 
 
 - (BOOL) isEmpty {
-    return _dict.isEmpty;
+    return self.dict.isEmpty;
 }
 
 
 - (BOOL) save: (NSError**)outError {
-    return [self saveWithConflictResolver: self.effectiveConflictResolver
-                                 deletion: NO
-                                    error: outError];
+    // NOTE: This method is called from the CBLDatabase's saveDocument:error: which already owns
+    // the database's lock.
+    CBL_LOCK(self.lock) {
+        return [self saveWithConflictResolver: self.effectiveConflictResolver
+                                     deletion: NO
+                                        error: outError];
+    }
 }
 
 
 - (BOOL) deleteDocument: (NSError**)outError {
-    return [self saveWithConflictResolver: self.effectiveConflictResolver
-                                 deletion: YES
-                                    error: outError];
+    // NOTE: This method is called from the CBLDatabase's deleteDocument:error: which already owns
+    // the database's lock.
+    CBL_LOCK(self.lock) {
+        return [self saveWithConflictResolver: self.effectiveConflictResolver
+                                     deletion: YES
+                                        error: outError];
+    }
 }
 
 
 - (BOOL) purge: (NSError**)outError {
-    if (!self.exists) {
-        return createError(kCBLStatusNotFound, outError);
-    }
-    
-    C4Transaction transaction(self.c4db);
-    if (!transaction.begin())
-        return convertError(transaction.error(),  outError);
-    
-    C4Error err;
-    if (c4doc_purgeRevision(self.c4Doc.rawDoc, C4Slice(), &err) >= 0) {
-        if (c4doc_save(self.c4Doc.rawDoc, 0, &err)) {
-            // Save succeeded; now commit:
-            if (!transaction.commit())
-                return convertError(transaction.error(), outError);
-            
-            // Reset:
-            [self setC4Doc: nil];
-            return YES;
+    // NOTE: This method is called from the CBLDatabase's purgeDocument:error: which already owns
+    // the database's lock.
+    CBL_LOCK(self.lock) {
+        if (!self.exists) {
+            return createError(kCBLStatusNotFound, outError);
         }
+        
+        C4Transaction transaction(self.c4db);
+        if (!transaction.begin())
+            return convertError(transaction.error(),  outError);
+        
+        C4Error err;
+        if (c4doc_purgeRevision(self.c4Doc.rawDoc, C4Slice(), &err) >= 0) {
+            if (c4doc_save(self.c4Doc.rawDoc, 0, &err)) {
+                // Save succeeded; now commit:
+                if (!transaction.commit())
+                    return convertError(transaction.error(), outError);
+                
+                // Reset:
+                [self setC4Doc: nil];
+                return YES;
+            }
+        }
+        return convertError(err, outError);
     }
-    return convertError(err, outError);
 }
 
 
@@ -269,7 +286,7 @@
 // Reflects only direct changes to the document. Changes on sub dictionaries or arrays will
 // not be propagated here.
 - (BOOL) changed {
-    return _dict.changed;
+    return self.dict.changed;
 }
 
 

--- a/Objective-C/CBLDocumentChange.h
+++ b/Objective-C/CBLDocumentChange.h
@@ -12,7 +12,7 @@
 @interface CBLDocumentChange : NSObject
 
 /** The ID of the document that changed. */
-@property (readonly, nonatomic) NSString* documentID;
+@property (atomic, readonly) NSString* documentID;
 
 @end
 

--- a/Objective-C/CBLReadOnlyArray.h
+++ b/Objective-C/CBLReadOnlyArray.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol CBLReadOnlyArray <NSObject, CBLReadOnlyArrayFragment, NSFastEnumeration>
 
 /** Gets a number of the items in the array. */
-@property (readonly) NSUInteger count;
+@property (atomic, readonly) NSUInteger count;
 
 /** Gets value at the given index as an object. The object types are CBLBlob,
     CBLReadOnlyArray, CBLReadOnlyDictionary, NSNumber, or NSString based on the underlying

--- a/Objective-C/CBLReadOnlyDictionary.h
+++ b/Objective-C/CBLReadOnlyDictionary.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol CBLReadOnlyDictionary <NSObject, CBLReadOnlyDictionaryFragment, NSFastEnumeration>
 
 /** The number of entries in the dictionary. */
-@property (readonly, nonatomic) NSUInteger count;
+@property (atomic, readonly) NSUInteger count;
 
 // Note:
 // The allKeys property is not in the spec yet. Beside the functionality,
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 // https://github.com/couchbaselabs/couchbase-lite-apiv2/issues/94
 
 /** An array containing all keys, or an empty array if the dictionary has no entries. */
-@property (readonly, copy, nonatomic) NSArray<NSString*>* keys;
+@property (atomic, readonly, copy) NSArray<NSString*>* keys;
 
 /** Gets a property's value as an object. The object types are CBLBlob, CBLReadOnlyArray,
     CBLReadOnlyDictionary, NSNumber, or NSString based on the underlying data type; or nil if the

--- a/Objective-C/CBLReadOnlyDocument.h
+++ b/Objective-C/CBLReadOnlyDocument.h
@@ -13,17 +13,17 @@
 @interface CBLReadOnlyDocument : CBLReadOnlyDictionary
 
 /** The document's ID. */
-@property (readonly, nonatomic) NSString* id;
+@property (atomic, readonly) NSString* id;
 
 /** Is the document deleted? */
-@property (readonly, nonatomic) BOOL isDeleted;
+@property (atomic, readonly) BOOL isDeleted;
 
 /** Sequence number of the document in the database.
  This indicates how recently the document has been changed: every time any document is updated,
  the database assigns it the next sequential sequence number. Thus, if a document's `sequence`
  property changes that means it's been changed (on-disk); and if one document's `sequence`
  is greater than another's, that means it was changed more recently. */
-@property (readonly, nonatomic) uint64_t sequence;
+@property (atomic, readonly) uint64_t sequence;
 
 - (instancetype) init NS_UNAVAILABLE;
 

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLDocument ()
 
+@property (atomic) CBLDictionary* dict;
+
 - (BOOL) save: (NSError**)error;
 
 - (BOOL) deleteDocument: (NSError**)error;
@@ -42,19 +44,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLReadOnlyDocument ()
 
-@property (nonatomic, nullable) CBLDatabase* database;
+@property (atomic, nullable) CBLDatabase* database;
 
-@property (nonatomic, readonly) C4Database* c4db;   // Throws assertion-failure if null
+@property (atomic, readonly) C4Database* c4db;   // Throws assertion-failure if null
 
-@property (nonatomic, nullable) CBLC4Document* c4Doc;
+@property (atomic, nullable) CBLC4Document* c4Doc;
 
-@property (nonatomic, readonly) BOOL exists;
+@property (atomic, readonly) NSObject* lock;
 
-@property (nonatomic, readonly) NSString* revID;
+@property (atomic, readonly) BOOL exists;
 
-@property (nonatomic, readonly) NSUInteger generation;
+@property (atomic, readonly) NSString* revID;
 
-@property (nonatomic, readonly) id<CBLConflictResolver> effectiveConflictResolver;
+@property (atomic, readonly) NSUInteger generation;
+
+@property (atomic, readonly) id<CBLConflictResolver> effectiveConflictResolver;
 
 - (instancetype) initWithDatabase: (nullable CBLDatabase*)database
                        documentID: (NSString*)documentID
@@ -78,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLDictionary ()
 
-@property (nonatomic) BOOL changed;
+@property (atomic, readonly) BOOL changed;
 
 @end
 
@@ -86,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLReadOnlyArray ()
 
-@property (nonatomic, readonly, nullable) CBLFLArray* data;
+@property (atomic, readonly, nullable) CBLFLArray* data;
 
 - (instancetype) initWithFleeceData: (nullable CBLFLArray*)data;
 
@@ -96,9 +100,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLReadOnlyDictionary ()
 
-@property (nonatomic, nullable) CBLFLDict* data;
+@property (atomic, nullable) CBLFLDict* data;
 
-@property (nonatomic, readonly) BOOL isEmpty;
+@property (atomic, readonly) BOOL isEmpty;
 
 - (instancetype) initWithFleeceData: (nullable CBLFLDict*)data;
 

--- a/Objective-C/Internal/CBLInternal.h
+++ b/Objective-C/Internal/CBLInternal.h
@@ -34,12 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// CBLDatabase:
 
-
 @interface CBLDatabase ()
 
-@property (readonly, nonatomic, nullable) C4Database* c4db;
-@property (readonly, nonatomic) NSMapTable<NSURL*,CBLReplicator*>* replications;
-@property (readonly, nonatomic) NSMutableSet* activeReplications;
+@property (atomic, readonly, nullable) C4Database* c4db;
+@property (atomic, readonly) NSMapTable<NSURL*,CBLReplicator*>* replications;
+@property (atomic, readonly) NSMutableSet* activeReplications;
+@property (atomic, readonly) NSObject* lock;
 
 #ifdef __cplusplus
 @property (readonly, nonatomic) cbl::SharedKeys sharedKeys;
@@ -49,7 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (bool) resolveConflictInDocument: (NSString*)docID
                      usingResolver: (nullable id<CBLConflictResolver>)resolver
                              error: (NSError**)outError;
-
 @end
 
 

--- a/Objective-C/Internal/CBLPrefix.h
+++ b/Objective-C/Internal/CBLPrefix.h
@@ -16,7 +16,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+    
+#ifndef CBL_THREADSAFE
+#define CBL_THREADSAFE 1
+#endif
+    
+#import "CBLThreadSafe.h"
 #import "CollectionUtils.h"
 #import "Test.h"
 

--- a/Objective-C/Internal/CBLThreadSafe.h
+++ b/Objective-C/Internal/CBLThreadSafe.h
@@ -1,0 +1,18 @@
+//
+//  CBLThreadSafe.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 6/20/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#ifndef CBLThreadSafe_h
+#define CBLThreadSafe_h
+
+#if CBL_THREADSAFE
+#define CBL_LOCK(m) @synchronized(m)
+#else
+#define CBL_LOCK(m) 
+#endif
+
+#endif /* CBLThreadSafe_h */

--- a/Objective-C/Tests/ConcurrentTest.m
+++ b/Objective-C/Tests/ConcurrentTest.m
@@ -1,0 +1,426 @@
+//
+//  ConcurrentTest.m
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/17/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLTestCase.h"
+
+#define kDocumentTestBlob @"i'm blob"
+
+@interface ConcurrentTest : CBLTestCase
+
+@end
+
+@implementation ConcurrentTest
+
+
+- (CBLDocument*) createDocumentWithTag: (NSString*)tag {
+    CBLDocument* doc = [[CBLDocument alloc] init];
+    
+    // Tag:
+    [doc setObject: tag forKey: @"tag"];
+    
+    // String:
+    [doc setObject: @"firstName" forKey: @"Daniel"];
+    [doc setObject: @"lastName" forKey: @"Tiger"];
+    
+    // Dictionary:
+    CBLDictionary* address = [[CBLDictionary alloc] init];
+    [address setObject: @"1 Main street" forKey: @"street"];
+    [address setObject: @"Mountain View" forKey: @"city"];
+    [address setObject: @"CA" forKey: @"state"];
+    [doc setObject: address forKey: @"address"];
+    
+    // Array:
+    CBLArray* phones = [[CBLArray alloc] init];
+    [phones addObject: @"650-123-0001"];
+    [phones addObject: @"650-123-0002"];
+    [doc setObject: phones forKey: @"phones"];
+    
+    // Date:
+    [doc setObject: [NSDate date] forKey: @"updated"];
+    
+    return doc;
+}
+
+
+- (NSArray*) createDocs: (NSUInteger)nDocs tag: (NSString*)tag {
+    NSMutableArray* docs = [NSMutableArray arrayWithCapacity: nDocs];
+    for (NSUInteger i = 0; i < nDocs; i++) {
+        CBLDocument* doc = [self createDocumentWithTag: tag];
+        NSError* error;
+        Assert([self.db saveDocument: doc error: &error], @"Error when creating docs: %@", error);
+        [docs addObject: doc];
+    }
+    return docs;
+}
+
+
+- (BOOL) createDocs: (NSUInteger)nDocs tag: (NSString*)tag error: (NSError**)error {
+    for (NSUInteger i = 1; i <= nDocs; i++) {
+        CBLDocument* doc = [self createDocumentWithTag: tag];
+        NSLog(@"[%@] rounds: %lu saving %@", tag, (unsigned long)i, doc.id);
+        if (![self.db saveDocument: doc error: error])
+            return NO;
+    }
+    return YES;
+}
+
+
+- (BOOL) updateDocs: (NSArray*)docs rounds: (NSUInteger)rounds tag: (NSString*)tag
+              error: (NSError**)error
+{
+    NSUInteger n = 0;
+    for (NSUInteger r = 1; r <= rounds; r++) {
+        for (CBLDocument* doc in docs) {
+            [doc setObject: tag forKey: @"tag"];
+            
+            CBLDictionary* address = [doc dictionaryForKey: @"address"];
+            Assert(address);
+            NSString* street = [NSString stringWithFormat: @"%lu street.", (unsigned long)n];
+            [address setObject: street forKey: @"street"];
+            
+            CBLArray* phones = [doc arrayForKey: @"phones"];
+            Assert(phones.count == 2);
+            NSString* phone = [NSString stringWithFormat: @"650-000-%lu", (unsigned long)n];
+            [phones setObject: phone atIndex: 0];
+            
+            [doc setObject: [NSDate date] forKey: @"updated"];
+            
+            NSLog(@"[%@] rounds: %lu updating %@", tag, (unsigned long)r, doc.id);
+            if (![self.db saveDocument: doc error: error]) {
+                return NO;
+            }
+        }
+    }
+    return YES;
+}
+
+
+- (void) readDocIDs: (NSArray<NSString*>*)docIDs rounds: (NSUInteger)rounds {
+    for (NSUInteger r = 1; r <= rounds; r++) {
+        for (NSString* docID in docIDs) {
+            CBLDocument* doc = [_db documentWithID: docID];
+            AssertNotNil(doc);
+            AssertEqualObjects(doc.id, docID);
+        }
+    }
+}
+
+
+- (void) verifyByTagName: (NSString*)name test: (void (^)(uint64_t n, CBLQueryRow *row))block {
+    CBLQueryExpression* TAG = [CBLQueryExpression property: @"tag"];
+    CBLQuerySelectResult* DOCID = [CBLQuerySelectResult expression:
+                                   [CBLQueryExpression meta].id];
+    CBLQuery* q = [CBLQuery select: @[DOCID]
+                              from: [CBLQueryDataSource database: self.db]
+                             where: [TAG equalTo: name]];
+    NSLog(@"%@", [q explain:nil]);
+    
+    NSError* error;
+    NSEnumerator* e = [q run: &error];
+    Assert(e, @"Query failed: %@", error);
+    uint64_t n = 0;
+    for (CBLQueryRow *row in e) {
+        block(++n, row);
+    }
+}
+
+
+- (void) verifyByTagName: (NSString*)name numRows: (NSUInteger)nRows {
+    __block NSUInteger count = 0;
+    [self verifyByTagName: name test: ^(uint64_t n, CBLQueryRow *row) {
+        count++;
+    }];
+    AssertEqual(count, nRows);
+}
+
+
+- (void) testConcurrentCreate {
+    const NSUInteger kNDocs = 1000;
+    
+    NSString* tag1 = @"Create1";
+    XCTestExpectation* exp1 = [self expectationWithDescription: tag1];
+    dispatch_queue_t queue1 = dispatch_queue_create([tag1 UTF8String],  NULL);
+    dispatch_async(queue1, ^{
+        NSError* error;
+        Assert([self createDocs: kNDocs tag: tag1 error: &error], @"Error creating docs: %@", error);
+        [exp1 fulfill];
+    });
+    
+    NSString* tag2 = @"Create2";
+    XCTestExpectation* exp2 = [self expectationWithDescription: tag2];
+    dispatch_queue_t queue2 = dispatch_queue_create([tag2 UTF8String],  NULL);
+    dispatch_async(queue2, ^{
+        NSError* error;
+        Assert([self createDocs: kNDocs tag: tag2 error: &error], @"Error creating docs: %@", error);
+        [exp2 fulfill];
+    });
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+    
+    [self verifyByTagName: tag1 numRows: kNDocs];
+    [self verifyByTagName: tag2 numRows: kNDocs];
+}
+
+
+- (void) testConcurrentUpdate {
+    const NSUInteger kNDocs = 10;
+    const NSUInteger kNRounds = 100;
+    
+    NSArray* docs = [self createDocs: kNDocs tag: @"Create"];
+    AssertEqual(docs.count, kNDocs);
+    
+    NSString* tag1 = @"Update1";
+    XCTestExpectation* exp1 = [self expectationWithDescription: tag1];
+    dispatch_queue_t queue1 = dispatch_queue_create([tag1 UTF8String],  NULL);
+    dispatch_async(queue1, ^{
+        NSError* error;
+        Assert([self updateDocs: docs rounds: kNRounds tag: tag1 error: &error],
+               @"Error updating doc: %@", error);
+        [exp1 fulfill];
+    });
+    
+    NSString* tag2 = @"Update2";
+    XCTestExpectation* exp2 = [self expectationWithDescription: tag2];
+    dispatch_queue_t queue2 = dispatch_queue_create([tag2 UTF8String],  NULL);
+    dispatch_async(queue2, ^{
+        NSError* error;
+        Assert([self updateDocs: docs rounds: kNRounds tag: tag2 error: &error],
+               @"Error updating doc: %@", error);
+        [exp2 fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+    
+    __block NSUInteger count = 0;
+    [self verifyByTagName: tag1 test:^(uint64_t n, CBLQueryRow *row) {
+        count++;
+    }];
+    
+    [self verifyByTagName: tag2 test:^(uint64_t n, CBLQueryRow *row) {
+        count++;
+    }];
+    
+    AssertEqual(count, kNDocs);
+}
+
+
+- (void) testConcurrentRead {
+    const NSUInteger kNDocs = 10;
+    const NSUInteger kNRounds = 1000;
+   
+    NSArray* docs = [self createDocs: kNDocs tag: @"Create"];
+    AssertEqual(docs.count, kNDocs);
+    
+    NSMutableArray* docIDs = [NSMutableArray arrayWithCapacity: kNDocs];
+    [docs enumerateObjectsUsingBlock: ^(CBLDocument* doc, NSUInteger idx, BOOL* stop) {
+        [docIDs addObject: doc.id];
+    }];
+    
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Read1"];
+    dispatch_queue_t queue1 = dispatch_queue_create("Read1",  NULL);
+    dispatch_async(queue1, ^{
+        [self readDocIDs: docIDs rounds:kNRounds];
+        [exp1 fulfill];
+    });
+    
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Read2"];
+    dispatch_queue_t queue2 = dispatch_queue_create("Read2",  NULL);
+    dispatch_async(queue2, ^{
+        [self readDocIDs: docIDs rounds:kNRounds];
+        [exp2 fulfill];
+    });
+
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+}
+
+
+- (void) testConcurrentReadNUpdate {
+    const NSUInteger kNDocs = 10;
+    const NSUInteger kNRounds = 100;
+    
+    NSArray* docs = [self createDocs: kNDocs tag: @"Create"];
+    AssertEqual(docs.count, kNDocs);
+    
+    NSMutableArray* docIDs = [NSMutableArray arrayWithCapacity: kNDocs];
+    [docs enumerateObjectsUsingBlock: ^(CBLDocument* doc, NSUInteger idx, BOOL* stop) {
+        [docIDs addObject: doc.id];
+    }];
+    
+    // Read:
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Read1"];
+    dispatch_queue_t queue1 = dispatch_queue_create("Read1",  NULL);
+    dispatch_async(queue1, ^{
+        [self readDocIDs: docIDs rounds: kNRounds];
+        [exp1 fulfill];
+    });
+    
+    // Update:
+    NSString* tag = @"Update";
+    XCTestExpectation* exp2 = [self expectationWithDescription: tag];
+    dispatch_queue_t queue2 = dispatch_queue_create([tag UTF8String],  NULL);
+    dispatch_async(queue2, ^{
+        NSError* error;
+        Assert([self updateDocs: docs rounds: kNRounds tag: tag error: &error],
+               @"Error updating doc: %@", error);
+        [exp2 fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+    
+    [self verifyByTagName: tag numRows: kNDocs];
+}
+
+
+- (void) testConcurrentDelete {
+    const NSUInteger kNDocs = 1000;
+    
+    NSArray* docs = [self createDocs: kNDocs tag: @"Create"];
+    AssertEqual(docs.count, kNDocs);
+    
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Delete1"];
+    dispatch_queue_t queue1 = dispatch_queue_create("Delete1",  NULL);
+    dispatch_async(queue1, ^{
+        for (CBLDocument* doc in docs) {
+            NSError* error;
+            Assert([self.db deleteDocument: doc error: &error], @"Error when delete: %@", error);
+        }
+        [exp1 fulfill];
+    });
+    
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Delete2"];
+    dispatch_queue_t queue2 = dispatch_queue_create("Delete2",  NULL);
+    dispatch_async(queue2, ^{
+        for (CBLDocument* doc in docs) {
+            NSError* error;
+            Assert([self.db deleteDocument: doc error: &error], @"Error when delete: %@", error);
+        }
+        [exp2 fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+    AssertEqual(self.db.count, 0u);
+}
+
+
+- (void) testConcurrentPurge {
+    const NSUInteger kNDocs = 1000;
+    
+    NSArray* docs = [self createDocs: kNDocs tag: @"Create"];
+    AssertEqual(docs.count, kNDocs);
+    
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Purge1"];
+    dispatch_queue_t queue1 = dispatch_queue_create("Purge1",  NULL);
+    dispatch_async(queue1, ^{
+        for (CBLDocument* doc in docs) {
+            NSError* error;
+            if (![self.db purgeDocument: doc error: &error])
+                AssertEqual(error.code, 404);
+        }
+        [exp1 fulfill];
+    });
+    
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Purge2"];
+    dispatch_queue_t queue2 = dispatch_queue_create("Purge2",  NULL);
+    dispatch_async(queue2, ^{
+        for (CBLDocument* doc in docs) {
+            NSError* error;
+            if (![self.db purgeDocument: doc error: &error])
+                AssertEqual(error.code, 404);
+        }
+        [exp2 fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+    AssertEqual(self.db.count, 0u);
+}
+
+
+- (void) testConcurrentCreateNCloseDB {
+    const NSUInteger kNDocs = 1000;
+    
+    NSString* tag1 = @"Create";
+    XCTestExpectation* exp1 = [self expectationWithDescription: tag1];
+    dispatch_queue_t queue1 = dispatch_queue_create([tag1 UTF8String],  NULL);
+    dispatch_async(queue1, ^{
+        ++gC4ExpectExceptions;
+        XCTAssertThrowsSpecificNamed([self createDocs: kNDocs tag: tag1 error: nil],
+                                     NSException, NSInternalInconsistencyException);
+        --gC4ExpectExceptions;
+        [exp1 fulfill];
+    });
+    
+    // Sleep for 0.1 seconds:
+    [NSThread sleepForTimeInterval: 0.1];
+    
+    NSError* error;
+    Assert([self.db close: &error], @"Error when closing the database: %@", error);
+    
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+}
+
+
+- (void) testConcurrentCreateNDeleteDB {
+    const NSUInteger kNDocs = 1000;
+    
+    NSString* tag1 = @"Create";
+    XCTestExpectation* exp1 = [self expectationWithDescription: tag1];
+    dispatch_queue_t queue1 = dispatch_queue_create([tag1 UTF8String],  NULL);
+    dispatch_async(queue1, ^{
+        ++gC4ExpectExceptions;
+        XCTAssertThrowsSpecificNamed([self createDocs: kNDocs tag: tag1 error: nil],
+                                     NSException, NSInternalInconsistencyException);
+        --gC4ExpectExceptions;
+        [exp1 fulfill];
+    });
+    
+    // Sleep for 0.1 seconds:
+    [NSThread sleepForTimeInterval: 0.1];
+    
+    NSError* error;
+    Assert([self.db deleteDatabase: &error], @"Error when closing the database: %@", error);
+    
+    [self waitForExpectationsWithTimeout: 60.0 handler: NULL];
+}
+
+
+- (void) testBlockDatabaseChange {
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Create"];
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Change"];
+    [self.db addChangeListener:^(CBLDatabaseChange *change) {
+        [self waitForExpectations: @[exp1] timeout: 20.0];
+        [exp2 fulfill];
+    }];
+    
+    dispatch_queue_t queue1 = dispatch_queue_create("Create",  NULL);
+    dispatch_async(queue1, ^{
+        [_db saveDocument: [[CBLDocument alloc] initWithID: @"doc1"]  error: nil];
+        [exp1 fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout: 10.0 handler: NULL];
+}
+
+
+- (void) testBlockDocumentChange {
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Create"];
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Change"];
+    [self.db addChangeListenerForDocumentID: @"doc1" usingBlock:^(CBLDocumentChange *change) {
+        [self waitForExpectations: @[exp1] timeout: 20.0];
+        [exp2 fulfill];
+    }];
+    
+    dispatch_queue_t queue1 = dispatch_queue_create("Create",  NULL);
+    dispatch_async(queue1, ^{
+        [_db saveDocument: [[CBLDocument alloc] initWithID: @"doc1"]  error: nil];
+        [exp1 fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout: 10.0 handler: NULL];
+}
+
+
+@end


### PR DESCRIPTION
* Created CBL_LOCK macro wrapping @syncronized(m) block.
* Applied CBL_LOCK to Database, Document, Dictionary, and Array to make them thread safe.
* NOTE: During the optimization we could consider not making Document and its related object not thread safe if locking process cause too much performance hits.