### PR TITLE
Simplified Swift Conflict class

### DIFF
--- a/Swift/ConflictResolver.swift
+++ b/Swift/ConflictResolver.swift
@@ -9,32 +9,15 @@
 import Foundation
 
 public struct Conflict {
-    public var mine: ReadOnlyDocument {
-        return _mine
-    }
-    
-    public var theirs: ReadOnlyDocument {
-        return _theirs
-    }
-    
-    public var base: ReadOnlyDocument? {
-        return _base
-    }
-    
+    public let mine: ReadOnlyDocument
+    public let theirs: ReadOnlyDocument
+    public let base: ReadOnlyDocument?
+
     init(impl: CBLConflict) {
-        _mine = ReadOnlyDocument(impl.mine)
-        _theirs = ReadOnlyDocument(impl.theirs)
-        
-        if let base = impl.base {
-            _base = ReadOnlyDocument(base)
-        } else {
-            _base = nil
-        }
+        mine = ReadOnlyDocument(impl.mine)
+        theirs = ReadOnlyDocument(impl.theirs)
+        base = impl.base.flatMap({ReadOnlyDocument($0)})
     }
-    
-    let _mine: ReadOnlyDocument
-    let _theirs: ReadOnlyDocument
-    let _base: ReadOnlyDocument?
 }
 
 public protocol ConflictResolver {


### PR DESCRIPTION
I was looking at the Swift code and saw that this class could be simplified.

* Made the mine/theirs/base properties regular 'var's.
* Used flatMap idiom to initialize base without needing an if/else. (It's the first time I've used it, but it's apparently a pretty common idiom in the Swift world.)