### PR TITLE
Implement setting log level API

### DIFF
--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -85,6 +85,31 @@ typedef struct {
 @end
 
 
+/**
+ Log domain. The log domains here are tentative and subject to change.
+ */
+typedef NS_ENUM(uint32_t, CBLLogDomain) {
+    kCBLLogDomainAll,
+    kCBLLogDomainDatabase,
+    kCBLLogDomainQuery,
+    kCBLLogDomainReplicator,
+    kCBLLogDomainNetwork,
+};
+
+
+/**
+ Log level. The default log level for all domains is kCBLLogLevelWarning.
+ The log levels here are tentative and subject to change.
+ */
+typedef NS_ENUM(uint32_t, CBLLogLevel) {
+    kCBLLogLevelDebug,
+    kCBLLogLevelVerbose,
+    kCBLLogLevelInfo,
+    kCBLLogLevelWarning,
+    kCBLLogLevelError,
+    kCBLLogLevelNone
+};
+
 /** A Couchbase Lite database. */
 @interface CBLDatabase : NSObject
 
@@ -307,6 +332,15 @@ typedef struct {
                config: (nullable CBLDatabaseConfiguration*)config
                 error: (NSError**)error;
 
+#pragma mark - Logging
+
+/**
+ Sets log level for the given log domain.
+
+ @param level The log level.
+ @param domain The log domain.
+ */
++ (void) setLogLevel: (CBLLogLevel)level domain: (CBLLogDomain)domain;
 
 #pragma mark - Change Listener
 

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -360,6 +360,43 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 }
 
 
+#pragma mark - Logging
+
+
++ (void) setLogLevel: (CBLLogLevel)level domain: (CBLLogDomain)domain {
+    C4LogLevel c4level = level != kCBLLogLevelNone ? (C4LogLevel)level : kC4LogNone;
+    switch (domain) {
+        case kCBLLogDomainAll:
+            CBLSetLogLevel(Database, c4level);
+            CBLSetLogLevel(DB, c4level);
+            CBLSetLogLevel(Query, c4level);
+            CBLSetLogLevel(SQL, c4level);
+            CBLSetLogLevel(Sync, c4level);
+            CBLSetLogLevel(BLIP, c4level);
+            CBLSetLogLevel(Actor, c4level);
+            CBLSetLogLevel(WebSocket, c4level);
+            break;
+        case kCBLLogDomainDatabase:
+            CBLSetLogLevel(Database, c4level);
+            CBLSetLogLevel(DB, c4level);
+            break;
+        case kCBLLogDomainQuery:
+            CBLSetLogLevel(Query, c4level);
+            CBLSetLogLevel(SQL, c4level);
+            break;
+        case kCBLLogDomainReplicator:
+            CBLSetLogLevel(Sync, c4level);
+            break;
+        case kCBLLogDomainNetwork:
+            CBLSetLogLevel(BLIP, c4level);
+            CBLSetLogLevel(Actor, c4level);
+            CBLSetLogLevel(WebSocket, c4level);
+        default:
+            break;
+    }
+}
+
+
 #pragma mark - DOCUMENT CHANGES
 
 

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -6,7 +6,8 @@
 //  Copyright © 2017 Couchbase. All rights reserved.
 //
 
-#import "CBLDatabase.h"
+#import <Foundation/Foundation.h>
+@class CBLDatabase;
 @class CBLReplicatorChange;
 @class CBLReplicatorConfiguration;
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -43,9 +43,6 @@ static NSTimeInterval retryDelay(unsigned retryCount) {
 }
 
 
-C4LogDomain kCBLSyncLogDomain;
-
-
 @interface CBLReplicatorStatus ()
 - (instancetype) initWithActivity: (CBLReplicatorActivityLevel)activity
                          progress: (CBLReplicatorProgress)progress
@@ -75,7 +72,7 @@ C4LogDomain kCBLSyncLogDomain;
 
 + (void) initialize {
     if (self == [CBLReplicator class]) {
-        kCBLSyncLogDomain = c4log_getDomain("Sync", true);
+        kCBL_LogDomainSync = c4log_getDomain("Sync", true);
         [CBLWebSocket registerWithC4];
     }
 }

--- a/Objective-C/Internal/CBLLog.h
+++ b/Objective-C/Internal/CBLLog.h
@@ -36,16 +36,23 @@ void CBLLog_Init(void);
 //    ... then inside a +initialize method:
 //    kCBLQueryLogDomain = c4log_getDomain("Query", true);
 
-#define kCBLDefaultLogDomain kC4DefaultLog
+#define kCBL_LogDomainDefault kC4DefaultLog
 
-extern C4LogDomain kCBLDatabaseLogDomain;
-extern C4LogDomain kCBLQueryLogDomain;
-extern C4LogDomain kCBLSyncLogDomain;
+// TODO: Sync Lite and LiteCore log domains:
+extern C4LogDomain kCBL_LogDomainDatabase;
+extern C4LogDomain kCBL_LogDomainDB;        // LiteCore Domain
+extern C4LogDomain kCBL_LogDomainQuery;
+extern C4LogDomain kCBL_LogDomainSQL;       // LiteCore Domain
+extern C4LogDomain kCBL_LogDomainSync;      // LiteCore Domain
+extern C4LogDomain kCBL_LogDomainBLIP;      // LiteCore Domain
+extern C4LogDomain kCBL_LogDomainActor;     // LiteCore Domain
+extern C4LogDomain kCBL_LogDomainWebSocket; // LiteCore Domain
+extern C4LogDomain kCBL_LogDomainWSMock;    // LiteCore Domain
 
 // Logging functions. For the domain, just use the part of the name between kCBL… and …LogDomain.
 #define CBLLogToAt(DOMAIN, LEVEL, FMT, ...)        \
-        ({if (__builtin_expect(c4log_getLevel(kCBL##DOMAIN##LogDomain) <= LEVEL, false))   \
-              cbllog(kCBL##DOMAIN##LogDomain, LEVEL, FMT, ## __VA_ARGS__);})
+        ({if (__builtin_expect(c4log_getLevel(kCBL_LogDomain##DOMAIN) <= LEVEL, false))   \
+              cblLog(kCBL_LogDomain##DOMAIN, LEVEL, FMT, ## __VA_ARGS__);})
 #define CBLLogVerbose(DOMAIN, FMT, ...) CBLLogToAt(DOMAIN, kC4LogVerbose, FMT, ## __VA_ARGS__)
 #define CBLLog(DOMAIN, FMT, ...)        CBLLogToAt(DOMAIN, kC4LogInfo,    FMT, ## __VA_ARGS__)
 #define CBLWarn(DOMAIN, FMT, ...)       CBLLogToAt(DOMAIN, kC4LogWarning, FMT, ## __VA_ARGS__)
@@ -57,9 +64,10 @@ extern C4LogDomain kCBLSyncLogDomain;
 #else
 #define CBLDebug(DOMAIN, FMT, ...)      ({ })
 #endif
+    
+#define CBLSetLogLevel(DOMAIN, LEVEL) c4log_setLevel(kCBL_LogDomain##DOMAIN, LEVEL)
 
-
-void cbllog(C4LogDomain domain, C4LogLevel level, NSString *msg, ...)
+void cblLog(C4LogDomain domain, C4LogLevel level, NSString *msg, ...)
     __attribute__((format(__NSString__, 3, 4)));
 
 NS_ASSUME_NONNULL_END

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -110,6 +110,27 @@ public struct DatabaseConfiguration {
 }
 
 
+/// Log domain. The logging domains listed here are tentative and subject to change.
+public enum LogDomain: UInt8 {
+    case all = 0
+    case database
+    case query
+    case replicator
+    case network
+}
+
+/// Log level. The default log level for all domains is warning.
+/// The log levels here are tentative and subject to change.
+public enum LogLevel: UInt8 {
+    case debug = 0
+    case verbose
+    case info
+    case warning
+    case error
+    case none
+}
+
+
 /// A Couchbase Lite database.
 public final class Database {
     
@@ -335,6 +356,18 @@ public final class Database {
                            config: DatabaseConfiguration?) throws
     {
         try CBLDatabase.copy(fromPath: path, toDatabase: name, config: config?.toImpl())
+    }
+    
+    
+    /// Set log level for the given log domain.
+    ///
+    /// - Parameters:
+    ///   - level: The log level.
+    ///   - domain: The log domain.
+    public class func setLogLevel(_ level: LogLevel, domain: LogDomain) {
+        let l = CBLLogLevel.init(rawValue: UInt32(level.rawValue))!
+        let d = CBLLogDomain.init(rawValue: UInt32(domain.rawValue))!
+        return CBLDatabase.setLogLevel(l, domain: d)
     }
     
     


### PR DESCRIPTION
* Implemented set log level API for ObjC and Swift.
* The log domains and levels are tentative.
* Need to sync between LiteCore and Lite log domains. We should shared the domains as many as possible.