### PR TITLE
Implement ResultSet/Result and projection with alias names

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -74,10 +74,6 @@
 		27E35A921E8C4F4300E103F9 /* Replicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E35A911E8C4F4300E103F9 /* Replicator.swift */; };
 		27E35A9C1E8C522200E103F9 /* CBLReplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 275229C51E776BC100E630FA /* CBLReplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27E35A9D1E8C539600E103F9 /* CBLReplicator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 275229C61E776BC100E630FA /* CBLReplicator.mm */; };
-		27E673941EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */; };
-		27E673951EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */; };
-		27E673961EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */; };
-		27E673971EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */; };
 		27EF6A941E298E26004748DF /* PredicateQueryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 27EF6A931E298E26004748DF /* PredicateQueryTest.m */; };
 		27EF6A971E2AC61B004748DF /* names_100.json in Resources */ = {isa = PBXBuildFile; fileRef = 27EF6A951E2AC609004748DF /* names_100.json */; };
 		27F961991ED8D9440060F804 /* CBLReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 27F961971ED8D9440060F804 /* CBLReachability.h */; };
@@ -108,6 +104,8 @@
 		9312EBCC1F04490500D5D3B3 /* CBLDocumentChangeListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 9312EBC91F04490500D5D3B3 /* CBLDocumentChangeListener.h */; };
 		9312EBCD1F04490500D5D3B3 /* CBLDocumentChangeListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 9312EBCA1F04490500D5D3B3 /* CBLDocumentChangeListener.m */; };
 		9312EBCE1F04490500D5D3B3 /* CBLDocumentChangeListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 9312EBCA1F04490500D5D3B3 /* CBLDocumentChangeListener.m */; };
+		93140F011F22AA5E006E18EF /* ResultSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93140F001F22AA5E006E18EF /* ResultSet.swift */; };
+		93140F031F22AA68006E18EF /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93140F021F22AA68006E18EF /* Result.swift */; };
 		9317621F1E2D439700563506 /* CBLPredicateQuery+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9317621E1E2D439700563506 /* CBLPredicateQuery+Internal.h */; };
 		931C14531EAABCE70094F9B2 /* CBLReadOnlyFragment.h in Headers */ = {isa = PBXBuildFile; fileRef = 931C14511EAABCE70094F9B2 /* CBLReadOnlyFragment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		931C14541EAABCE70094F9B2 /* CBLReadOnlyFragment.m in Sources */ = {isa = PBXBuildFile; fileRef = 931C14521EAABCE70094F9B2 /* CBLReadOnlyFragment.m */; };
@@ -294,6 +292,24 @@
 		938196331EC15F660032CC51 /* CBLFLDict.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93655B781EB8F85B00AC7E2A /* CBLFLDict.mm */; };
 		938196341EC15F890032CC51 /* CBLStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 9381959A1EB9A6FC0032CC51 /* CBLStatus.h */; };
 		938196351EC15F8B0032CC51 /* CBLStatus.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9381959B1EB9A6FC0032CC51 /* CBLStatus.mm */; };
+		9383A57E1F1EE7860083053D /* CBLQueryResultsArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A57C1F1EE7860083053D /* CBLQueryResultsArray.h */; };
+		9383A57F1F1EE7860083053D /* CBLQueryResultsArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A57C1F1EE7860083053D /* CBLQueryResultsArray.h */; };
+		9383A5801F1EE7860083053D /* CBLQueryResultsArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9383A57D1F1EE7860083053D /* CBLQueryResultsArray.mm */; };
+		9383A5811F1EE7860083053D /* CBLQueryResultsArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9383A57D1F1EE7860083053D /* CBLQueryResultsArray.mm */; };
+		9383A5841F1EE7C00083053D /* CBLQueryResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5821F1EE7C00083053D /* CBLQueryResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9383A5851F1EE7C00083053D /* CBLQueryResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5821F1EE7C00083053D /* CBLQueryResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9383A5861F1EE7C00083053D /* CBLQueryResultSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9383A5831F1EE7C00083053D /* CBLQueryResultSet.mm */; };
+		9383A5871F1EE7C00083053D /* CBLQueryResultSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9383A5831F1EE7C00083053D /* CBLQueryResultSet.mm */; };
+		9383A58A1F1EE8EF0083053D /* CBLQueryResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5881F1EE8EF0083053D /* CBLQueryResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9383A58B1F1EE8EF0083053D /* CBLQueryResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5881F1EE8EF0083053D /* CBLQueryResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9383A58C1F1EE8EF0083053D /* CBLQueryResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9383A5891F1EE8EF0083053D /* CBLQueryResult.mm */; };
+		9383A58D1F1EE8EF0083053D /* CBLQueryResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9383A5891F1EE8EF0083053D /* CBLQueryResult.mm */; };
+		9383A58F1F1EE9550083053D /* CBLQueryResultSet+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A58E1F1EE9550083053D /* CBLQueryResultSet+Internal.h */; };
+		9383A5901F1EE9550083053D /* CBLQueryResultSet+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A58E1F1EE9550083053D /* CBLQueryResultSet+Internal.h */; };
+		9383A5951F1EEFCD0083053D /* CBLQueryResult+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5941F1EEFCD0083053D /* CBLQueryResult+Internal.h */; };
+		9383A5961F1EEFCD0083053D /* CBLQueryResult+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5941F1EEFCD0083053D /* CBLQueryResult+Internal.h */; };
+		9383A5A41F2008A50083053D /* CBLFLDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5A31F2008A50083053D /* CBLFLDataSource.h */; };
+		9383A5A51F2008A50083053D /* CBLFLDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 9383A5A31F2008A50083053D /* CBLFLDataSource.h */; };
 		938CDF161E807EEB002EE790 /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CDF151E807EEB002EE790 /* Query.swift */; };
 		938CDF181E807F08002EE790 /* Select.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CDF171E807F08002EE790 /* Select.swift */; };
 		938CDF1A1E807F14002EE790 /* From.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CDF191E807F14002EE790 /* From.swift */; };
@@ -661,8 +677,6 @@
 		27DF4BD71ECA442400EE6B8D /* CBLLiveQuery.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLLiveQuery.mm; sourceTree = "<group>"; };
 		27E35A811E8B3B3A00E103F9 /* ReplicatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorTest.m; sourceTree = "<group>"; };
 		27E35A911E8C4F4300E103F9 /* Replicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Replicator.swift; sourceTree = "<group>"; };
-		27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryResultsArray.h; sourceTree = "<group>"; };
-		27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLQueryResultsArray.mm; sourceTree = "<group>"; };
 		27EF6A931E298E26004748DF /* PredicateQueryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PredicateQueryTest.m; sourceTree = "<group>"; };
 		27EF6A951E2AC609004748DF /* names_100.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = names_100.json; sourceTree = "<group>"; };
 		27EF6AF11E32D12C004748DF /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -678,6 +692,8 @@
 		930AE46C1EAA6C9100E92E9A /* CBLData.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLData.mm; sourceTree = "<group>"; };
 		9312EBC91F04490500D5D3B3 /* CBLDocumentChangeListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLDocumentChangeListener.h; sourceTree = "<group>"; };
 		9312EBCA1F04490500D5D3B3 /* CBLDocumentChangeListener.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLDocumentChangeListener.m; sourceTree = "<group>"; };
+		93140F001F22AA5E006E18EF /* ResultSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultSet.swift; sourceTree = "<group>"; };
+		93140F021F22AA68006E18EF /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		9317621E1E2D439700563506 /* CBLPredicateQuery+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CBLPredicateQuery+Internal.h"; sourceTree = "<group>"; };
 		931C14511EAABCE70094F9B2 /* CBLReadOnlyFragment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLReadOnlyFragment.h; sourceTree = "<group>"; };
 		931C14521EAABCE70094F9B2 /* CBLReadOnlyFragment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLReadOnlyFragment.m; sourceTree = "<group>"; };
@@ -813,6 +829,15 @@
 		938196231EC122F20032CC51 /* CBLDictionary+Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CBLDictionary+Swift.h"; sourceTree = "<group>"; };
 		938196261EC1230A0032CC51 /* CBLArray+Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLArray+Swift.h"; sourceTree = "<group>"; };
 		938196291EC152410032CC51 /* ReadOnlyDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadOnlyDocument.swift; sourceTree = "<group>"; };
+		9383A57C1F1EE7860083053D /* CBLQueryResultsArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryResultsArray.h; sourceTree = "<group>"; };
+		9383A57D1F1EE7860083053D /* CBLQueryResultsArray.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLQueryResultsArray.mm; sourceTree = "<group>"; };
+		9383A5821F1EE7C00083053D /* CBLQueryResultSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryResultSet.h; sourceTree = "<group>"; };
+		9383A5831F1EE7C00083053D /* CBLQueryResultSet.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLQueryResultSet.mm; sourceTree = "<group>"; };
+		9383A5881F1EE8EF0083053D /* CBLQueryResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryResult.h; sourceTree = "<group>"; };
+		9383A5891F1EE8EF0083053D /* CBLQueryResult.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLQueryResult.mm; sourceTree = "<group>"; };
+		9383A58E1F1EE9550083053D /* CBLQueryResultSet+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CBLQueryResultSet+Internal.h"; sourceTree = "<group>"; };
+		9383A5941F1EEFCD0083053D /* CBLQueryResult+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CBLQueryResult+Internal.h"; sourceTree = "<group>"; };
+		9383A5A31F2008A50083053D /* CBLFLDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLFLDataSource.h; sourceTree = "<group>"; };
 		938CDF151E807EEB002EE790 /* Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
 		938CDF171E807F08002EE790 /* Select.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Select.swift; sourceTree = "<group>"; };
 		938CDF191E807F14002EE790 /* From.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = From.swift; sourceTree = "<group>"; };
@@ -964,6 +989,7 @@
 			children = (
 				9338BED21ED5473300634873 /* Database */,
 				938195F31EC10B780032CC51 /* Document */,
+				93140EEE1F22A99F006E18EF /* Predicate */,
 				938CDF071E807E98002EE790 /* Query */,
 				9338BEE21ED5475200634873 /* Replication */,
 				27BE3B491E4E45CB0012B74A /* Tests */,
@@ -1014,6 +1040,15 @@
 				27EF6AF11E32D12C004748DF /* libsqlite3.tbd */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		93140EEE1F22A99F006E18EF /* Predicate */ = {
+			isa = PBXGroup;
+			children = (
+				27BE3B551E4E93000012B74A /* PredicateQuery.swift */,
+				93A2AFB91E830BF800A08CAE /* QueryRow.swift */,
+			);
+			name = Predicate;
 			sourceTree = "<group>";
 		};
 		9338BED21ED5473300634873 /* Database */ = {
@@ -1072,6 +1107,7 @@
 			isa = PBXGroup;
 			children = (
 				93CD021B1E9D8E3700AFB3FA /* Document */,
+				9383A5691F1EE6BD0083053D /* Predicate */,
 				93B75BF71E79B0A20033B61B /* Query */,
 				2753AFF01EC39CA200C12E98 /* Replicator */,
 				9378C5E91E26F101001BB196 /* Bridge */,
@@ -1191,6 +1227,30 @@
 			name = Document;
 			sourceTree = "<group>";
 		};
+		9383A5691F1EE6BD0083053D /* Predicate */ = {
+			isa = PBXGroup;
+			children = (
+				9317621E1E2D439700563506 /* CBLPredicateQuery+Internal.h */,
+				27A8B5011EC5350A00BB4C07 /* CBLQueryEnumerator.h */,
+				9383A57C1F1EE7860083053D /* CBLQueryResultsArray.h */,
+				9383A57D1F1EE7860083053D /* CBLQueryResultsArray.mm */,
+			);
+			name = Predicate;
+			sourceTree = "<group>";
+		};
+		9383A57B1F1EE6FF0083053D /* Predicate */ = {
+			isa = PBXGroup;
+			children = (
+				937441D01E7B8B0500CB8F11 /* CBLPredicateQuery.h */,
+				937441D11E7B8B0500CB8F11 /* CBLPredicateQuery.mm */,
+				937441D21E7B8B0500CB8F11 /* CBLPredicateQuery+Predicates.mm */,
+				275FF66E1E43E013005F90DD /* CBLQueryRow.h */,
+				275FF66F1E43E013005F90DD /* CBLQueryRow.mm */,
+				27A8B5121EC5351000BB4C07 /* CBLQueryEnumerator.mm */,
+			);
+			name = Predicate;
+			sourceTree = "<group>";
+		};
 		938CDF071E807E98002EE790 /* Query */ = {
 			isa = PBXGroup;
 			children = (
@@ -1216,15 +1276,15 @@
 				938CDF281E807F9F002EE790 /* OrderByRouter.swift */,
 				9322DCAA1F0F0E0200C4ACF7 /* Ordering.swift */,
 				937A69381F104C1C0058277F /* Parameters.swift */,
-				27BE3B551E4E93000012B74A /* PredicateQuery.swift */,
 				937A69441F1076ED0058277F /* PropertyExpression.swift */,
 				938CDF151E807EEB002EE790 /* Query.swift */,
-				93A2AFB91E830BF800A08CAE /* QueryRow.swift */,
 				938CDF171E807F08002EE790 /* Select.swift */,
 				9380D2721F0DBD79007DD84A /* SelectResult.swift */,
 				938CDF1B1E807F23002EE790 /* Where.swift */,
 				938CDF261E807F8F002EE790 /* WhereRouter.swift */,
 				9322DCF61F14671F00C4ACF7 /* LimitRouter.swift */,
+				93140F001F22AA5E006E18EF /* ResultSet.swift */,
+				93140F021F22AA68006E18EF /* Result.swift */,
 			);
 			name = Query;
 			sourceTree = "<group>";
@@ -1293,6 +1353,7 @@
 			children = (
 				933A42E81EA6CB8200AE9084 /* Database */,
 				93CD02271E9D8E9800AFB3FA /* Document */,
+				9383A57B1F1EE6FF0083053D /* Predicate */,
 				93CD02261E9D8E6200AFB3FA /* Query */,
 				938195D91EBCD5F70032CC51 /* Replicator */,
 				934F4C931E241FB500F90659 /* Internal */,
@@ -1309,9 +1370,9 @@
 			children = (
 				937F02681EFC635500060D64 /* CBLLiveQuery+Internal.h */,
 				937F026E1EFC694900060D64 /* CBLLiveQueryChange+Internal.h */,
-				9317621E1E2D439700563506 /* CBLPredicateQuery+Internal.h */,
 				933208291E774171000D9993 /* CBLQuery+Internal.h */,
-				27A8B5011EC5350A00BB4C07 /* CBLQueryEnumerator.h */,
+				9383A58E1F1EE9550083053D /* CBLQueryResultSet+Internal.h */,
+				9383A5941F1EEFCD0083053D /* CBLQueryResult+Internal.h */,
 			);
 			name = Query;
 			sourceTree = "<group>";
@@ -1357,6 +1418,7 @@
 				9312EBCA1F04490500D5D3B3 /* CBLDocumentChangeListener.m */,
 				93655B751EB8F85B00AC7E2A /* CBLFLArray.h */,
 				93655B761EB8F85B00AC7E2A /* CBLFLArray.mm */,
+				9383A5A31F2008A50083053D /* CBLFLDataSource.h */,
 				93655B771EB8F85B00AC7E2A /* CBLFLDict.h */,
 				93655B781EB8F85B00AC7E2A /* CBLFLDict.mm */,
 				938196201EC11CDF0032CC51 /* CBLReadOnlyArray+Swift.h */,
@@ -1372,34 +1434,30 @@
 				27DF4BD71ECA442400EE6B8D /* CBLLiveQuery.mm */,
 				937F02531EFC62B200060D64 /* CBLLiveQueryChange.h */,
 				937F02541EFC62B200060D64 /* CBLLiveQueryChange.m */,
-				937441D01E7B8B0500CB8F11 /* CBLPredicateQuery.h */,
-				937441D11E7B8B0500CB8F11 /* CBLPredicateQuery.mm */,
-				937441D21E7B8B0500CB8F11 /* CBLPredicateQuery+Predicates.mm */,
 				933208101E77415E000D9993 /* CBLQuery.h */,
 				933208111E77415E000D9993 /* CBLQuery.mm */,
 				933208081E77415E000D9993 /* CBLQueryDataSource.h */,
 				933208091E77415E000D9993 /* CBLQueryDataSource.m */,
-				27A8B5121EC5351000BB4C07 /* CBLQueryEnumerator.mm */,
 				9332080A1E77415E000D9993 /* CBLQueryExpression.h */,
 				9332080B1E77415E000D9993 /* CBLQueryExpression.m */,
 				937A69011F0731230058277F /* CBLQueryFunction.h */,
 				937A69021F0731230058277F /* CBLQueryFunction.m */,
 				93B41D621F0580E700A7F114 /* CBLQueryJoin.h */,
 				93B41D631F0580E700A7F114 /* CBLQueryJoin.m */,
+				9322DCDD1F14603400C4ACF7 /* CBLQueryLimit.h */,
+				9322DCDE1F14603400C4ACF7 /* CBLQueryLimit.m */,
+				937A693A1F1065610058277F /* CBLQueryMeta.h */,
+				937A693B1F1065610058277F /* CBLQueryMeta.m */,
 				9332080C1E77415E000D9993 /* CBLQueryOrdering.h */,
 				9332080D1E77415E000D9993 /* CBLQueryOrdering.m */,
 				937A69211F1039370058277F /* CBLQueryParameters.h */,
 				937A69221F1039370058277F /* CBLQueryParameters.m */,
-				27E673921EC7DD62008F50C4 /* CBLQueryResultsArray.h */,
-				27E673931EC7DD62008F50C4 /* CBLQueryResultsArray.mm */,
-				275FF66E1E43E013005F90DD /* CBLQueryRow.h */,
-				275FF66F1E43E013005F90DD /* CBLQueryRow.mm */,
+				9383A5881F1EE8EF0083053D /* CBLQueryResult.h */,
+				9383A5891F1EE8EF0083053D /* CBLQueryResult.mm */,
+				9383A5821F1EE7C00083053D /* CBLQueryResultSet.h */,
+				9383A5831F1EE7C00083053D /* CBLQueryResultSet.mm */,
 				9380D26C1F0D8C1A007DD84A /* CBLQuerySelectResult.h */,
 				9380D26D1F0D8C1A007DD84A /* CBLQuerySelectResult.m */,
-				937A693A1F1065610058277F /* CBLQueryMeta.h */,
-				937A693B1F1065610058277F /* CBLQueryMeta.m */,
-				9322DCDD1F14603400C4ACF7 /* CBLQueryLimit.h */,
-				9322DCDE1F14603400C4ACF7 /* CBLQueryLimit.m */,
 			);
 			name = Query;
 			sourceTree = "<group>";
@@ -1445,9 +1503,11 @@
 				9381961A1EC1137C0032CC51 /* CBLReadOnlyDictionaryFragment.h in Headers */,
 				27F9619A1ED8D9440060F804 /* CBLReachability.h in Headers */,
 				937A693D1F1065610058277F /* CBLQueryMeta.h in Headers */,
+				9383A5961F1EEFCD0083053D /* CBLQueryResult+Internal.h in Headers */,
 				275F929D1E4D377C007FD5A2 /* CouchbaseLite.h in Headers */,
 				937F01E21EFB269300060D64 /* CBLAuthenticator.h in Headers */,
 				93B503751E64B0B4002C4680 /* CBLBlobStream.h in Headers */,
+				9383A58B1F1EE8EF0083053D /* CBLQueryResult.h in Headers */,
 				93B75C1B1E79EF690033B61B /* CBLQueryExpression.h in Headers */,
 				93B41CB11F04706100A7F114 /* CBLReplicatorChange.h in Headers */,
 				2753AFF61EC39CA200C12E98 /* CBLHTTPLogic.h in Headers */,
@@ -1475,13 +1535,14 @@
 				9381961F1EC11A8C0032CC51 /* CBLReadOnlyDictionary+Swift.h in Headers */,
 				937A69241F1039370058277F /* CBLQueryParameters.h in Headers */,
 				9308F40A1E64B23300F53EE4 /* Test.h in Headers */,
-				27E673951EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */,
 				938196171EC1136E0032CC51 /* CBLFragment.h in Headers */,
 				938196251EC122F20032CC51 /* CBLDictionary+Swift.h in Headers */,
 				9380D26F1F0D8C1A007DD84A /* CBLQuerySelectResult.h in Headers */,
 				93B503671E64B085002C4680 /* CBLSharedKeys.hh in Headers */,
 				938196131EC113540032CC51 /* CBLDictionaryFragment.h in Headers */,
+				9383A5A51F2008A50083053D /* CBLFLDataSource.h in Headers */,
 				937F01DD1EFB1A2500060D64 /* CBLSessionAuthenticator.h in Headers */,
+				9383A5901F1EE9550083053D /* CBLQueryResultSet+Internal.h in Headers */,
 				93B503651E64B07F002C4680 /* CBLStringBytes.h in Headers */,
 				27E35A9C1E8C522200E103F9 /* CBLReplicator.h in Headers */,
 				275F92A01E4D377C007FD5A2 /* CBLConflictResolver.h in Headers */,
@@ -1495,8 +1556,10 @@
 				938196321EC15F620032CC51 /* CBLFLDict.h in Headers */,
 				93DB7FED1ED8E1C000C4F845 /* CBLReplicatorConfiguration.h in Headers */,
 				93B503641E64B07C002C4680 /* CBLCoreBridge.h in Headers */,
+				9383A57F1F1EE7860083053D /* CBLQueryResultsArray.h in Headers */,
 				938196191EC113770032CC51 /* CBLReadOnlyArrayFragment.h in Headers */,
 				275F92841E4D30A4007FD5A2 /* CouchbaseLiteSwift.h in Headers */,
+				9383A5851F1EE7C00083053D /* CBLQueryResultSet.h in Headers */,
 				938196311EC15F5F0032CC51 /* CBLFLArray.h in Headers */,
 				938196151EC1135F0032CC51 /* CBLDocumentFragment.h in Headers */,
 				275F92A21E4D377C007FD5A2 /* CBLQueryRow.h in Headers */,
@@ -1533,9 +1596,11 @@
 				933207AE1E773CFB000D9993 /* CBLJSONCoding.h in Headers */,
 				933208141E77415E000D9993 /* CBLQueryExpression.h in Headers */,
 				937A693C1F1065610058277F /* CBLQueryMeta.h in Headers */,
+				9383A5951F1EEFCD0083053D /* CBLQueryResult+Internal.h in Headers */,
 				93A8434D1E3BB95200B4AF2D /* CBLBlob.h in Headers */,
 				2704F1C91E395F3300A3B405 /* CBLConflictResolver.h in Headers */,
 				933208161E77415E000D9993 /* CBLQueryOrdering.h in Headers */,
+				9383A58A1F1EE8EF0083053D /* CBLQueryResult.h in Headers */,
 				9332082A1E774171000D9993 /* CBLQuery+Internal.h in Headers */,
 				93B41CB01F04706100A7F114 /* CBLReplicatorChange.h in Headers */,
 				937F026C1EFC662100060D64 /* CBLChangeListener.h in Headers */,
@@ -1555,7 +1620,6 @@
 				275FF6701E43E013005F90DD /* CBLQueryRow.h in Headers */,
 				934F4CA71E241FB500F90659 /* CBLBase64.h in Headers */,
 				93B41D641F0580E700A7F114 /* CBLQueryJoin.h in Headers */,
-				27E673941EC7DD62008F50C4 /* CBLQueryResultsArray.h in Headers */,
 				937F02551EFC62B200060D64 /* CBLLiveQueryChange.h in Headers */,
 				93CD02661E9FFEC500AFB3FA /* CBLArray.h in Headers */,
 				934F4C101E1EF19000F90659 /* CollectionUtils.h in Headers */,
@@ -1569,7 +1633,9 @@
 				9380D26E1F0D8C1A007DD84A /* CBLQuerySelectResult.h in Headers */,
 				934F4CA91E241FB500F90659 /* CBLCoreBridge.h in Headers */,
 				27A0C85E1E3E7AB600F68646 /* CBLSharedKeys.hh in Headers */,
+				9383A5A41F2008A50083053D /* CBLFLDataSource.h in Headers */,
 				931C14661EAAD6610094F9B2 /* CBLDictionaryFragment.h in Headers */,
+				9383A58F1F1EE9550083053D /* CBLQueryResultSet+Internal.h in Headers */,
 				93F5D1A61EFAEA2400E2DF53 /* CBLSessionAuthenticator.h in Headers */,
 				938196241EC122F20032CC51 /* CBLDictionary+Swift.h in Headers */,
 				93900CFE1EA197F000745D4F /* CBLDocument+Internal.h in Headers */,
@@ -1583,8 +1649,10 @@
 				9381959C1EB9A6FC0032CC51 /* CBLStatus.h in Headers */,
 				276740B71EE7381E0036DE42 /* CBLTrustCheck.h in Headers */,
 				93F5D19F1EFAE90200E2DF53 /* CBLBasicAuthenticator.h in Headers */,
+				9383A57E1F1EE7860083053D /* CBLQueryResultsArray.h in Headers */,
 				934F4CAD1E241FB500F90659 /* CBLJSON.h in Headers */,
 				93E17EF81ED3ABE200671CA1 /* CBLDocumentChange.h in Headers */,
+				9383A5841F1EE7C00083053D /* CBLQueryResultSet.h in Headers */,
 				934F4CAB1E241FB500F90659 /* CBLInternal.h in Headers */,
 				931C145E1EAACAAA0094F9B2 /* CBLReadOnlyDictionaryFragment.h in Headers */,
 				27F961991ED8D9440060F804 /* CBLReachability.h in Headers */,
@@ -2037,6 +2105,7 @@
 				937A69391F104C1C0058277F /* Parameters.swift in Sources */,
 				9308F4071E64B22A00F53EE4 /* MYErrorUtils.m in Sources */,
 				27DF4BDB1ECA442400EE6B8D /* CBLLiveQuery.mm in Sources */,
+				9383A58D1F1EE8EF0083053D /* CBLQueryResult.mm in Sources */,
 				933F45F51EC29EF100863ECB /* Fragment.swift in Sources */,
 				938196161EC113650032CC51 /* CBLDocumentFragment.m in Sources */,
 				93A2AFBA1E830BF800A08CAE /* QueryRow.swift in Sources */,
@@ -2053,6 +2122,7 @@
 				93B41CB31F04706100A7F114 /* CBLReplicatorChange.m in Sources */,
 				276740BA1EE7381E0036DE42 /* CBLTrustCheck.m in Sources */,
 				933F45F61EC2A62000863ECB /* DocumentFragment.swift in Sources */,
+				93140F031F22AA68006E18EF /* Result.swift in Sources */,
 				937F02A21EFC7DC600060D64 /* CBLLiveQueryChange.m in Sources */,
 				93E17F0F1ED3BA7500671CA1 /* CBLDatabaseChange.m in Sources */,
 				937441D61E7B8B0500CB8F11 /* CBLPredicateQuery.mm in Sources */,
@@ -2076,6 +2146,7 @@
 				938CDF161E807EEB002EE790 /* Query.swift in Sources */,
 				9312EBCE1F04490500D5D3B3 /* CBLDocumentChangeListener.m in Sources */,
 				9322DCBE1F0F161A00C4ACF7 /* Joins.swift in Sources */,
+				93140F011F22AA5E006E18EF /* ResultSet.swift in Sources */,
 				937F02A41EFC7DD000060D64 /* CBLChangeListener.m in Sources */,
 				9322DCF51F14654E00C4ACF7 /* Limit.swift in Sources */,
 				93B503611E64B06E002C4680 /* CBLQueryRow.mm in Sources */,
@@ -2087,7 +2158,6 @@
 				938196061EC10E890032CC51 /* DictionaryObject.swift in Sources */,
 				938196021EC10BA40032CC51 /* ReadOnlyDictionaryObject.swift in Sources */,
 				93B5035B1E64B053002C4680 /* CBLDatabase.mm in Sources */,
-				27E673971EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */,
 				938196101EC1121F0032CC51 /* CBLReadOnlyDictionary.mm in Sources */,
 				9308F4051E64B22500F53EE4 /* ExceptionUtils.m in Sources */,
 				93B503701E64B0A3002C4680 /* CBLMisc.m in Sources */,
@@ -2099,6 +2169,7 @@
 				9308F4111E64B2B300F53EE4 /* CBLDocument.mm in Sources */,
 				9308F4091E64B23000F53EE4 /* MYLogging.m in Sources */,
 				938196041EC10DBA0032CC51 /* ReadOnlyArrayObject.swift in Sources */,
+				9383A5811F1EE7860083053D /* CBLQueryResultsArray.mm in Sources */,
 				938CDF221E807F51002EE790 /* Expression.swift in Sources */,
 				2753AFF81EC39CA200C12E98 /* CBLHTTPLogic.m in Sources */,
 				938CDF1C1E807F23002EE790 /* Where.swift in Sources */,
@@ -2114,6 +2185,7 @@
 				938CDF181E807F08002EE790 /* Select.swift in Sources */,
 				93AF51C51E80A70100E200F0 /* CBLQueryExpression.m in Sources */,
 				938CDF1E1E807F35002EE790 /* OrderBy.swift in Sources */,
+				9383A5871F1EE7C00083053D /* CBLQueryResultSet.mm in Sources */,
 				93B503741E64B0B0002C4680 /* CBLSymmetricKey.m in Sources */,
 				938196351EC15F8B0032CC51 /* CBLStatus.mm in Sources */,
 				937A69261F1039370058277F /* CBLQueryParameters.m in Sources */,
@@ -2212,12 +2284,14 @@
 				72A879F01E2DD51C008466FF /* CBLBlob.mm in Sources */,
 				934F4CAE1E241FB500F90659 /* CBLJSON.m in Sources */,
 				934F4CB31E241FB500F90659 /* CBLParseDate.c in Sources */,
+				9383A5861F1EE7C00083053D /* CBLQueryResultSet.mm in Sources */,
 				93E17F0C1ED3AC8100671CA1 /* CBLDatabaseChange.m in Sources */,
 				933208171E77415E000D9993 /* CBLQueryOrdering.m in Sources */,
 				27A0C85F1E3E7AB600F68646 /* CBLSharedKeys.mm in Sources */,
 				931C14541EAABCE70094F9B2 /* CBLReadOnlyFragment.m in Sources */,
 				9380C6F01E15B8C20011E8CB /* CBLDocument.mm in Sources */,
 				27F9619B1ED8D9440060F804 /* CBLReachability.m in Sources */,
+				9383A5801F1EE7860083053D /* CBLQueryResultsArray.mm in Sources */,
 				933208131E77415E000D9993 /* CBLQueryDataSource.m in Sources */,
 				93655B7C1EB8F85B00AC7E2A /* CBLFLDict.mm in Sources */,
 				2753AFF71EC39CA200C12E98 /* CBLHTTPLogic.m in Sources */,
@@ -2241,7 +2315,6 @@
 				93CD02731EA0004500AFB3FA /* CBLReadOnlyDocument.mm in Sources */,
 				934F4CB91E241FB500F90659 /* CBLSymmetricKey.m in Sources */,
 				93CD02671E9FFEC500AFB3FA /* CBLArray.m in Sources */,
-				27E673961EC7DD62008F50C4 /* CBLQueryResultsArray.mm in Sources */,
 				937A69251F1039370058277F /* CBLQueryParameters.m in Sources */,
 				934F4CAC1E241FB500F90659 /* CBLInternal.mm in Sources */,
 				937F02561EFC62B200060D64 /* CBLLiveQueryChange.m in Sources */,
@@ -2263,6 +2336,7 @@
 				93CD02E71EA0382D00AFB3FA /* CBLDictionary.mm in Sources */,
 				938195991EB97E7A0032CC51 /* CBLDocumentFragment.m in Sources */,
 				93CD02DF1EA037B200AFB3FA /* CBLReadOnlyDictionary.mm in Sources */,
+				9383A58C1F1EE8EF0083053D /* CBLQueryResult.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Objective-C/CBLLiveQuery.h
+++ b/Objective-C/CBLLiveQuery.h
@@ -26,8 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) stop;
 
 /** Returns a string describing the implementation of the compiled query.
- This is intended to be read by a developer for purposes of optimizing the query, especially
- to add database indexes. It's not machine-readable and its format may change. */
+    This is intended to be read by a developer for purposes of optimizing the query, especially
+    to add database indexes. It's not machine-readable and its format may change. */
 - (nullable NSString*) explain: (NSError**)outError;
 
 /** Adds a query change listener block.

--- a/Objective-C/CBLLiveQueryChange.h
+++ b/Objective-C/CBLLiveQueryChange.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 @class CBLLiveQuery;
-@class CBLQueryRow;
+@class CBLQueryResultSet;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CBLLiveQuery* query;
 
 /** The new query result. */
-@property (nonatomic, readonly, nullable) NSEnumerator<CBLQueryRow*>* rows;
+@property (nonatomic, readonly, nullable) CBLQueryResultSet* rows;
 
 /** The error occurred when running the query. */
 @property (nonatomic, readonly, nullable) NSError* error;

--- a/Objective-C/CBLLiveQueryChange.h
+++ b/Objective-C/CBLLiveQueryChange.h
@@ -13,7 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** CBLLiveQueryChange contains the information about the query result changes reported
- by a live query object. */
+    by a live query object. */
 @interface CBLLiveQueryChange : NSObject
 
 /** The source live query object. */

--- a/Objective-C/CBLLiveQueryChange.m
+++ b/Objective-C/CBLLiveQueryChange.m
@@ -7,13 +7,15 @@
 //
 
 #import "CBLLiveQueryChange+Internal.h"
+#import "CBLLiveQuery.h"
+#import "CBLQueryResultSet.h"
 
 @implementation CBLLiveQueryChange
 
 @synthesize query=_query, rows=_rows, error=_error;
 
 - (instancetype) initWithQuery: (CBLLiveQuery*)query
-                          rows: (NSEnumerator<CBLQueryRow*>*)rows
+                          rows: (CBLQueryResultSet*)rows
                          error: (NSError*)error {
     self = [super init];
     if (self) {

--- a/Objective-C/CBLQuery.h
+++ b/Objective-C/CBLQuery.h
@@ -10,6 +10,7 @@
 @class CBLDatabase, CBLQueryRow, CBLDocument;
 @class CBLQuerySelectResult, CBLQueryDataSource, CBLQueryJoin, CBLQueryOrdering, CBLQueryGroupBy;
 @class CBLQueryLimit, CBLQueryExpression, CBLQueryParameters;
+@class CBLQueryResultSet;
 @class CBLLiveQuery;
 
 
@@ -376,7 +377,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param outError If an error occurs, it will be stored here if this parameter is non-NULL.
     @return An enumerator of the query result.
  */
-- (nullable NSEnumerator<CBLQueryRow*>*) run: (NSError**)outError;
+- (nullable CBLQueryResultSet*) run: (NSError**)outError;
 
 /** Returns a live query based on the current query.
     @return A live query object. */

--- a/Objective-C/CBLQueryResult.h
+++ b/Objective-C/CBLQueryResult.h
@@ -12,6 +12,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** CBLQueryResult represents a single row in the query result. The projecting result value 
+    can be accessed either by using a zero based index or by a key corresponding to the
+    CBLQuerySelectResult objects given when constructing the CBLQuery object. 
+    
+    A key used for accessing the projecting result value could be one of the followings:
+    * The alias name of the CBLQuerySelectResult object.
+    * The last component of the keypath or property name of the property expression used 
+      when creating the CBLQuerySelectResult object.
+    * The provision key in $1, $2, ...$N format for the CBLQuerySelectResult that doesn't have
+      an alias name specified or is not a property expression such as an aggregate function 
+      expression (e.g. count(), avg(), min(), max(), sum() and etc). The number suffix 
+      after the '$' character is a running number starting from one. */
 @interface CBLQueryResult : NSObject <CBLReadOnlyArray, CBLReadOnlyDictionary>
 
 /** Not Available. */

--- a/Objective-C/CBLQueryResult.h
+++ b/Objective-C/CBLQueryResult.h
@@ -1,0 +1,22 @@
+//
+//  CBLQueryResult.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/18/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CBLReadOnlyArray.h"
+#import "CBLReadOnlyDictionary.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CBLQueryResult : NSObject <CBLReadOnlyArray, CBLReadOnlyDictionary>
+
+/** Not Available. */
+- (instancetype) init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/CBLQueryResult.mm
+++ b/Objective-C/CBLQueryResult.mm
@@ -1,0 +1,274 @@
+//
+//  CBLQueryResult.mm
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/18/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLQueryResult.h"
+#import "CBLData.h"
+#import "CBLDocument+Internal.h"
+#import "CBLInternal.h"
+#import "CBLJSON.h"
+#import "CBLQueryResultSet+Internal.h"
+#import "CBLSharedKeys.hh"
+
+
+@implementation CBLQueryResult {
+    CBLQueryResultSet* _rs;
+    FLArrayIterator _columns;
+}
+
+
+- (instancetype) initWithResultSet: (CBLQueryResultSet*)rs
+                      c4Enumerator: (C4QueryEnumerator*)e {
+    self = [super init];
+    if (self) {
+        _rs = rs;
+        _columns = e->columns;
+    }
+    return self;
+}
+
+
+#pragma mark - CBLReadOnlyArray
+
+
+- (NSUInteger) count {
+    return c4query_columnCount(_rs.c4Query);
+}
+
+
+- (nullable id) objectAtIndex: (NSUInteger)index {
+    return [self fleeceValueToObjectAtIndex: index];
+}
+
+
+- (BOOL) booleanAtIndex: (NSUInteger)index {
+    return FLValue_AsBool([self fleeceValueAtIndex: index]);
+}
+
+
+- (NSInteger) integerAtIndex: (NSUInteger)index {
+    return (NSInteger)FLValue_AsInt([self fleeceValueAtIndex: index]);
+}
+
+
+- (float) floatAtIndex: (NSUInteger)index {
+    return FLValue_AsFloat([self fleeceValueAtIndex: index]);
+}
+
+
+- (double) doubleAtIndex: (NSUInteger)index {
+    return FLValue_AsDouble([self fleeceValueAtIndex: index]);
+}
+
+
+- (nullable NSString*) stringAtIndex: (NSUInteger)index {
+    return $castIf(NSString, [self fleeceValueToObjectAtIndex: index]);
+}
+
+
+- (nullable NSNumber*) numberAtIndex: (NSUInteger)index {
+    return $castIf(NSNumber, [self fleeceValueToObjectAtIndex: index]);
+}
+
+
+- (nullable NSDate*) dateAtIndex: (NSUInteger)index {
+    return [CBLJSON dateWithJSONObject: [self fleeceValueToObjectAtIndex: index]];
+}
+
+
+- (nullable CBLBlob*) blobAtIndex: (NSUInteger)index {
+    return $castIf(CBLBlob, [self fleeceValueToObjectAtIndex: index]);
+}
+
+
+- (nullable CBLReadOnlyDictionary*) dictionaryAtIndex: (NSUInteger)index {
+    return $castIf(CBLReadOnlyDictionary, [self fleeceValueToObjectAtIndex: index]);
+}
+
+
+- (nullable CBLReadOnlyArray*) arrayAtIndex: (NSUInteger)index {
+    return $castIf(CBLReadOnlyArray, [self fleeceValueToObjectAtIndex: index]);
+}
+
+
+- (NSArray*) toArray {
+    NSMutableArray* array = [NSMutableArray array];
+    for (NSUInteger i = 0; i < self.count; i++) {
+        cbl::SharedKeys sk = [self database].sharedKeys;
+        [array addObject: FLValue_GetNSObject([self fleeceValueAtIndex: i], &sk)];
+    }
+    return array;
+}
+
+
+- (CBLReadOnlyFragment*) objectAtIndexedSubscript: (NSUInteger)index {
+    id value = index < self.count ? [self fleeceValueToObjectAtIndex: index] : nil;
+    return [[CBLReadOnlyFragment alloc] initWithValue: value];
+}
+
+
+#pragma mark - CBLReadOnlyDictionary
+
+
+- (NSArray*) keys {
+    // TODO: Support SELECT *
+    return [_rs.columnNames allKeys];
+}
+
+
+- (id) objectForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self objectAtIndex: index];
+    return nil;
+}
+
+
+- (BOOL) booleanForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self booleanAtIndex: index];
+    return NO;
+}
+
+
+- (NSInteger) integerForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self integerAtIndex: index];
+    return 0;
+}
+
+
+- (float) floatForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self floatAtIndex: index];
+    return 0.0f;
+}
+
+
+- (double) doubleForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self doubleAtIndex: index];
+    return 0.0;
+}
+
+
+- (nullable NSString*) stringForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self stringAtIndex: index];
+    return nil;
+}
+
+
+- (nullable NSNumber*) numberForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self numberAtIndex: index];
+    return nil;
+}
+
+
+- (nullable NSDate*) dateForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self dateAtIndex: index];
+    return nil;
+}
+
+
+- (nullable CBLBlob*) blobForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self blobAtIndex: index];
+    return nil;
+}
+
+
+- (nullable CBLReadOnlyDictionary*) dictionaryForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self dictionaryAtIndex: index];
+    return nil;
+}
+
+
+- (nullable CBLReadOnlyArray*) arrayForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    if (index >= 0)
+        return [self arrayAtIndex: index];
+    return nil;
+}
+
+
+- (BOOL) containsObjectForKey: (NSString*)key {
+    NSInteger index = [self indexForColumnName: key];
+    return index > 0;
+}
+
+
+- (NSDictionary<NSString*,id>*) toDictionary {
+    NSArray* values = [self toArray];
+    NSMutableDictionary* dict = [NSMutableDictionary dictionary];
+    for (NSString* name in _rs.columnNames) {
+        NSInteger index = [self indexForColumnName: name];
+        dict[name] = values[index];
+    }
+    return dict;
+}
+
+
+- (CBLReadOnlyFragment*) objectForKeyedSubscript: (NSString*)key {
+    return [self objectAtIndexedSubscript: [self indexForColumnName: key]];
+}
+
+
+#pragma mark - NSFastEnumeration
+
+
+- (NSUInteger)countByEnumeratingWithState: (NSFastEnumerationState *)state
+                                  objects: (id __unsafe_unretained [])buffer
+                                    count: (NSUInteger)len
+{
+    return [_rs.columnNames countByEnumeratingWithState: state objects: buffer count: len];
+}
+
+
+#pragma mark - Private
+
+
+- (CBLDatabase*) database {
+    CBLDatabase* database = _rs.database;
+    Assert(database);
+    return database;
+}
+
+
+- (NSInteger) indexForColumnName: (NSString*)name {
+    NSNumber* index = [_rs.columnNames objectForKey: name];
+    return index ? index.integerValue : -1;
+}
+
+
+- (id) fleeceValueToObjectAtIndex: (NSUInteger)index {
+    FLValue value = [self fleeceValueAtIndex: index];
+    if (value != nullptr)
+        return [CBLData fleeceValueToObject: value datasource: _rs database: [self database]];
+    else
+        return nil;
+}
+
+
+- (FLValue) fleeceValueAtIndex: (NSUInteger)index {
+    return FLArrayIterator_GetValueAt(&_columns, (uint32_t)index);
+}
+
+
+@end

--- a/Objective-C/CBLQueryResultSet.h
+++ b/Objective-C/CBLQueryResultSet.h
@@ -1,0 +1,14 @@
+//
+//  CBLQueryResultSet.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/18/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+@class CBLQueryResult;
+
+@interface CBLQueryResultSet : NSEnumerator<CBLQueryResult*>
+
+@end

--- a/Objective-C/CBLQueryResultSet.h
+++ b/Objective-C/CBLQueryResultSet.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 @class CBLQueryResult;
 
+/** CBLQueryResultSet is a result returned from a query. The CBLQueryResultSet is an NSEnumerator of 
+    the CBLQueryResult objects, each of which represent a single row in the query result. */
 @interface CBLQueryResultSet : NSEnumerator<CBLQueryResult*>
 
 @end

--- a/Objective-C/CBLQueryResultSet.mm
+++ b/Objective-C/CBLQueryResultSet.mm
@@ -1,0 +1,129 @@
+//
+//  CBLQueryResultSet.mm
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/18/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLQueryResultSet.h"
+#import "CBLCoreBridge.h"
+#import "CBLInternal.h"
+#import "CBLQuery+Internal.h"
+#import "CBLQueryResult.h"
+#import "CBLQueryResultSet+Internal.h"
+#import "CBLQueryResult+Internal.h"
+#import "CBLQueryResultsArray.h"
+#import "CBLStatus.h"
+#import "c4Query.h"
+#import "Fleece.h"
+
+@implementation CBLQueryResultSet {
+    __weak CBLQuery* _query;
+    C4QueryEnumerator* _c4enum;
+    C4Error _error;
+    bool _randomAccess;
+}
+
+@synthesize c4Query=_c4Query, columnNames=_columnNames;
+
+
+- (instancetype) initWithQuery: (CBLQuery*)query
+                    enumerator: (C4QueryEnumerator*)e
+                   columnNames: (NSDictionary*)columnNames
+{
+    self = [super init];
+    if (self) {
+        if (!e)
+            return nil;
+        _query = query;
+        _c4enum = e;
+        _columnNames = columnNames;
+        CBLLog(Query, @"Beginning query enumeration (%p)", _c4enum);
+    }
+    return self;
+}
+
+
+- (void) dealloc {
+    c4queryenum_free(_c4enum);
+}
+
+
+- (CBLDatabase*) database {
+    return _query.database;
+}
+
+
+- (id) nextObject {
+    if (_randomAccess)
+        return nil;
+    
+    id row = nil;
+    if (c4queryenum_next(_c4enum, &_error)) {
+        row = self.currentObject;
+    } else if (_error.code)
+        CBLWarnError(Query, @"%@[%p] error: %d/%d", [self class], self, _error.domain, _error.code);
+    else
+        CBLLog(Query, @"End of query enumeration (%p)", _c4enum);
+    return row;
+}
+
+
+- (id) currentObject {
+    return [[CBLQueryResult alloc] initWithResultSet: self c4Enumerator: _c4enum];
+}
+
+
+// Called by CBLQueryResultsArray
+- (id) objectAtIndex: (NSUInteger)index {
+    if (!c4queryenum_seek(_c4enum, index, &_error)) {
+        NSString* message = sliceResult2string(c4error_getMessage(_error));
+        [NSException raise: NSInternalInconsistencyException
+                    format: @"CBLQueryEnumerator couldn't get a value: %@", message];
+    }
+    return self.currentObject;
+}
+
+
+- (NSArray*) allObjects {
+    NSInteger count = (NSInteger)c4queryenum_getRowCount(_c4enum, nullptr);
+    if (count >= 0) {
+        _randomAccess = true;
+        return [[CBLQueryResultsArray alloc] initWithEnumerator: self count: count];
+    } else
+        return super.allObjects;
+}
+
+
+// TODO: Should we make this public? How else can the app find the error?
+- (NSError*) error {
+    if (_error.code == 0)
+        return nil;
+    NSError* error;
+    convertError(_error, &error);
+    return error;
+}
+
+
+- (CBLQueryResultSet*) refresh: (NSError**)outError {
+    if (outError)
+        *outError = nil;
+    
+    auto query = _query;
+    if (!query)
+        return nil;
+    
+    C4Error c4error;
+    C4QueryEnumerator *newEnum = c4queryenum_refresh(_c4enum, &c4error);
+    if (!newEnum) {
+        if (c4error.code)
+            convertError(c4error, outError);
+        return nil;
+    }
+    return [[CBLQueryResultSet alloc] initWithQuery: query enumerator: newEnum
+                                        columnNames: _columnNames];
+}
+
+
+@end

--- a/Objective-C/CBLQuerySelectResult.h
+++ b/Objective-C/CBLQuerySelectResult.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
     @return A CBLQuerySelectResult for the given expression. */
 + (instancetype) expression: (CBLQueryExpression*)expression;
 
++ (instancetype) expression: (CBLQueryExpression*)expression as: (nullable NSString*)alias;
+
 /** Not available. */
 - (instancetype) init NS_UNAVAILABLE;
 

--- a/Objective-C/CBLQuerySelectResult.h
+++ b/Objective-C/CBLQuerySelectResult.h
@@ -16,9 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Creates a CBLQuerySelectResult for the given expression.
     @param expression   The expression.
-    @return A CBLQuerySelectResult for the given expression. */
+    @return A CBLQuerySelectResult. */
 + (instancetype) expression: (CBLQueryExpression*)expression;
 
+/** Creates a CBLQuerySelectResult for the given expression and the alias name.
+    @param expression   The expression.
+    @param alias   The alias name.
+    @return A CBLQuerySelectResult. */
 + (instancetype) expression: (CBLQueryExpression*)expression as: (nullable NSString*)alias;
 
 /** Not available. */

--- a/Objective-C/CBLQuerySelectResult.m
+++ b/Objective-C/CBLQuerySelectResult.m
@@ -11,23 +11,43 @@
 
 @implementation CBLQuerySelectResult {
     CBLQueryExpression* _expression;
+    NSString* _alias;
 }
 
 
 + (instancetype) expression: (CBLQueryExpression*)expression {
-    return [[self alloc] initWithExpression: expression];
+    return [self expression: expression as: nil];
+}
+
+
++ (instancetype) expression: (CBLQueryExpression*)expression as: (nullable NSString*)alias {
+    return [[self alloc] initWithExpression: expression as: alias];
 }
 
 
 #pragma mark - Internal
 
 
-- (instancetype) initWithExpression: (CBLQueryExpression*)expression {
+- (instancetype) initWithExpression: (CBLQueryExpression*)expression as: (nullable NSString*)alias {
     self = [super init];
     if (self) {
         _expression = expression;
+        _alias = alias;
     }
     return self;
+}
+
+- (nullable NSString*) columnName {
+    if (_alias)
+        return _alias;
+    
+    CBLKeyPathExpression* keyPathExpr = $castIf(CBLKeyPathExpression, _expression);
+    if (keyPathExpr) {
+        NSArray* paths = [keyPathExpr.keyPath componentsSeparatedByString: @"."];
+        return paths.lastObject;
+    }
+    
+    return nil;
 }
 
 

--- a/Objective-C/CBLReadOnlyArray.mm
+++ b/Objective-C/CBLReadOnlyArray.mm
@@ -160,7 +160,8 @@
 - (id) fleeceValueToObjectAtIndex: (NSUInteger)index {
     FLValue value = FLArray_Get(_array, (uint)index);
     if (value != nullptr)
-        return [CBLData fleeceValueToObject: value c4doc: _data.c4doc database: _data.database];
+        return [CBLData fleeceValueToObject: value
+                                 datasource: _data.datasource database: _data.database];
     else
         return nil;
 }

--- a/Objective-C/CBLReadOnlyDictionary.mm
+++ b/Objective-C/CBLReadOnlyDictionary.mm
@@ -169,7 +169,8 @@
 - (id) fleeceValueToObjectForKey: (NSString*)key {
     FLValue value = [self fleeceValueForKey: key];
     if (value != nullptr)
-        return [CBLData fleeceValueToObject: value c4doc: _data.c4doc database: _data.database];
+        return [CBLData fleeceValueToObject: value datasource: _data.datasource
+                                   database: _data.database];
     else
         return nil;
 }

--- a/Objective-C/CBLReadOnlyDocument.mm
+++ b/Objective-C/CBLReadOnlyDocument.mm
@@ -93,7 +93,7 @@
         C4Slice body = c4doc.selectedRev.body;
         if (body.size > 0)
             root = FLValue_AsDict(FLValue_FromTrustedData({body.buf, body.size}));
-        self.data = [[CBLFLDict alloc] initWithDict: root c4doc: c4doc database: _database];
+        self.data = [[CBLFLDict alloc] initWithDict: root datasource: c4doc database: _database];
     } else {
         self.data = nil;
     }

--- a/Objective-C/CouchbaseLite.exp
+++ b/Objective-C/CouchbaseLite.exp
@@ -32,6 +32,8 @@
 .objc_class_name_CBLQueryOrdering
 .objc_class_name_CBLQueryParameters
 .objc_class_name_CBLQuerySelectResult
+.objc_class_name_CBLQueryResult
+.objc_class_name_CBLQueryResultSet
 .objc_class_name_CBLQueryRow
 .objc_class_name_CBLReadOnlyArray
 .objc_class_name_CBLReadOnlyDocument

--- a/Objective-C/CouchbaseLite.h
+++ b/Objective-C/CouchbaseLite.h
@@ -39,6 +39,8 @@ FOUNDATION_EXPORT const unsigned char CouchbaseLiteVersionString[];
 #import "CBLQueryOrdering.h"
 #import "CBLQueryParameters.h"
 #import "CBLQuerySelectResult.h"
+#import "CBLQueryResult.h"
+#import "CBLQueryResultSet.h"
 #import "CBLQueryRow.h"
 #import "CBLReadOnlyArray.h"
 #import "CBLReadOnlyDictionary.h"

--- a/Objective-C/Internal/CBLC4Document.h
+++ b/Objective-C/Internal/CBLC4Document.h
@@ -7,11 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "CBLFLDataSource.h"
 #import "c4.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CBLC4Document : NSObject
+@interface CBLC4Document : NSObject <CBLFLDataSource>
 
 @property (readonly, nonatomic) C4Document* rawDoc;
 

--- a/Objective-C/Internal/CBLData.h
+++ b/Objective-C/Internal/CBLData.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "CBLFLDataSource.h"
 #import "Fleece.h"
 @class CBLDatabase;
 @class CBLC4Document;
@@ -23,7 +24,7 @@ extern NSObject * const kCBLRemovedValue;
 + (BOOL) booleanValueForObject: (id)object;
 
 + (nullable id) fleeceValueToObject: (FLValue)value
-                              c4doc: (CBLC4Document*)c4doc
+                         datasource: (id<CBLFLDataSource>)datasource
                            database: (CBLDatabase*)database;
 
 

--- a/Objective-C/Internal/CBLData.mm
+++ b/Objective-C/Internal/CBLData.mm
@@ -67,14 +67,15 @@ NSObject *const kCBLRemovedValue = [[NSObject alloc] init];
 
 
 + (id) fleeceValueToObject: (FLValue)value
-                     c4doc: (CBLC4Document*)c4doc
+                datasource: (id <CBLFLDataSource>)datasource
                   database: (CBLDatabase*)database
 {
     switch (FLValue_GetType(value)) {
         case kFLArray: {
             FLArray array = FLValue_AsArray(value);
-            id data = [[CBLFLArray alloc] initWithArray: array c4doc: c4doc database: database];
-            return [[CBLReadOnlyArray alloc] initWithFleeceData: data];
+            id flData = [[CBLFLArray alloc] initWithArray: array
+                                               datasource: datasource database: database];
+            return [[CBLReadOnlyArray alloc] initWithFleeceData: flData];
         }
         case kFLDict: {
             FLDict dict = FLValue_AsDict(value);
@@ -82,8 +83,9 @@ NSObject *const kCBLRemovedValue = [[NSObject alloc] init];
             cbl::SharedKeys sk = database.sharedKeys;
             FLSlice type = FLValue_AsString(FLDict_GetSharedKey(dict, typeKey, &sk));
             if(!type.buf) {
-                id data = [[CBLFLDict alloc] initWithDict: dict c4doc: c4doc database: database];
-                return [[CBLReadOnlyDictionary alloc] initWithFleeceData: data];
+                id flData = [[CBLFLDict alloc] initWithDict: dict
+                                                 datasource: datasource database: database];
+                return [[CBLReadOnlyDictionary alloc] initWithFleeceData: flData];
             } else {
                 id result = FLValue_GetNSObject(value, &sk);
                 return [self dictionaryToCBLObject: result database: database];

--- a/Objective-C/Internal/CBLFLArray.h
+++ b/Objective-C/Internal/CBLFLArray.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "Fleece+CoreFoundation.h"
+#import "CBLFLDataSource.h"
 @class CBLC4Document;
 @class CBLDatabase;
 
@@ -17,14 +18,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) FLArray array;
 
-@property (nonatomic, readonly) CBLC4Document* c4doc;
+@property (nonatomic, readonly) id<CBLFLDataSource> datasource;
 
 @property (nonatomic, readonly) CBLDatabase* database;
 
 - (instancetype) initWithArray: (nullable FLArray) array
-                         c4doc: (CBLC4Document*)c4doc
+                    datasource: (id<CBLFLDataSource>)datasource
                       database: (CBLDatabase*)database;
-
 
 @end
 

--- a/Objective-C/Internal/CBLFLArray.mm
+++ b/Objective-C/Internal/CBLFLArray.mm
@@ -10,22 +10,18 @@
 #import "CBLC4Document.h"
 #import "CBLDatabase.h"
 
-@implementation CBLFLArray {
-    FLArray _array;
-    CBLC4Document* _c4doc;
-    CBLDatabase* _database;
-}
+@implementation CBLFLArray
 
-@synthesize array=_array, c4doc=_c4doc, database=_database;
+@synthesize array=_array, datasource=_datasource, database=_database;
 
 - (instancetype) initWithArray: (nullable FLArray) array
-                         c4doc: (CBLC4Document*)c4doc
+                    datasource: (id<CBLFLDataSource>)datasource
                       database: (CBLDatabase*)database
 {
     self = [super init];
     if (self) {
         _array = array;
-        _c4doc = c4doc;
+        _datasource = datasource;
         _database = database;
     }
     return self;

--- a/Objective-C/Internal/CBLFLDataSource.h
+++ b/Objective-C/Internal/CBLFLDataSource.h
@@ -1,0 +1,12 @@
+//
+//  CBLFLDataSource.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/19/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+/** CBLFLDataSource protocol used for marking the object a fleece data source. */
+@protocol CBLFLDataSource <NSObject>
+
+@end

--- a/Objective-C/Internal/CBLFLDict.h
+++ b/Objective-C/Internal/CBLFLDict.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "Fleece+CoreFoundation.h"
+#import "CBLFLDataSource.h"
 @class CBLC4Document;
 @class CBLDatabase;
 
@@ -17,12 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) FLDict dict;
 
-@property (nonatomic, readonly) CBLC4Document* c4doc;
+@property (nonatomic, readonly) id<CBLFLDataSource> datasource;
 
 @property (nonatomic, readonly) CBLDatabase* database;
 
 - (instancetype) initWithDict: (nullable FLDict) dict
-                        c4doc: (CBLC4Document*)c4doc
+                   datasource: (id <CBLFLDataSource>)datasource
                      database: (CBLDatabase*)database;
 
 @end

--- a/Objective-C/Internal/CBLFLDict.mm
+++ b/Objective-C/Internal/CBLFLDict.mm
@@ -11,21 +11,17 @@
 #import "CBLDatabase.h"
 #import "CBLSharedKeys.hh"
 
-@implementation CBLFLDict {
-    FLDict _dict;
-    CBLC4Document* _c4doc;
-    CBLDatabase* _database;
-}
+@implementation CBLFLDict
 
-@synthesize dict=_dict, c4doc=_c4doc, database=_database;
+@synthesize dict=_dict, datasource=_datasource, database=_database;
 
 - (instancetype) initWithDict: (nullable FLDict) dict
-                        c4doc: (CBLC4Document*)c4doc
+                   datasource: (id<CBLFLDataSource>)datasource
                      database: (CBLDatabase*)database {
     self = [super init];
     if (self) {
         _dict = dict;
-        _c4doc = c4doc;
+        _datasource = datasource;
         _database = database;
     }
     return self;

--- a/Objective-C/Internal/CBLLiveQueryChange+Internal.h
+++ b/Objective-C/Internal/CBLLiveQueryChange+Internal.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CBLLiveQueryChange ()
 
 - (instancetype) initWithQuery: (CBLLiveQuery*)query
-                          rows: (nullable NSEnumerator<CBLQueryRow*>*)rows
+                          rows: (nullable CBLQueryResultSet*)rows
                          error: (nullable NSError*)error;
 
 @end

--- a/Objective-C/Internal/CBLPredicateQuery+Internal.h
+++ b/Objective-C/Internal/CBLPredicateQuery+Internal.h
@@ -20,11 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 #define mkError(ERR, FMT, ...)  MYReturnError(ERR, kBadQuerySpecError, CBLErrorDomain, \
                                               FMT, ## __VA_ARGS__)
 
-/** Common API of CBLQuery and CBLPredicateQuery (used by CBLQueryEnumerator) */
+/** Used by CBLQueryEnumerator) */
 @protocol CBLQueryInternal <NSObject>
 @property (readonly, nonatomic) CBLDatabase* database;
 @end
-
 
 @interface CBLPredicateQuery () <CBLQueryInternal>
 

--- a/Objective-C/Internal/CBLQuery+Internal.h
+++ b/Objective-C/Internal/CBLQuery+Internal.h
@@ -21,7 +21,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-
 /////
 
 @protocol CBLQueryJSONEncoding <NSObject>
@@ -33,7 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /////
 
-@interface CBLQuery () <CBLQueryInternal, NSCopying>
+@interface CBLQuery () <NSCopying>
+
+@property (nonatomic, readonly) CBLDatabase* database;
 
 @property (nonatomic, readonly) NSArray<CBLQuerySelectResult*>* select;
 
@@ -85,7 +86,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLQuerySelectResult () <CBLQueryJSONEncoding>
 
-- (instancetype) initWithExpression: (CBLQueryExpression*)expression;
+- (instancetype) initWithExpression: (CBLQueryExpression*)expression as: (nullable NSString*)alias;
+
+- (nullable NSString*) columnName;
 
 @end
 

--- a/Objective-C/Internal/CBLQueryResult+Internal.h
+++ b/Objective-C/Internal/CBLQueryResult+Internal.h
@@ -1,0 +1,22 @@
+//
+//  CBLQueryResult+Internal.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/18/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLQueryResult.h"
+#import "c4.h"
+@class CBLQueryResultSet;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CBLQueryResult ()
+
+- (instancetype) initWithResultSet: (CBLQueryResultSet*)rs
+                      c4Enumerator: (C4QueryEnumerator*)e;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/CBLQueryResultSet+Internal.h
+++ b/Objective-C/Internal/CBLQueryResultSet+Internal.h
@@ -1,0 +1,33 @@
+//
+//  CBLQueryResultSet+Internal.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/18/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLQueryResultSet.h"
+#import "CBLFLDataSource.h"
+#import "c4.h"
+@class CBLDatabase, CBLQuery;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CBLQueryResultSet () <CBLFLDataSource>
+
+- (instancetype) initWithQuery: (CBLQuery*)query
+                    enumerator: (C4QueryEnumerator*)e
+                   columnNames: (NSDictionary*)columnNames;
+
+@property (nonatomic, weak, readonly) CBLDatabase* database;
+@property (nonatomic, readonly) C4Query* c4Query;
+@property (nonatomic, readonly) NSDictionary* columnNames;
+
+- (id) objectAtIndex: (NSUInteger)index;
+
+// If query results have changed, returns a new enumerator, else nil.
+- (nullable CBLQueryResultSet*) refresh: (NSError**)outError;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/CBLQueryResultsArray.h
+++ b/Objective-C/Internal/CBLQueryResultsArray.h
@@ -9,10 +9,10 @@
 #import <Foundation/Foundation.h>
 @class CBLQueryEnumerator;
 
-
 @interface CBLQueryResultsArray : NSArray
 
-- (instancetype) initWithEnumerator: (CBLQueryEnumerator*)enumerator
+// TODO: We should define a protocol here:
+- (instancetype) initWithEnumerator: (id)enumerator
                               count: (NSUInteger)count;
 
 @end

--- a/Objective-C/Internal/CBLQueryResultsArray.mm
+++ b/Objective-C/Internal/CBLQueryResultsArray.mm
@@ -20,7 +20,7 @@
     NSUInteger _count;
 }
 
-- (instancetype) initWithEnumerator: (CBLQueryEnumerator*)enumerator
+- (instancetype) initWithEnumerator: (id)enumerator
                               count: (NSUInteger)count
 {
     self = [super init];

--- a/Objective-C/Internal/CBLStatus.h
+++ b/Objective-C/Internal/CBLStatus.h
@@ -15,7 +15,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef enum {
     kCBLStatusForbidden = 403,
-    kCBLStatusNotFound = 404
+    kCBLStatusNotFound = 404,
+    
+    // Non-HTTP error:
+    kCBLStatusInvalidQuery = 490
 } CBLStatus;
 
 BOOL convertError(const C4Error &error, NSError* _Nullable * outError);

--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -704,7 +704,7 @@
 }
 
 
-- (void) testQueryProvResultKeys {
+- (void) testQueryProjectingKeys {
     [self loadNumbers: 100];
     
     CBLQueryExpression* AVG = [CBLQueryFunction avg: [CBLQueryExpression property: @"number1"]];

--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -13,6 +13,8 @@
 #import "CBLQueryDataSource.h"
 #import "CBLQueryOrdering.h"
 
+#define kDOCID      [CBLQuerySelectResult expression: [CBLQueryExpression meta].documentID]
+#define kSEQUENCE   [CBLQuerySelectResult expression: [CBLQueryExpression meta].sequence]
 
 @interface QueryTest : CBLTestCase
 
@@ -23,17 +25,16 @@
 
 - (uint64_t) verifyQuery: (CBLQuery*)q
             randomAccess: (BOOL)randomAccess
-                    test: (void (^)(uint64_t n, CBLQueryRow *row))block {
+                    test: (void (^)(uint64_t n, CBLQueryResult *result))block {
     NSError* error;
-    NSEnumerator* e = [q run: &error];
-    Assert(e, @"Query failed: %@", error);
+    CBLQueryResultSet* rs = [q run: &error];
+    Assert(rs, @"Query failed: %@", error);
     uint64_t n = 0;
-    for (CBLQueryRow *row in e) {
-        //Log(@"Row: docID='%@', sequence=%llu", row.documentID, row.sequence);
-        block(++n, row);
+    for (CBLQueryResult *r in rs) {
+        block(++n, r);
     }
 
-    NSArray* all = e.allObjects;
+    NSArray* all = rs.allObjects;
     AssertEqual(all.count, n);
     if (randomAccess && n > 0) {
         // Note: the block's 1st parameter is 1-based, while NSArray is 0-based
@@ -74,15 +75,17 @@
 
 - (void) runTestWithNumbers: (NSArray*)numbers cases: (NSArray*)cases {
     for (NSArray* c in cases) {
-        CBLQuery* q = [CBLQuery select: @[]
+        CBLQuery* q = [CBLQuery select: @[kDOCID]
                                   from: [CBLQueryDataSource database: self.db]
                                  where: c[0]];
         NSPredicate* p = [NSPredicate predicateWithFormat: c[1]];
         NSMutableArray* result = [[numbers filteredArrayUsingPredicate: p] mutableCopy];
         uint64_t total = result.count;
         uint64_t rows = [self verifyQuery: q randomAccess: NO
-                                     test: ^(uint64_t n, CBLQueryRow *row) {
-            id dict = [row.document toDictionary];
+                                     test: ^(uint64_t n, CBLQueryResult *r)
+        {
+            CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
+            id dict = [doc toDictionary];
             Assert([result containsObject: dict]);
             [result removeObject: dict];
         }];
@@ -95,15 +98,20 @@
 - (void) testNoWhereQuery {
     [self loadJSONResource: @"names_100"];
     
-    CBLQuery* q = [CBLQuery select: @[]
+    CBLQuery* q = [CBLQuery select: @[kDOCID, kSEQUENCE]
                               from: [CBLQueryDataSource database: self.db]];
     Assert(q);
     uint64_t numRows = [self verifyQuery: q randomAccess: YES
-                                    test:^(uint64_t n, CBLQueryRow *row) {
+                                    test:^(uint64_t n, CBLQueryResult *r)
+    {
+        NSString* docID = [r objectAtIndex: 0];
         NSString* expectedID = [NSString stringWithFormat: @"doc-%03llu", n];
-        AssertEqualObjects(row.documentID, expectedID);
-        AssertEqual(row.sequence, n);
-        CBLDocument* doc = row.document;
+        AssertEqualObjects(docID, expectedID);
+        
+        NSUInteger seq = [[r objectAtIndex: 1] unsignedIntegerValue];
+        AssertEqual(seq, n);
+        
+        CBLDocument* doc = [self.db documentWithID: docID];
         AssertEqualObjects(doc.documentID, expectedID);
         AssertEqual(doc.sequence, n);
     }];
@@ -195,14 +203,16 @@
     for (NSArray* test in tests) {
         CBLQueryExpression* exp = test[0];
         NSArray* expectedDocs = test[1];
-        CBLQuery *q = [CBLQuery select: @[]
+        CBLQuery *q = [CBLQuery select: @[kDOCID]
                                   from: [CBLQueryDataSource database: self.db]
                                  where: exp];
         uint64_t numRows = [self verifyQuery: q randomAccess: YES
-                                        test:^(uint64_t n, CBLQueryRow *row) {
+                                        test: ^(uint64_t n, CBLQueryResult* r)
+        {
             if (expectedDocs.count <= n) {
-                CBLDocument* doc = expectedDocs[(NSUInteger)(n-1)];
-                AssertEqualObjects(doc.documentID, row.documentID, @"Failed case: %@", exp);
+                NSString* documentID = [r objectAtIndex: 0];
+                CBLDocument* expDoc = expectedDocs[(NSUInteger)(n-1)];
+                AssertEqualObjects(expDoc.documentID, documentID, @"Failed case: %@", exp);
             }
         }];
         AssertEqual((int)numRows, (int)expectedDocs.count, @"Failed case: %@", exp);
@@ -216,26 +226,28 @@
     [doc1 setObject: @"string" forKey: @"string"];
     Assert([_db saveDocument: doc1 error: &error], @"Error when creating a document: %@", error);
     
-    CBLQuery* q = [CBLQuery select: @[]
+    CBLQuery* q = [CBLQuery select: @[kDOCID]
                               from: [CBLQueryDataSource database: self.db]
                              where: [[CBLQueryExpression property: @"string"] is: @"string"]];
     
     Assert(q);
     uint64_t numRows = [self verifyQuery: q randomAccess: YES
-                                    test: ^(uint64_t n, CBLQueryRow *row) {
-        CBLDocument* doc = row.document;
+                                    test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
         AssertEqualObjects(doc.documentID, doc1.documentID);
         AssertEqualObjects([doc objectForKey: @"string"], @"string");
     }];
     AssertEqual(numRows, 1u);
     
-    q = [CBLQuery select: @[]
+    q = [CBLQuery select: @[kDOCID]
                     from: [CBLQueryDataSource database: self.db]
                    where: [[CBLQueryExpression property: @"string"] isNot: @"string1"]];
     
     Assert(q);
-    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        CBLDocument* doc = row.document;
+    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
         AssertEqualObjects(doc.documentID, doc1.documentID);
         AssertEqualObjects([doc objectForKey: @"string"], @"string");
     }];
@@ -258,13 +270,15 @@
     
     NSArray* expected = @[@"Marcy", @"Margaretta", @"Margrett", @"Marlen", @"Maryjo"];
     CBLQueryExpression* firstName = [CBLQueryExpression property: @"name.first"];
-    CBLQuery* q = [CBLQuery select: @[]
+    CBLQuery* q = [CBLQuery select: @[kDOCID]
                               from: [CBLQueryDataSource database: self.db]
                              where: [firstName in: expected]
                            orderBy: @[[CBLQuerySortOrder property: @"name.first"]]];
     uint64_t numRows = [self verifyQuery: q randomAccess: YES
-                                    test:^(uint64_t n, CBLQueryRow *row) {
-        NSString* first = [[row.document objectForKey: @"name"] objectForKey: @"first"];
+                                    test:^(uint64_t n, CBLQueryResult* r)
+    {
+        CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
+        NSString* first = [[doc objectForKey: @"name"] objectForKey: @"first"];
         AssertEqualObjects(first, expected[(NSUInteger)(n-1)]);
     }];
     AssertEqual((int)numRows, (int)expected.count);
@@ -275,15 +289,15 @@
     [self loadJSONResource: @"names_100"];
     
     CBLQueryExpression* where = [[CBLQueryExpression property: @"name.first"] like: @"%Mar%"];
-    CBLQuery* q = [CBLQuery select: @[]
+    CBLQuery* q = [CBLQuery select: @[kDOCID]
                               from: [CBLQueryDataSource database: self.db]
                              where: where
                            orderBy: @[[[CBLQueryOrdering property: @"name.first"] ascending]]];
     
     NSMutableArray* firstNames = [NSMutableArray array];
     uint64_t numRows = [self verifyQuery: q randomAccess: NO
-                                    test:^(uint64_t n, CBLQueryRow *row) {
-        CBLDocument* doc = row.document;
+                                    test:^(uint64_t n, CBLQueryResult* r) {
+        CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
         NSString* firstName = [[doc objectForKey:@"name"] objectForKey: @"first"];
         if (firstName)
             [firstNames addObject: firstName];
@@ -297,15 +311,16 @@
     [self loadJSONResource: @"names_100"];
     
     CBLQueryExpression* where = [[CBLQueryExpression property: @"name.first"] regex: @"^Mar.*"];
-    CBLQuery* q = [CBLQuery select: @[]
+    CBLQuery* q = [CBLQuery select: @[kDOCID]
                               from: [CBLQueryDataSource database: self.db]
                              where: where
                            orderBy: @[[[CBLQueryOrdering property: @"name.first"] ascending]]];
     
     NSMutableArray* firstNames = [NSMutableArray array];
     uint64_t numRows = [self verifyQuery: q randomAccess: NO
-                                    test:^(uint64_t n, CBLQueryRow *row) {
-        CBLDocument* doc = row.document;
+                                    test:^(uint64_t n, CBLQueryResult* r)
+    {
+        CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
         NSString* firstName = [[doc objectForKey:@"name"] objectForKey: @"first"];
         if (firstName)
             [firstNames addObject: firstName];
@@ -328,14 +343,16 @@
                              where: where
                            orderBy: @[order]];
     uint64_t numRows = [self verifyQuery: q  randomAccess: YES
-                                    test:^(uint64_t n, CBLQueryRow *row) {
-        CBLFullTextQueryRow* ftsRow = (id)row;
-        NSString* text = ftsRow.fullTextMatched;
+                                    test:^(uint64_t n, CBLQueryResult* r)
+    {
+        // TODO: Wait for the FTS API:
+        // CBLFullTextQueryRow* ftsRow = (id)r;
+        // NSString* text = ftsRow.fullTextMatched;
         //        Log(@"    full text = \"%@\"", text);
         //        Log(@"    matchCount = %u", (unsigned)ftsRow.matchCount);
-        Assert([text containsString: @"Dummie"]);
-        Assert([text containsString: @"woman"]);
-        AssertEqual(ftsRow.matchCount, 2ul);
+        // Assert([text containsString: @"Dummie"]);
+        // Assert([text containsString: @"woman"]);
+        // AssertEqual(ftsRow.matchCount, 2ul);
     }];
     AssertEqual(numRows, 2u);
 }
@@ -353,7 +370,7 @@
         else
             order = [[CBLQueryOrdering property: @"name.first"] descending];
         
-        CBLQuery* q = [CBLQuery select: @[]
+        CBLQuery* q = [CBLQuery select: @[kDOCID]
                                   from: [CBLQueryDataSource database: self.db]
                                  where: nil
                                orderBy: @[order]];
@@ -361,8 +378,9 @@
         
         NSMutableArray* firstNames = [NSMutableArray array];
         uint64_t numRows = [self verifyQuery: q randomAccess: NO
-                                        test:^(uint64_t n, CBLQueryRow *row) {
-            CBLDocument* doc = row.document;
+                                        test: ^(uint64_t n, CBLQueryResult* r)
+        {
+            CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
             NSString* firstName = [[doc objectForKey:@"name"] objectForKey: @"first"];
             if (firstName)
                 [firstNames addObject: firstName];
@@ -389,12 +407,14 @@
     [doc2 setObject: @(1) forKey: @"number"];
     Assert([_db saveDocument: doc2 error: &error], @"Error when creating a document: %@", error);
     
-    CBLQuery* q = [CBLQuery selectDistinct: @[]
-                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQuery* q = [CBLQuery selectDistinct: @[kDOCID]
+                                      from: [CBLQueryDataSource database: self.db]];
     Assert(q);
     uint64_t numRows = [self verifyQuery: q randomAccess: YES
-                                    test: ^(uint64_t n, CBLQueryRow *row) {
-        AssertEqualObjects(row.documentID, doc1.documentID);
+                                    test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        NSString* docID = [r objectAtIndex: 0];
+        AssertEqualObjects(docID, doc1.documentID);
     }];
     AssertEqual(numRows, 1u);
 }
@@ -403,22 +423,27 @@
 - (void) testJoin {
     [self loadNumbers: 100];
     
-    CBLDocument* doc = [[CBLDocument alloc] initWithID: @"joinme"];
-    [doc setObject:@42 forKey:@"theone"];
-    [self saveDocument:doc];
+    CBLDocument* joinme = [[CBLDocument alloc] initWithID: @"joinme"];
+    [joinme setObject: @42 forKey: @"theone"];
+    [self saveDocument: joinme];
+    
+    CBLQuerySelectResult* MAIN_DOC_ID =
+        [CBLQuerySelectResult expression: [CBLQueryExpression metaFrom: @"main"].documentID];
     
     CBLQueryExpression* on = [[CBLQueryExpression property: @"number1" from: @"main"]
                               equalTo: [CBLQueryExpression property:@"theone" from:@"secondary"]];
     CBLQueryJoin* join = [CBLQueryJoin join: [CBLQueryDataSource database: self.db as: @"secondary"]
                                          on: on];
-    CBLQuery* q = [CBLQuery select: @[]
+    CBLQuery* q = [CBLQuery select: @[MAIN_DOC_ID]
                               from: [CBLQueryDataSource database: self.db as: @"main"]
                               join: @[join]];
     Assert(q);
     uint64_t numRows = [self verifyQuery: q randomAccess: YES
-                                    test: ^(uint64_t n, CBLQueryRow *row) {
-                                        AssertEqual([row.document integerForKey:@"number1"], 42);
-                                    }];
+                                    test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        CBLDocument* doc = [self.db documentWithID: [r objectAtIndex: 0]];
+        AssertEqual([doc integerForKey:@"number1"], 42);
+    }];
     AssertEqual(numRows, 1u);
 }
 
@@ -441,12 +466,13 @@
     CBLQuery* q = [CBLQuery select: results
                               from: [CBLQueryDataSource database: self.db]];
     Assert(q);
-    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        AssertEqual([row doubleAtIndex:0], 50.5);
-        AssertEqual([row integerAtIndex:1], 100);
-        AssertEqual([row integerAtIndex:2], 1);
-        AssertEqual([row integerAtIndex:3], 100);
-        AssertEqual([row integerAtIndex:4], 5050);
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        AssertEqual([[r objectAtIndex:0] doubleValue], 50.5);
+        AssertEqual([[r objectAtIndex:1] integerValue], 100);
+        AssertEqual([[r objectAtIndex:2] integerValue], 1);
+        AssertEqual([[r objectAtIndex:3] integerValue], 100);
+        AssertEqual([[r objectAtIndex:4] integerValue], 5050);
     }];
     AssertEqual(numRows, 1u);
 }
@@ -477,10 +503,11 @@
                            orderBy: @[[CBLQueryOrdering expression: STATE]]
                              limit: nil];
     
-    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSString* state = [row stringAtIndex: 0];
-        NSInteger count = [row integerAtIndex: 1];
-        NSString* maxZip = [row stringAtIndex: 2];
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        NSString* state = [r objectAtIndex: 0];
+        NSInteger count = [[r objectAtIndex: 1] integerValue];
+        NSString* maxZip = [r objectAtIndex: 2];
         // Log(@"State = %@, count = %d, maxZip = %@", state, (int)count, maxZip);
         if (n-1 < expectedStates.count) {
             AssertEqualObjects(state,  expectedStates[(NSUInteger)(n-1)]);
@@ -503,10 +530,10 @@
                  orderBy: @[[CBLQueryOrdering expression: STATE]]
                    limit: nil];
     
-    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSString* state = [row stringAtIndex: 0];
-        NSInteger count = [row integerAtIndex: 1];
-        NSString* maxZip = [row stringAtIndex: 2];
+    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r) {
+        NSString* state = [r objectAtIndex: 0];
+        NSInteger count = [[r objectAtIndex: 1] integerValue];
+        NSString* maxZip = [r objectAtIndex: 2];
         // Log(@"State = %@, count = %d, maxZip = %@", state, (int)count, maxZip);
         if (n-1 < expectedStates.count) {
             AssertEqualObjects(state,  expectedStates[(NSUInteger)(n-1)]);
@@ -534,8 +561,8 @@
     [q.parameters setValue: @(5) forName: @"num2"];
     
     NSArray* expectedNumbers = @[@2, @3, @4, @5];
-    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSInteger number = [row integerAtIndex: 0];
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r) {
+        NSInteger number = [[r objectAtIndex: 0] integerValue];
         AssertEqual(number, [expectedNumbers[(NSUInteger)(n-1)] integerValue]);
     }];
     AssertEqual(numRows, 4u);
@@ -562,10 +589,10 @@
     NSArray* expectedSeqs    = @[@1, @2, @3, @4, @5];
     NSArray* expectedNumbers = @[@1, @2, @3, @4, @5];
     
-    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSString* docID = [row stringAtIndex:0];
-        NSInteger seq = [row integerAtIndex:1];
-        NSInteger number = [row integerAtIndex: 2];
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r) {
+        NSString* docID = [r objectAtIndex: 0];
+        NSInteger seq = [[r objectAtIndex: 1] integerValue];
+        NSInteger number = [[r objectAtIndex: 2] integerValue];
         
         AssertEqualObjects(docID,  expectedDocIDs[(NSUInteger)(n-1)]);
         AssertEqual(seq, [expectedSeqs[(NSUInteger)(n-1)] integerValue]);
@@ -587,8 +614,9 @@
                             limit: [CBLQueryLimit limit: @5]];
     
     NSArray* expectedNumbers = @[@1, @2, @3, @4, @5];
-    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSInteger number = [row integerAtIndex: 0];
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        NSInteger number = [[r objectAtIndex: 0] integerValue];
         AssertEqual(number, [expectedNumbers[(NSUInteger)(n-1)] integerValue]);
     }];
     AssertEqual(numRows, 5u);
@@ -601,8 +629,9 @@
     [q.parameters setValue: @3 forName: @"LIMIT_NUM"];
     
     expectedNumbers = @[@1, @2, @3];
-    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSInteger number = [row integerAtIndex: 0];
+    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        NSInteger number = [[r objectAtIndex: 0] integerValue];
         AssertEqual(number, [expectedNumbers[(NSUInteger)(n-1)] integerValue]);
     }];
     AssertEqual(numRows, 3u);
@@ -621,8 +650,9 @@
                             limit: [CBLQueryLimit limit: @5 offset: @3]];
     
     NSArray* expectedNumbers = @[@4, @5, @6, @7, @8];
-    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSInteger number = [row integerAtIndex: 0];
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        NSInteger number = [[r objectAtIndex: 0] integerValue];
         AssertEqual(number, [expectedNumbers[(NSUInteger)(n-1)] integerValue]);
     }];
     AssertEqual(numRows, 5u);
@@ -637,11 +667,70 @@
     [q.parameters setValue: @5 forName: @"OFFSET_NUM"];
     
     expectedNumbers = @[@6, @7, @8];
-    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryRow *row) {
-        NSInteger number = [row integerAtIndex: 0];
+    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        NSInteger number = [[r objectAtIndex: 0] integerValue];
         AssertEqual(number, [expectedNumbers[(NSUInteger)(n-1)] integerValue]);
     }];
     AssertEqual(numRows, 3u);
+}
+
+
+- (void) testQueryResult {
+    [self loadJSONResource: @"names_100"];
+    
+    CBLQueryExpression* FNAME = [CBLQueryExpression property: @"name.first"];
+    CBLQueryExpression* LNAME = [CBLQueryExpression property: @"name.last"];
+    CBLQueryExpression* GENDER = [CBLQueryExpression property: @"gender"];
+    CBLQueryExpression* CITY = [CBLQueryExpression property: @"contact.address.city"];
+    
+    CBLQuerySelectResult* RES_FNAME = [CBLQuerySelectResult expression: FNAME as: @"firstname"];
+    CBLQuerySelectResult* RES_LNAME = [CBLQuerySelectResult expression: LNAME as: @"lastname"];
+    CBLQuerySelectResult* RES_GENDER = [CBLQuerySelectResult expression: GENDER];
+    CBLQuerySelectResult* RES_CITY = [CBLQuerySelectResult expression: CITY];
+    
+    CBLQuery* q = [CBLQuery select: @[RES_FNAME, RES_LNAME, RES_GENDER, RES_CITY]
+                              from: [CBLQueryDataSource database: self.db]];
+    
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES
+                                    test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        AssertEqualObjects([r objectForKey: @"firstname"], [r objectAtIndex: 0]);
+        AssertEqualObjects([r objectForKey: @"lastname"], [r objectAtIndex: 1]);
+        AssertEqualObjects([r objectForKey: @"gender"], [r objectAtIndex: 2]);
+        AssertEqualObjects([r objectForKey: @"city"], [r objectAtIndex: 3]);
+    }];
+    AssertEqual((int)numRows, 100);
+}
+
+
+- (void) testQueryProvResultKeys {
+    [self loadNumbers: 100];
+    
+    CBLQueryExpression* AVG = [CBLQueryFunction avg: [CBLQueryExpression property: @"number1"]];
+    CBLQueryExpression* CNT = [CBLQueryFunction count: [CBLQueryExpression property: @"number1"]];
+    CBLQueryExpression* MIN = [CBLQueryFunction min: [CBLQueryExpression property: @"number1"]];
+    CBLQueryExpression* MAX = [CBLQueryFunction max: [CBLQueryExpression property: @"number1"]];
+    CBLQueryExpression* SUM = [CBLQueryFunction sum: [CBLQueryExpression property: @"number1"]];
+    
+    NSArray* results = @[[CBLQuerySelectResult expression: AVG],
+                         [CBLQuerySelectResult expression: CNT],
+                         [CBLQuerySelectResult expression: MIN as: @"min"],
+                         [CBLQuerySelectResult expression: MAX],
+                         [CBLQuerySelectResult expression: SUM as: @"sum"]];
+    
+    CBLQuery* q = [CBLQuery select: results
+                              from: [CBLQueryDataSource database: self.db]];
+    Assert(q);
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        AssertEqual([r doubleForKey: @"$1"], [r doubleAtIndex: 0]);
+        AssertEqual([r integerForKey: @"$2"], [r integerAtIndex: 1]);
+        AssertEqual([r integerForKey: @"min"], [r integerAtIndex: 2]);
+        AssertEqual([r integerForKey: @"$3"], [r integerAtIndex: 3]);
+        AssertEqual([r integerForKey: @"sum"], [r integerAtIndex: 4]);
+    }];
+    AssertEqual(numRows, 1u);
 }
 
 
@@ -650,7 +739,7 @@
     
     __block int count = 0;
     XCTestExpectation* x = [self expectationWithDescription: @"changes"];
-    CBLLiveQuery* q = [[CBLQuery select: @[]
+    CBLLiveQuery* q = [[CBLQuery select: @[kDOCID]
                                    from: [CBLQueryDataSource database: self.db]
                                   where: [[CBLQueryExpression property: @"number1"] lessThan: @(10)]
                                 orderBy: @[[CBLQueryOrdering property: @"number1"]]] toLive];
@@ -658,12 +747,13 @@
         count++;
         AssertNotNil(change.query);
         AssertNil(change.error);
-        NSArray<CBLQueryRow*>* rows = [change.rows allObjects];
+        NSArray<CBLQueryResult*>* rows = [change.rows allObjects];
         if (count == 1) {
             AssertEqual(rows.count, 9u);
         } else {
             AssertEqual(rows.count, 10u);
-            AssertEqualObjects([rows[0].document objectForKey: @"number1"], @(-1));
+            CBLDocument* doc = [self.db documentWithID: [rows[0] objectAtIndex: 0]];
+            AssertEqualObjects([doc objectForKey: @"number1"], @(-1));
             [x fulfill];
         }
     }];
@@ -695,7 +785,7 @@
         count++;
         AssertNotNil(change.query);
         AssertNil(change.error);
-        NSArray<CBLQueryRow*>* rows = [change.rows allObjects];
+        NSArray<CBLQueryResult*>* rows = [change.rows allObjects];
         if (count == 1) {
             AssertEqual(rows.count, 9u);
         } else {

--- a/Swift/LiveQuery.swift
+++ b/Swift/LiveQuery.swift
@@ -44,9 +44,9 @@ public class LiveQuery {
     @discardableResult
     public func addChangeListener(_ block: @escaping (LiveQueryChange) -> Void) -> NSObjectProtocol {
         return impl.addChangeListener { [unowned self] change in
-            let rows: QueryIterator?;
-            if let rowsEnum = change.rows {
-                rows = QueryIterator(database: self.database, enumerator: rowsEnum)
+            let rows: ResultSet?;
+            if let rs = change.rows {
+                rows = ResultSet(impl: rs)
             } else {
                 rows = nil;
             }

--- a/Swift/LiveQueryChange.swift
+++ b/Swift/LiveQueryChange.swift
@@ -15,7 +15,7 @@ public struct LiveQueryChange {
     public let query: LiveQuery
     
     /** The new query result. */
-    public let rows: QueryIterator?
+    public let rows: ResultSet?
     
     /** The error occurred when running the query. */
     public let error: Error?

--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -45,10 +45,10 @@ public class Query {
         The results come from a snapshot of the database taken at the moment -run: is called, so they
         will not reflect any changes made to the database afterwards. 
         @return A QueryIterator object. */
-    public func run() throws -> QueryIterator {
+    public func run() throws -> ResultSet {
         prepareQuery()
         applyParameters()
-        return try QueryIterator(database: database!, enumerator: queryImpl!.run())
+        return try ResultSet(impl: queryImpl!.run())
     }
     
     /** Returns a string describing the implementation of the compiled query.

--- a/Swift/QueryRow.swift
+++ b/Swift/QueryRow.swift
@@ -46,7 +46,7 @@ public class QueryRow {
         return impl.double(at: UInt(index))
     }
     
-    /** The projecting result value at the given index as an Integer value. */
+    /** The projecting result value at the given index as an String value. */
     public subscript(index: Int) -> String? {
         return impl.string(at: UInt(index))
     }

--- a/Swift/Result.swift
+++ b/Swift/Result.swift
@@ -8,126 +8,190 @@
 
 import Foundation
 
+/** Result represents a single row in the query result. The projecting result value can be
+    accessed either by using a zero based index or by a key corresponding to the
+    SelectResult objects given when constructing the Query object.
+ 
+    A key used for accessing the projecting result value could be one of the followings:
+    * The alias name of the SelectResult object.
+    * The last component of the keypath or property name of the property expression used
+      when creating the SelectResult object.
+    * The provision key in $1, $2, ...$N format for the SelectResult that doesn't have
+      an alias name specified or is not a property expression such as an aggregate function 
+      expression (e.g. count(), avg(), min(), max(), sum() and etc). The number suffix 
+      after the '$' character is a running number starting from one. */
 public class Result : ReadOnlyArrayProtocol, ReadOnlyDictionaryProtocol {
     
     // MARK: ReadOnlyArrayProtocol
     
+    /** A number of the projecting values in the result */
     public var count: Int {
         return Int(impl.count)
     }
     
+    /** The projecting result value at the given index. */
     public func value(at index: Int) -> Any? {
         return DataConverter.convertGETValue(impl.object(at: UInt(index)))
     }
     
+    /** The projecting result value at the given index as a String value. 
+        Returns nil if the value is not a string. */
     public func string(at index: Int) -> String? {
         return impl.string(at: UInt(index))
     }
     
+    /** The projecting result value at the given index as an Integer value. 
+        Returns 0 if the value is not a numeric value. */
     public func int(at index: Int) -> Int {
         return impl.integer(at: UInt(index))
     }
     
+    /** The projecting result value at the given index as a Float value. 
+        Returns 0.0 if the value is not a numeric value. */
     public func float(at index: Int) -> Float {
         return impl.float(at: UInt(index))
     }
     
+    /** The projecting result value at the given index as a Double value. 
+        Returns 0.0 if the value is not a numeric value. */
     public func double(at index: Int) -> Double {
         return impl.double(at: UInt(index))
     }
     
+    /** The projecting result value at the given index as a Boolean value. 
+        Returns true if the value is not null, and is either `true` or a nonzero number. */
     public func boolean(at index: Int) -> Bool {
         return impl.boolean(at: UInt(index))
     }
     
+    /** The projecting result value at the given index as a Blob value. 
+        Returns nil if the value is not a blob. */
     public func blob(at index: Int) -> Blob? {
         return impl.blob(at: UInt(index))
     }
     
+    /** The projecting result value at the given index as a Date value. 
+        Returns nil if the value is not a string and is not parseable as a date. */
     public func date(at index: Int) -> Date? {
         return impl.date(at: UInt(index))
     }
     
+    /** The projecting result value at the given index as a readonly ArrayObject value. 
+        Returns nil if the value is not an array. */
     public func array(at index: Int) -> ReadOnlyArrayObject? {
         return value(at: index) as? ReadOnlyArrayObject
     }
     
+    /** The projecting result value at the given index as a readonly DictionaryObject value. 
+        Returns nil if the value is not a dictionary. */
     public func dictionary(at index: Int) -> ReadOnlyDictionaryObject? {
         return value(at: index) as? ReadOnlyDictionaryObject
     }
     
+    /** All values as a JSON Array object. The values contained in the
+        returned Array object are all JSON based values. */
     public func toArray() -> Array<Any> {
         return impl.toArray()
     }
     
     // MARK: ReadOnlyArrayFragment
     
+    /** Subscript access to a ReadOnlyFragment object of the projecting result 
+        value at the given index. */
     public subscript(index: Int) -> ReadOnlyFragment {
         return ReadOnlyFragment(impl[UInt(index)])
     }
     
     // MARK: ReadOnlyDictionaryProtocol
     
+    /** All projecting keys. */
     public var keys: Array<String> {
         return impl.keys
     }
     
+    /** The projecting result value for the given key. */
     public func value(forKey key: String) -> Any? {
         return DataConverter.convertGETValue(impl.object(forKey: key))
     }
     
+    /** The projecting result value for the given key as a String value.
+        Returns nil if the key doesn't exist, or the value is not a string. */
     public func string(forKey key: String) -> String? {
         return impl.string(forKey: key)
     }
     
+    /** The projecting result value for the given key as an Integer value.
+        Returns 0 if the key doesn't exist, or the value is not a numeric value. */
     public func int(forKey key: String) -> Int {
         return impl.integer(forKey: key)
     }
     
+    /** The projecting result value for the given key as a Float value.
+        Returns 0.0 if the key doesn't exist, or the value is not a numeric value. */
     public func float(forKey key: String) -> Float {
         return impl.float(forKey: key)
     }
     
+    /** The projecting result value for the given key as a Double value.
+        Returns 0.0 if the key doesn't exist, or the value is not a numeric value. */
     public func double(forKey key: String) -> Double {
         return impl.double(forKey: key)
     }
     
+    /** The projecting result value for the given key as a Boolean value.
+        Returns true if the key doesn't exist, or 
+        the value is not null, and is either `true` or a nonzero number. */
     public func boolean(forKey key: String) -> Bool {
         return impl.boolean(forKey: key)
     }
     
+    /** The projecting result value for the given key as a Blob value.
+        Returns nil if the key doesn't exist, or the value is not a blob. */
     public func blob(forKey key: String) -> Blob? {
         return impl.blob(forKey: key)
     }
     
+    /** The projecting result value for the given key as a Date value.
+        Returns nil if the key doesn't exist, or 
+        the value is not a string and is not parseable as a date. */
     public func date(forKey key: String) -> Date? {
         return impl.date(forKey: key)
     }
     
+    /** The projecting result value for the given key as a readonly ArrayObject value.
+        Returns nil if the key doesn't exist, or the value is not an array. */
     public func array(forKey key: String) -> ReadOnlyArrayObject? {
         return value(forKey: key) as? ReadOnlyArrayObject
     }
     
+    /** The projecting result value for the given key as a readonly DictionaryObject value.
+        Returns nil if the key doesn't exist, or the value is not a dictionary. */
     public func dictionary(forKey key: String) -> ReadOnlyDictionaryObject? {
         return value(forKey: key) as? ReadOnlyDictionaryObject
     }
     
+    /** Tests whether a projecting result key exists or not. */
     public func contains(_ key: String) -> Bool {
         return impl.containsObject(forKey: key)
     }
     
+    /** All values as a JSON Dictionary object. The values contained in the 
+        returned Dictionary object are all JSON based values. */
     public func toDictionary() -> Dictionary<String, Any> {
         return impl.toDictionary()
     }
     
     // MARK: Sequence
     
+    /** Gets  an iterator over the prjecting result keys. */
     public func makeIterator() -> IndexingIterator<[String]> {
         return impl.keys.makeIterator();
     }
     
     // MARK: ReadOnlyDictionaryFragment
     
+    /** Subscript access to a ReadOnlyFragment object of the projecting result
+        value for the given key. */
     public subscript(key: String) -> ReadOnlyFragment {
         return ReadOnlyFragment(impl[key])
     }

--- a/Swift/Result.swift
+++ b/Swift/Result.swift
@@ -1,0 +1,142 @@
+//
+//  Result.swift
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/21/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+import Foundation
+
+public class Result : ReadOnlyArrayProtocol, ReadOnlyDictionaryProtocol {
+    
+    // MARK: ReadOnlyArrayProtocol
+    
+    public var count: Int {
+        return Int(impl.count)
+    }
+    
+    public func value(at index: Int) -> Any? {
+        return DataConverter.convertGETValue(impl.object(at: UInt(index)))
+    }
+    
+    public func string(at index: Int) -> String? {
+        return impl.string(at: UInt(index))
+    }
+    
+    public func int(at index: Int) -> Int {
+        return impl.integer(at: UInt(index))
+    }
+    
+    public func float(at index: Int) -> Float {
+        return impl.float(at: UInt(index))
+    }
+    
+    public func double(at index: Int) -> Double {
+        return impl.double(at: UInt(index))
+    }
+    
+    public func boolean(at index: Int) -> Bool {
+        return impl.boolean(at: UInt(index))
+    }
+    
+    public func blob(at index: Int) -> Blob? {
+        return impl.blob(at: UInt(index))
+    }
+    
+    public func date(at index: Int) -> Date? {
+        return impl.date(at: UInt(index))
+    }
+    
+    public func array(at index: Int) -> ReadOnlyArrayObject? {
+        return value(at: index) as? ReadOnlyArrayObject
+    }
+    
+    public func dictionary(at index: Int) -> ReadOnlyDictionaryObject? {
+        return value(at: index) as? ReadOnlyDictionaryObject
+    }
+    
+    public func toArray() -> Array<Any> {
+        return impl.toArray()
+    }
+    
+    // MARK: ReadOnlyArrayFragment
+    
+    public subscript(index: Int) -> ReadOnlyFragment {
+        return ReadOnlyFragment(impl[UInt(index)])
+    }
+    
+    // MARK: ReadOnlyDictionaryProtocol
+    
+    public var keys: Array<String> {
+        return impl.keys
+    }
+    
+    public func value(forKey key: String) -> Any? {
+        return DataConverter.convertGETValue(impl.object(forKey: key))
+    }
+    
+    public func string(forKey key: String) -> String? {
+        return impl.string(forKey: key)
+    }
+    
+    public func int(forKey key: String) -> Int {
+        return impl.integer(forKey: key)
+    }
+    
+    public func float(forKey key: String) -> Float {
+        return impl.float(forKey: key)
+    }
+    
+    public func double(forKey key: String) -> Double {
+        return impl.double(forKey: key)
+    }
+    
+    public func boolean(forKey key: String) -> Bool {
+        return impl.boolean(forKey: key)
+    }
+    
+    public func blob(forKey key: String) -> Blob? {
+        return impl.blob(forKey: key)
+    }
+    
+    public func date(forKey key: String) -> Date? {
+        return impl.date(forKey: key)
+    }
+    
+    public func array(forKey key: String) -> ReadOnlyArrayObject? {
+        return value(forKey: key) as? ReadOnlyArrayObject
+    }
+    
+    public func dictionary(forKey key: String) -> ReadOnlyDictionaryObject? {
+        return value(forKey: key) as? ReadOnlyDictionaryObject
+    }
+    
+    public func contains(_ key: String) -> Bool {
+        return impl.containsObject(forKey: key)
+    }
+    
+    public func toDictionary() -> Dictionary<String, Any> {
+        return impl.toDictionary()
+    }
+    
+    // MARK: Sequence
+    
+    public func makeIterator() -> IndexingIterator<[String]> {
+        return impl.keys.makeIterator();
+    }
+    
+    // MARK: ReadOnlyDictionaryFragment
+    
+    public subscript(key: String) -> ReadOnlyFragment {
+        return ReadOnlyFragment(impl[key])
+    }
+    
+    // MARK: Internal
+    
+    private var impl: CBLQueryResult
+    
+    init(impl: CBLQueryResult) {
+        self.impl = impl
+    }
+}

--- a/Swift/ResultSet.swift
+++ b/Swift/ResultSet.swift
@@ -1,0 +1,27 @@
+//
+//  ResultSet.swift
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 7/21/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+import Foundation
+
+public struct ResultSet : Sequence, IteratorProtocol {
+    public typealias Element = Result
+    
+    public mutating func next() -> Result? {
+        if let row = impl.nextObject() as? CBLQueryResult {
+            return Result(impl: row)
+        } else {
+            return nil
+        }
+    }
+    
+    private let impl: CBLQueryResultSet
+    
+    init(impl: CBLQueryResultSet) {
+        self.impl = impl
+    }
+}

--- a/Swift/ResultSet.swift
+++ b/Swift/ResultSet.swift
@@ -8,10 +8,13 @@
 
 import Foundation
 
-public struct ResultSet : Sequence, IteratorProtocol {
+/** ResultSet is a result returned from a query. */
+public class ResultSet : Sequence, IteratorProtocol {
     public typealias Element = Result
     
-    public mutating func next() -> Result? {
+    /** Advances to and return the next result row.
+        @return A Result object. */
+    public func next() -> Result? {
         if let row = impl.nextObject() as? CBLQueryResult {
             return Result(impl: row)
         } else {

--- a/Swift/SelectResult.swift
+++ b/Swift/SelectResult.swift
@@ -11,14 +11,20 @@ import Foundation
 /** SelectResult represents a signle return value of the query statement. */
 public class SelectResult {
     
-    /** Create a SelectResult object with the given expression. 
+    /** Creates a SelectResult.As object with the given expression.
         @param expression   The expression.
-        @return A SelectResult object. */
+        @return A SelectResult.As object. */
     public static func expression(_ expression: Expression) -> As {
         return As(expression: expression, alias: nil)
     }
     
+    /** SelectResult.As is a SelectResult that you can specified an alias name to it. The
+        alias name can be used as the key for accessing the result value from the query Result
+        object. */
     public class As: SelectResult {
+        /** Specifies the alias name to the SelectResult object. 
+            @param alias   The alias name.
+            @return A SelectResult object with the alias name specified. */
         public func `as`(_ alias: String) -> SelectResult {
             return SelectResult(expression: self.expression, alias: alias)
         }

--- a/Swift/SelectResult.swift
+++ b/Swift/SelectResult.swift
@@ -14,17 +14,29 @@ public class SelectResult {
     /** Create a SelectResult object with the given expression. 
         @param expression   The expression.
         @return A SelectResult object. */
-    public static func expression(_ expression: Expression) -> SelectResult {
-        let result = CBLQuerySelectResult.expression(expression.impl)
-        return SelectResult(impl: result)
+    public static func expression(_ expression: Expression) -> As {
+        return As(expression: expression, alias: nil)
+    }
+    
+    public class As: SelectResult {
+        public func `as`(_ alias: String) -> SelectResult {
+            return SelectResult(expression: self.expression, alias: alias)
+        }
     }
     
     // MARK: Internal
     
-    let impl: CBLQuerySelectResult
+    let expression: Expression
     
-    init(impl: CBLQuerySelectResult) {
-        self.impl = impl
+    var alias: String?
+    
+    var impl: CBLQuerySelectResult {
+        return CBLQuerySelectResult.expression(expression.impl, as: alias)
+    }
+    
+    init(expression: Expression, alias: String?) {
+        self.expression = expression
+        self.alias = alias
     }
     
     static func toImpl(results: [SelectResult]) -> [CBLQuerySelectResult] {
@@ -36,7 +48,3 @@ public class SelectResult {
     }
     
 }
-
-// TODO:
-// * Support Alias
-// * Support From Alias

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -610,7 +610,7 @@ class QueryTest: CBLTestCase {
     }
     
     
-    func testQueryProvResultKeys() throws {
+    func testQueryProjectingKeys() throws {
         try loadNumbers(100)
         
         let AVG = SelectResult.expression(Function.avg(Expression.property("number1")))


### PR DESCRIPTION
* Implement ResultSet and Result API according to spec; Result implements ReadOnlyArray and ReadOnlyDictionary interface.

* Separate PredicateQuery and QueryAPI; PredicateQuery still uses the  QueryRow class.

#1827 , #1828