### PR TITLE
Fix race between resetting _bgMonitor to nil and using it on different threads

### DIFF
--- a/Source/CBLRestReplicator+Backgrounding.m
+++ b/Source/CBLRestReplicator+Backgrounding.m
@@ -60,7 +60,6 @@
                                             name: UIApplicationProtectedDataDidBecomeAvailable
                                           object: nil];
     [_bgMonitor stop];
-    _bgMonitor = nil;
 }
 
 


### PR DESCRIPTION
* There is a race condition between resetting _bgMonitor to nil in -endBackground on the replicator thread and accessing _bgMonitor in -okToEndBackgrounding on the main thread.

* The easiest way to fix this is to not resetting nil after stopping the bgMonitor given the fact that it could also be recreated again from the replicator thread in the -setupBackgrounding method.

#1677 #CBSE-4145