### PR TITLE
Updated query generation to compensate for changed LiteCore "IN" op

### DIFF
--- a/Objective-C/CBLPredicateQuery+Predicates.mm
+++ b/Objective-C/CBLPredicateQuery+Predicates.mm
@@ -198,7 +198,7 @@ static id EncodePredicate(NSPredicate* pred, NSError** outError) {
             if (rtype != NSVariableExpressionType && rtype != NSAggregateExpressionType) {
                 return @[@"ANY", @"X", rhs, @[@"=", @[@"?X"], lhs]];
             } else if (rtype == NSAggregateExpressionType)
-                return [@[op, lhs] arrayByAddingObjectsFromArray: rhs];
+                return @[op, lhs, rhs];
         }
 
         static NSString* const kModifiers[3] = {nil, @"EVERY", @"ANY"};
@@ -267,7 +267,7 @@ static id EncodeExpression(NSExpression* expr, NSError **outError, bool aggregat
             return @[@"CASE", [NSNull null], condition, ifTrue, ifFalse];
         }
         case NSAggregateExpressionType: {
-            NSMutableArray* collection = [NSMutableArray array];
+            NSMutableArray* collection = [NSMutableArray arrayWithObject: @"[]"];
             for (id exp in expr.collection) {
                 if ([exp isKindOfClass: [NSExpression class]])
                     [collection addObject: EncodeExpression(exp, outError, aggregate)];

--- a/Objective-C/Internal/CBLAggregateExpression.m
+++ b/Objective-C/Internal/CBLAggregateExpression.m
@@ -22,7 +22,7 @@
 }
 
 - (id) asJSON {
-    NSMutableArray *json = [NSMutableArray array];
+    NSMutableArray *json = [NSMutableArray arrayWithObject: @"[]"];
     for (id exp in _subexpressions) {
         if ([exp isKindOfClass:[CBLQueryExpression class]])
             [json addObject: [(CBLQueryExpression *)exp asJSON]];

--- a/Objective-C/Internal/CBLBinaryExpression.m
+++ b/Objective-C/Internal/CBLBinaryExpression.m
@@ -87,19 +87,26 @@
             break;
     }
     
-    if ([_lhs isKindOfClass: [CBLQueryExpression class]])
-        [json addObject: [(CBLQueryExpression*)_lhs asJSON]];
-    else
-        [json addObject: _lhs];
-    
-    if ([_rhs isKindOfClass: [CBLAggregateExpression class]])
-        [json addObjectsFromArray: [(CBLAggregateExpression*)_rhs asJSON]];
-    else if ([_rhs isKindOfClass: [CBLQueryExpression class]])
-        [json addObject: [(CBLQueryExpression*)_rhs asJSON]];
-    else
-        [json addObject: _rhs];
+    [json addObject: valueAsJSON(_lhs)];
+
+    if (_type == CBLBetweenBinaryExpType) {
+        // "between"'s RHS is an aggregate of the min and max, but the min and max need to be
+        // written out as parameters to the BETWEEN operation:
+        NSArray* rangeExprs = ((CBLAggregateExpression*)_rhs).subexpressions;
+        [json addObject: valueAsJSON(rangeExprs[0])];
+        [json addObject: valueAsJSON(rangeExprs[1])];
+    } else {
+        [json addObject: valueAsJSON(_rhs)];
+    }
     
     return json;
+}
+
+static id valueAsJSON(id val) {
+    if ([val isKindOfClass: [CBLQueryExpression class]])
+        return [(CBLQueryExpression*)val asJSON];
+    else
+        return val;
 }
 
 @end


### PR DESCRIPTION
See couchbase/couchbase-lite-core#204

The LC change (not yet pushed to Github) is that the "IN" operation now takes exactly 2 args: first the item, second the array expression. Also I added an array-literal syntax so you can do the SQL-style "IN" where you give a list of values. That's a "[]" expression where the args are the array elements.