### PR TITLE
Sped up array/dictionary conversions and Fleece encoding

### DIFF
--- a/Objective-C/CBLBlob.mm
+++ b/Objective-C/CBLBlob.mm
@@ -260,9 +260,14 @@ static NSString* const kBlobType = @kC4ObjectType_Blob;
 #pragma mark FLEECE ENCODABLE
 
 
-- (BOOL) fleeceEncode: (FLEncoder)encoder
-             database: (CBLDatabase*)database
-                error: (NSError**)outError
+- (id) cbl_toCBLObject {
+    return self;
+}
+
+
+- (BOOL) cbl_fleeceEncode: (FLEncoder)encoder
+                 database: (CBLDatabase*)database
+                    error: (NSError**)outError
 {
     if(![self installInDatabase: database error: outError])
         return NO;

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -17,6 +17,7 @@
 #import "CBLArray.h"
 #import "CBLC4Document.h"
 #import "CBLConflictResolver.h"
+#import "CBLData.h"
 #import "CBLCoreBridge.h"
 #import "CBLDocument+Internal.h"
 #import "CBLInternal.h"
@@ -445,7 +446,7 @@ static bool dictionaryContainsBlob(__unsafe_unretained CBLDictionary* dict) {
 
 - (NSData*) encode: (NSError**)outError {
     auto encoder = c4db_createFleeceEncoder(self.c4db);
-    if (![_dict fleeceEncode: encoder database: self.database error: outError])
+    if (![_dict cbl_fleeceEncode: encoder database: self.database error: outError])
         return nil;
     FLError flErr;
     FLSliceResult body = FLEncoder_Finish(encoder, &flErr);

--- a/Objective-C/CBLReadOnlyArray.mm
+++ b/Objective-C/CBLReadOnlyArray.mm
@@ -106,6 +106,16 @@
 }
 
 
+- (id) cbl_toPlainObject {
+    return [self toArray];
+}
+
+
+- (id) cbl_toCBLObject {
+    return [[CBLArray alloc] initWithFleeceData: self.data];
+}
+
+
 #pragma mark - NSFastEnumeration
 
 
@@ -145,9 +155,9 @@
 #pragma mark - FLEECE ENCODABLE
 
 
-- (BOOL) fleeceEncode: (FLEncoder)encoder
-             database: (CBLDatabase*)database
-                error: (NSError**)outError
+- (BOOL) cbl_fleeceEncode: (FLEncoder)encoder
+                 database: (CBLDatabase*)database
+                    error: (NSError**)outError
 {
     
     return FLEncoder_WriteValueWithSharedKeys(encoder, (FLValue)_array, _sharedKeys);

--- a/Objective-C/CBLReadOnlyDictionary.mm
+++ b/Objective-C/CBLReadOnlyDictionary.mm
@@ -113,6 +113,16 @@
 }
 
 
+- (id) cbl_toPlainObject {
+    return [self toDictionary];
+}
+
+
+- (id) cbl_toCBLObject {
+    return [[CBLDictionary alloc] initWithFleeceData: self.data];
+}
+
+
 #pragma mark - NSFastEnumeration
 
 
@@ -150,9 +160,9 @@
 #pragma mark - FLEECE ENCODING
 
 
-- (BOOL) fleeceEncode: (FLEncoder)encoder
-             database: (CBLDatabase*)database
-                error: (NSError**)outError
+- (BOOL) cbl_fleeceEncode: (FLEncoder)encoder
+                 database: (CBLDatabase*)database
+                    error: (NSError**)outError
 {
     return FLEncoder_WriteValueWithSharedKeys(encoder, (FLValue)_dict, _sharedKeys);
 }
@@ -178,7 +188,7 @@
 
 - (NSArray*) fleeceKeys {
     if (!_keys) {
-        NSMutableArray* keys = [NSMutableArray array];
+        NSMutableArray* keys = [NSMutableArray arrayWithCapacity: FLDict_Count(_dict)];
         if (_dict != nullptr) {
             FLDictIterator iter;
             FLDictIterator_Begin(_dict, &iter);

--- a/Objective-C/Internal/CBLData.h
+++ b/Objective-C/Internal/CBLData.h
@@ -15,14 +15,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+/** A unique object instance that's used as a value in CBLDictionary to represent a removed value. */
 extern NSObject * const kCBLRemovedValue;
+
+
+/** Category methods for value conversions, added to all objects. */
+@interface NSObject (CBLConversions)
+
+/** Encodes this object to Fleece. */
+- (BOOL) cbl_fleeceEncode: (FLEncoder)encoder
+                 database: (CBLDatabase*)database
+                    error: (NSError**)outError;
+
+/** Returns this object represented as a plain Cocoa object, like an NSArray, NSDictionary,
+    NSString, etc.
+    The default implementation in NSObject just returns self. CBL classes override this. */
+- (id) cbl_toPlainObject;
+
+/** Returns this object as it will appear in a Couchbase Lite document, if there's a different
+    form for that. For example, converts NSArray to CBLArray.
+    For classes that can't be stored in a document, throws an exception. */
+- (id) cbl_toCBLObject;
+
+@end
+
 
 @interface CBLData : NSObject
 
-+ (id) convertValue: (id)value;
-
+/** Returns the boolean interpretation of an object.
+    nil, NSNull, and NSNumbers with a 0 or NO value are NO. All others are YES. */
 + (BOOL) booleanValueForObject: (id)object;
 
+/** Decodes a Fleece value to an NSObject. Creates CBL containers like CBLDictionary. */
 + (nullable id) fleeceValueToObject: (FLValue)value
                          datasource: (id<CBLFLDataSource>)datasource
                            database: (CBLDatabase*)database;

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -1,5 +1,5 @@
 //
-//  CBLDocumentObjectInternal.h
+//  CBLDocument+Internal.h
 //  CouchbaseLite
 //
 //  Created by Pasin Suriyentrakorn on 4/14/17.
@@ -25,15 +25,6 @@
 
 
 NS_ASSUME_NONNULL_BEGIN
-
-@protocol CBLFleeceEncodable <NSObject>
-
-- (BOOL) fleeceEncode: (FLEncoder)encoder
-             database: (CBLDatabase*)database
-                error: (NSError**)outError;
-
-@end
-
 
 //////////////////
 
@@ -85,12 +76,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 //////////////////
 
-@interface CBLBlob() <CBLFleeceEncodable>
-
-@end
-
-//////////////////
-
 @interface CBLDictionary ()
 
 @property (nonatomic) BOOL changed;
@@ -99,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 //////////////////
 
-@interface CBLReadOnlyArray () <CBLFleeceEncodable>
+@interface CBLReadOnlyArray ()
 
 @property (nonatomic, readonly, nullable) CBLFLArray* data;
 
@@ -109,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 //////////////////
 
-@interface CBLReadOnlyDictionary () <CBLFleeceEncodable>
+@interface CBLReadOnlyDictionary ()
 
 @property (nonatomic, nullable) CBLFLDict* data;
 


### PR DESCRIPTION
In the TuneMark benchmark's import phase, the time was dominated by adding an NSDictionary to an empty document, and encoding the document to Fleece. I've sped this up, and some other methods that showed up as hot-spots.

The biggest problem was the large number of -conformsToProtocol: calls. This method is very slow. I've replaced those with category methods on NSObject, which the CBL classes override. These are declared in CBLData.h.

There are some more changes in CBLDictionary to reduce the amount of work done in -setDictionary: and -toDictionary.