### PR TITLE
Implement replicator backgrounding option

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -163,6 +163,12 @@
 		933F45F51EC29EF100863ECB /* Fragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93765EA91EC17FEA005E4050 /* Fragment.swift */; };
 		933F45F61EC2A62000863ECB /* DocumentFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93765EAB1EC17FFE005E4050 /* DocumentFragment.swift */; };
 		933F45FA1EC2B47500863ECB /* DataConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933F45F91EC2B47500863ECB /* DataConverter.swift */; };
+		933FC1711F58B111004D0528 /* CBLReplicator+Backgrounding.h in Headers */ = {isa = PBXBuildFile; fileRef = 933FC16F1F58B111004D0528 /* CBLReplicator+Backgrounding.h */; };
+		933FC1721F58B111004D0528 /* CBLReplicator+Backgrounding.m in Sources */ = {isa = PBXBuildFile; fileRef = 933FC1701F58B111004D0528 /* CBLReplicator+Backgrounding.m */; };
+		933FC1791F58EFD6004D0528 /* CBLReplicator+Backgrounding.h in Headers */ = {isa = PBXBuildFile; fileRef = 933FC16F1F58B111004D0528 /* CBLReplicator+Backgrounding.h */; };
+		933FC17A1F58EFD9004D0528 /* CBLReplicator+Backgrounding.m in Sources */ = {isa = PBXBuildFile; fileRef = 933FC1701F58B111004D0528 /* CBLReplicator+Backgrounding.m */; };
+		9340F9E51F709A7200C347C4 /* MYBackgroundMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9340F9CE1F709A6E00C347C4 /* MYBackgroundMonitor.m */; };
+		9340F9E61F709A7300C347C4 /* MYBackgroundMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9340F9CE1F709A6E00C347C4 /* MYBackgroundMonitor.m */; };
 		934A27381F26A6F3003946A7 /* Database+PredicateQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934A27371F26A6F3003946A7 /* Database+PredicateQuery.swift */; };
 		934A278C1F30E5A5003946A7 /* CBLAggregateExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 934A278A1F30E5A5003946A7 /* CBLAggregateExpression.h */; };
 		934A278D1F30E5A5003946A7 /* CBLAggregateExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 934A278A1F30E5A5003946A7 /* CBLAggregateExpression.h */; };
@@ -590,6 +596,13 @@
 			remoteGlobalIDString = 27EF80F91917EEC600A327B9;
 			remoteInfo = "LiteCore static";
 		};
+		9340F9E21F709A6E00C347C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9398D9311E0347B600464432 /* LiteCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 272AEC5B1F560FF600051F0A;
+			remoteInfo = cblite;
+		};
 		936483901E442F15008D08B3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9398D9091E03434200464432 /* Project object */;
@@ -820,6 +833,10 @@
 		933F1A991F39098400338C6A /* CBLQueryResultArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLQueryResultArray.h; sourceTree = "<group>"; };
 		933F1A9A1F39098400338C6A /* CBLQueryResultArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLQueryResultArray.m; sourceTree = "<group>"; };
 		933F45F91EC2B47500863ECB /* DataConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataConverter.swift; sourceTree = "<group>"; };
+		933FC16F1F58B111004D0528 /* CBLReplicator+Backgrounding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CBLReplicator+Backgrounding.h"; sourceTree = "<group>"; };
+		933FC1701F58B111004D0528 /* CBLReplicator+Backgrounding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CBLReplicator+Backgrounding.m"; sourceTree = "<group>"; };
+		9340F9CE1F709A6E00C347C4 /* MYBackgroundMonitor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MYBackgroundMonitor.m; sourceTree = "<group>"; };
+		9340F9E41F709A6E00C347C4 /* MYBackgroundMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MYBackgroundMonitor.h; sourceTree = "<group>"; };
 		9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "CBL ObjC Tests - iOS App.xcconfig"; sourceTree = "<group>"; };
 		9344A3621E44517B0091F581 /* CBL ObjC Tests - iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "CBL ObjC Tests - iOS.xcconfig"; sourceTree = "<group>"; };
 		934A27371F26A6F3003946A7 /* Database+PredicateQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Database+PredicateQuery.swift"; sourceTree = "<group>"; };
@@ -1094,6 +1111,8 @@
 			isa = PBXGroup;
 			children = (
 				937F01E51EFB280000060D64 /* CBLAuthenticator+Internal.h */,
+				933FC16F1F58B111004D0528 /* CBLReplicator+Backgrounding.h */,
+				933FC1701F58B111004D0528 /* CBLReplicator+Backgrounding.m */,
 				2728509C1E99CA4D009CA22F /* CBLReplicator+Internal.h */,
 				93B41CC81F04730500A7F114 /* CBLReplicatorChange+Internal.h */,
 				2753AFF41EC39CA200C12E98 /* CBLWebSocket.mm */,
@@ -1281,6 +1300,8 @@
 				275FF6B71E47B2FC005F90DD /* ExceptionUtils.m */,
 				27B69A121F2A4B7400782145 /* MYAnonymousIdentity.h */,
 				27B69A131F2A4B7400782145 /* MYAnonymousIdentity.m */,
+				9340F9E41F709A6E00C347C4 /* MYBackgroundMonitor.h */,
+				9340F9CE1F709A6E00C347C4 /* MYBackgroundMonitor.m */,
 				934F4BE91E1EF19000F90659 /* MYErrorUtils.h */,
 				934F4BEA1E1EF19000F90659 /* MYErrorUtils.m */,
 				934F4BEB1E1EF19000F90659 /* MYLogging.h */,
@@ -1808,6 +1829,7 @@
 				937F01E71EFB280000060D64 /* CBLAuthenticator+Internal.h in Headers */,
 				93B41CCA1F04730500A7F114 /* CBLReplicatorChange+Internal.h in Headers */,
 				934A27AC1F30E641003946A7 /* CBLParameterExpression.h in Headers */,
+				933FC1791F58EFD6004D0528 /* CBLReplicator+Backgrounding.h in Headers */,
 				938E389E1F3A7A47006806C7 /* CBLCollationExpression.h in Headers */,
 				93B75C1A1E79EF5F0033B61B /* CBLQueryDataSource.h in Headers */,
 				937A69041F0731230058277F /* CBLQueryFunction.h in Headers */,
@@ -1826,6 +1848,7 @@
 			files = (
 				933207AE1E773CFB000D9993 /* CBLJSONCoding.h in Headers */,
 				933208141E77415E000D9993 /* CBLQueryExpression.h in Headers */,
+				933FC1711F58B111004D0528 /* CBLReplicator+Backgrounding.h in Headers */,
 				937A693C1F1065610058277F /* CBLQueryMeta.h in Headers */,
 				9383A5951F1EEFCD0083053D /* CBLQueryResult+Internal.h in Headers */,
 				934A27921F30E5CA003946A7 /* CBLBinaryExpression.h in Headers */,
@@ -2231,6 +2254,13 @@
 			remoteRef = 27F961951ED777EA0060F804 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		9340F9E31F709A6E00C347C4 /* cblite */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = cblite;
+			remoteRef = 9340F9E21F709A6E00C347C4 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		93765EE71EC4C874005E4050 /* litecorelog */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.executable";
@@ -2388,6 +2418,7 @@
 			files = (
 				93B503621E64B073002C4680 /* CBLBlob.mm in Sources */,
 				937F01E41EFB269300060D64 /* CBLAuthenticator.m in Sources */,
+				933FC17A1F58EFD9004D0528 /* CBLReplicator+Backgrounding.m in Sources */,
 				27BE3B561E4E93000012B74A /* PredicateQuery.swift in Sources */,
 				93B503761E64B0B7002C4680 /* CBLBlobStream.mm in Sources */,
 				9380D2711F0D8C1A007DD84A /* CBLQuerySelectResult.m in Sources */,
@@ -2422,6 +2453,7 @@
 				93E17F101ED3BA7800671CA1 /* CBLDocumentChange.m in Sources */,
 				93B503711E64B0A5002C4680 /* CBLParseDate.c in Sources */,
 				934A27A81F30E62F003946A7 /* CBLUnaryExpression.m in Sources */,
+				9340F9E61F709A7300C347C4 /* MYBackgroundMonitor.m in Sources */,
 				9381962C1EC15F430032CC51 /* CBLC4Document.mm in Sources */,
 				93C3984D1EC57688005A7A96 /* CBLQueryEnumerator.mm in Sources */,
 				93B41CB31F04706100A7F114 /* CBLReplicatorChange.m in Sources */,
@@ -2607,6 +2639,7 @@
 				934F4C5B1E1EF25E00F90659 /* Test.m in Sources */,
 				27B69A141F2A4C6D00782145 /* MYAnonymousIdentity.m in Sources */,
 				72A879F01E2DD51C008466FF /* CBLBlob.mm in Sources */,
+				933FC1721F58B111004D0528 /* CBLReplicator+Backgrounding.m in Sources */,
 				934A278E1F30E5A5003946A7 /* CBLAggregateExpression.m in Sources */,
 				934F4CAE1E241FB500F90659 /* CBLJSON.m in Sources */,
 				934F4CB31E241FB500F90659 /* CBLParseDate.c in Sources */,
@@ -2631,6 +2664,7 @@
 				934A279B1F30E5FA003946A7 /* CBLCompoundExpression.m in Sources */,
 				934F4CA81E241FB500F90659 /* CBLBase64.m in Sources */,
 				934A27AD1F30E641003946A7 /* CBLParameterExpression.m in Sources */,
+				9340F9E51F709A7200C347C4 /* MYBackgroundMonitor.m in Sources */,
 				275229C81E776BC100E630FA /* CBLReplicator.mm in Sources */,
 				72A87A061E2E0E70008466FF /* CBLBlobStream.mm in Sources */,
 				93655B7A1EB8F85B00AC7E2A /* CBLFLArray.mm in Sources */,

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -61,7 +61,7 @@ typedef struct {
 @property (readonly, copy, nonatomic) CBLReplicatorConfiguration* config;
 
 /** The replicator's current status: its activity level and progress. Observable. */
-@property (readonly, nonatomic) CBLReplicatorStatus* status;
+@property (atomic, readonly) CBLReplicatorStatus* status;
 
 /** Initializes a replicator with the given configuration. */
 - (instancetype) initWithConfig: (CBLReplicatorConfiguration*)config;

--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -82,6 +82,25 @@ typedef enum {
  */
 @property (nonatomic, nullable) NSArray<NSString*>* documentIDs;
 
+
+#if TARGET_OS_IPHONE
+/**
+ Allows the replicator to run when the app goes into the background.
+ The default value is NO which means that the replicator will suspend itself when the app
+ goes into the background, and will automatically resume when the app is brought into
+ the foreground. The replicator will also resume when the -start method is called; this
+ allows the replicator to be started or run when the app is already in the background.
+ The replicator will suspend itself or stop (for a non-continuous replicator) when the
+ replicator is inactive or the background task is expired.
+ 
+ If the runInBackground property is set to YES, the replicator
+ will allow to continue running in the background without suspension; it is the
+ app's responsibility to manage the replicator running status when the app enters into the
+ background, and comes back to the foreground.
+ */
+@property (nonatomic) BOOL runInBackground;
+#endif
+
 /**
   Creates a CBLReplicatorConfiguration with the given local database and remote database URL.
  */

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -28,6 +28,9 @@
 @synthesize documentIDs=_documentIDs, channels=_channels;
 @synthesize checkpointInterval=_checkpointInterval;
 
+#if TARGET_OS_IPHONE
+@synthesize runInBackground=_runInBackground;
+#endif
 
 + (instancetype) withDatabase: (CBLDatabase*)database targetURL: (NSURL*)targetURL {
     return [[self alloc] initWithDatabase: database targetURL: targetURL];
@@ -74,6 +77,10 @@
     c.documentIDs = _documentIDs;
     c.channels = _channels;
     c.checkpointInterval = _checkpointInterval;
+    
+#if TARGET_OS_IPHONE
+    c.runInBackground = _runInBackground;
+#endif
     return c;
 }
 

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -9,6 +9,7 @@
 #import "CBLReplicator.h"
 #import "CBLReplicatorConfiguration.h"
 #import "c4.h"
+@class MYBackgroundMonitor;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,8 +20,16 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 
-@interface CBLReplicator ()
+@interface CBLReplicator () {
+    BOOL _deepBackground;
+    BOOL _filesystemUnavailable;
+}
 
+@property (nonatomic, readonly) dispatch_queue_t dispatchQueue;
+@property (atomic) CBLReplicatorStatus* status;
+@property (nonatomic) MYBackgroundMonitor* bgMonitor;
+@property (nonatomic, readonly) BOOL isActive;
+@property (nonatomic) BOOL suspended;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
@@ -1,0 +1,27 @@
+//
+//  CBLReplicator+Backgrounding.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 8/31/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#if TARGET_OS_IPHONE
+
+#import <CouchbaseLite/CouchbaseLite.h>
+
+@interface CBLReplicator (Backgrounding)
+
+- (void) setupBackgrounding;
+
+- (void) endBackgrounding;
+
+- (void) okToEndBackgrounding;
+
+- (void) appBackgrounding; // Make the method available for testing
+
+- (void) appForegrounding; // Make the method available for testing
+
+@end
+
+#endif

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
@@ -1,0 +1,123 @@
+//
+//  CBLReplicator+Backgrounding.m
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 8/31/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#if TARGET_OS_IPHONE
+
+#import <UIKit/UIKit.h>
+#import "CBLReplicator+Backgrounding.h"
+#import "CBLReplicator+Internal.h"
+#import "MYBackgroundMonitor.h"
+
+
+@implementation CBLReplicator (Backgrounding)
+
+
+- (void) setupBackgrounding {
+    NSFileProtectionType prot = self.fileProtection;
+    if ([prot isEqual: NSFileProtectionComplete] ||
+       [prot isEqual: NSFileProtectionCompleteUnlessOpen]) {
+        [NSNotificationCenter.defaultCenter addObserver: self
+                                               selector: @selector(fileAccessChanged:)
+                                                   name: UIApplicationProtectedDataWillBecomeUnavailable
+                                                 object: nil];
+        [NSNotificationCenter.defaultCenter addObserver: self
+                                               selector: @selector(fileAccessChanged:)
+                                                   name: UIApplicationProtectedDataDidBecomeAvailable
+                                                 object: nil];
+    }
+    
+    self.bgMonitor = [[MYBackgroundMonitor alloc] init];
+    __weak CBLReplicator* weakSelf = self;
+    self.bgMonitor.onAppBackgrounding = ^{ id strongSelf = weakSelf; [strongSelf appBackgrounding]; };
+    self.bgMonitor.onAppForegrounding = ^{ id strongSelf = weakSelf; [strongSelf appForegrounding]; };
+    self.bgMonitor.onBackgroundTaskExpired = ^{ id strongSelf = weakSelf; [strongSelf backgroundTaskExpired];};
+    [self.bgMonitor start];
+}
+
+
+- (NSFileProtectionType) fileProtection {
+    NSDictionary* attrs = [NSFileManager.defaultManager attributesOfItemAtPath: self.config.database.path error: NULL];
+    return attrs[NSFileProtectionKey] ?: NSFileProtectionNone;
+}
+
+
+- (void) endBackgrounding {
+    [self.bgMonitor stop];
+}
+
+
+// Called when the replicator goes idle
+- (void) okToEndBackgrounding {
+    if ([self.bgMonitor hasBackgroundTask]) {
+        _deepBackground = YES;
+        [self updateSuspended];
+        CBLLog(Sync, @"%@: Now idle; ending background task", self);
+        [self.bgMonitor endBackgroundTask];  // will probably suspend the process immediately
+    }
+}
+
+
+////// All the methods below are called on the MAIN THREAD ////////
+
+
+- (void) appBackgrounding {
+    dispatch_async(self.dispatchQueue, ^{
+        if ([self isActive] && [self.bgMonitor beginBackgroundTaskNamed: self.description]) {
+            CBLLog(Sync, @"%@: App backgrounding; starting temporary background task", self);
+        } else {
+            CBLLog(Sync, @"%@: App backgrounding, but replication is inactive; suspending", self);
+            _deepBackground = YES;
+            [self updateSuspended];
+        }
+    });
+}
+
+
+- (void) appForegrounding {
+    dispatch_async(self.dispatchQueue, ^{
+        BOOL ended = [self.bgMonitor endBackgroundTask];
+        if (ended)
+            CBLLog(Sync, @"%@: App foregrounded, ending background task", self);
+        if (_deepBackground) {
+            _deepBackground = NO;
+            [self updateSuspended];
+        }
+    });
+}
+
+
+- (void) backgroundTaskExpired {
+    dispatch_async(self.dispatchQueue, ^{
+        CBLLog(Sync, @"%@: Background task time expired!", self);
+        _deepBackground = YES;
+        [self updateSuspended];
+    });
+}
+
+
+// Called when the app is about to lose access to files:
+- (void) fileAccessChanged: (NSNotification*)n {
+    dispatch_async(self.dispatchQueue, ^{
+        CBLLog(Sync, @"%@: Device locked, database unavailable", self);
+        _filesystemUnavailable = [n.name isEqual: UIApplicationProtectedDataWillBecomeUnavailable];
+        [self updateSuspended];
+    });
+
+}
+
+
+- (void) updateSuspended {
+    BOOL suspended = (_filesystemUnavailable || _deepBackground);
+    self.suspended = suspended;
+}
+
+
+@end
+
+
+#endif // TARGET_OS_IPHONE

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
@@ -47,6 +47,12 @@
 
 
 - (void) endBackgrounding {
+    [NSNotificationCenter.defaultCenter removeObserver: self
+                                                  name: UIApplicationProtectedDataWillBecomeUnavailable
+                                                object: nil];
+    [NSNotificationCenter.defaultCenter removeObserver: self
+                                                  name: UIApplicationProtectedDataDidBecomeAvailable
+                                                object: nil];
     [self.bgMonitor stop];
 }
 

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -8,6 +8,7 @@
 
 #import "CBLTestCase.h"
 #import "CBLReplicator+Internal.h"
+#import "CBLReplicator+Backgrounding.h"
 #import "ConflictTest.h"
 
 
@@ -331,6 +332,156 @@
 }
 
 
+#if TARGET_OS_IPHONE
+
+
+- (void) testSwitchBackgroundForeground {
+    CBLReplicatorConfiguration* config = [self configForPush: YES pull: YES continuous: YES];
+    CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
+    
+    static NSInteger numRounds = 10;
+    
+    NSMutableArray* foregroundExps = [NSMutableArray arrayWithCapacity: numRounds + 1];
+    NSMutableArray* backgroundExps = [NSMutableArray arrayWithCapacity: numRounds];
+    for (NSInteger i = 0; i < numRounds; i++) {
+        [foregroundExps addObject: [self expectationWithDescription: @"Foregrounding"]];
+        [backgroundExps addObject: [self expectationWithDescription: @"Backgrounding"]];
+    }
+    [foregroundExps addObject: [self expectationWithDescription: @"Foregrounding"]];
+    
+    __block NSInteger backgroundCount = 0;
+    __block NSInteger foregroundCount = 0;
+    
+    XCTestExpectation* stopped = [self expectationWithDescription: @"Stopped"];
+    
+    id listener = [r addChangeListener: ^(CBLReplicatorChange* change) {
+        AssertNil(change.status.error);
+        if (change.status.activity == kCBLReplicatorBusy) {
+            [foregroundExps[foregroundCount++] fulfill];
+        } else if (change.status.activity == kCBLReplicatorOffline) {
+            [backgroundExps[backgroundCount++] fulfill];
+        } else if (change.status.activity == kCBLReplicatorStopped) {
+            [stopped fulfill];
+        }
+    }];
+    
+    [r start];
+    [self waitForExpectations: @[foregroundExps[0]] timeout: 5.0];
+    
+    for (int i = 0; i < numRounds; i++) {
+        [r appBackgrounding];
+        [self waitForExpectations: @[backgroundExps[i]] timeout: 5.0];
+        
+        [r appForegrounding];
+        [self waitForExpectations: @[foregroundExps[i+1]] timeout: 5.0];
+    }
+    
+    [r stop];
+    [self waitForExpectations: @[stopped] timeout: 5.0];
+    
+    AssertEqual(foregroundCount, numRounds + 1);
+    AssertEqual(backgroundCount, numRounds);
+    
+    [r removeChangeListener: listener];
+    r = nil;
+}
+
+
+- (void) testFastSwitchBackgroundForeground {
+    CBLReplicatorConfiguration* config = [self configForPush: YES pull: YES continuous: YES];
+    CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
+    
+    __block NSInteger backgroundCount = 0;
+    __block NSInteger foregroundCount = 0;
+    
+    XCTestExpectation* stopped = [self expectationWithDescription: @"Stopped"];
+    XCTestExpectation* done = [self expectationWithDescription: @"Done"];
+    
+    id listener = [r addChangeListener: ^(CBLReplicatorChange* change) {
+        AssertNil(change.status.error);
+        if (change.status.activity == kCBLReplicatorIdle) {
+            foregroundCount++;
+        } else if (change.status.activity == kCBLReplicatorOffline) {
+            backgroundCount++;
+        } else if (change.status.activity == kCBLReplicatorStopped) {
+            [stopped fulfill];
+        }
+    }];
+    
+    [r start];
+    
+    for (int i = 0; i < 10; i++) {
+        [r appBackgrounding];
+        [r appForegrounding];
+    }
+    
+    id block = [NSBlockOperation blockOperationWithBlock: ^{ [done fulfill]; }];
+    [NSTimer scheduledTimerWithTimeInterval: 0.3
+                                     target: block
+                                   selector: @selector(main) userInfo: nil repeats: NO];
+    [self waitForExpectations: @[done] timeout: 1.0];
+    
+    Assert(r.status.activity == kCBLReplicatorIdle);
+    
+    [r stop];
+    [self waitForExpectations: @[stopped] timeout: 5.0];
+    
+    [r removeChangeListener: listener];
+    r = nil;
+}
+
+
+- (void) testBackgroundingWhenStopping {
+    CBLReplicatorConfiguration* config = [self configForPush: YES pull: YES continuous: YES];
+    CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
+    
+    __block BOOL foregrounding = NO;
+    
+    XCTestExpectation* idle = [self expectationWithDescription: @"Idle after starting"];
+    XCTestExpectation* stopped = [self expectationWithDescription: @"Stopped"];
+    XCTestExpectation* done = [self expectationWithDescription: @"Done"];
+    
+    id listener = [r addChangeListener: ^(CBLReplicatorChange* change) {
+        Assert(!foregrounding);
+        AssertNil(change.status.error);
+        Assert(change.status.activity != kCBLReplicatorOffline);
+        
+        if (change.status.activity == kCBLReplicatorIdle) {
+            [idle fulfill];
+        } else if (change.status.activity == kCBLReplicatorStopped) {
+            [stopped fulfill];
+        }
+    }];
+    
+    [r start];
+    [self waitForExpectations: @[idle] timeout: 5.0];
+    
+    [r stop];
+    
+    // This shouldn't prevent the replicator to stop:
+    [r appBackgrounding];
+    [self waitForExpectations: @[stopped] timeout: 5.0];
+    
+    // This shouldn't wake up the replicator:
+    foregrounding = YES;
+    [r appForegrounding];
+    
+    // Wait for 0.3 seconds to ensure no more changes notified and cause !foregrounding to fail:
+    id block = [NSBlockOperation blockOperationWithBlock: ^{ [done fulfill]; }];
+    [NSTimer scheduledTimerWithTimeInterval: 0.3
+                                     target: block
+                                   selector: @selector(main) userInfo: nil repeats: NO];
+    [self waitForExpectations: @[done] timeout: 1.0];
+    
+    [r removeChangeListener: listener];
+    r = nil;
+}
+
+
+#endif
+
+
+>>>>>>> Implement replicator backgrounding option
 // These test are disabled because they require a password-protected database 'seekrit' to exist
 // on localhost:4984, with a user 'pupshaw' whose password is 'frank'.
 

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -356,7 +356,7 @@
     
     id listener = [r addChangeListener: ^(CBLReplicatorChange* change) {
         AssertNil(change.status.error);
-        if (change.status.activity == kCBLReplicatorBusy) {
+        if (change.status.activity == kCBLReplicatorIdle) {
             [foregroundExps[foregroundCount++] fulfill];
         } else if (change.status.activity == kCBLReplicatorOffline) {
             [backgroundExps[backgroundCount++] fulfill];

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -67,6 +67,7 @@ public final class Replicator {
     /// - Parameter config: The configuration.
     public init(config: ReplicatorConfiguration) {
         let c: CBLReplicatorConfiguration;
+        
         if let url = config.target as? URL {
             c = CBLReplicatorConfiguration(database: config.database._impl, targetURL: url)
         } else {
@@ -83,6 +84,10 @@ public final class Replicator {
         c.channels = config.channels
         c.documentIDs = config.documentIDs
         
+        #if os(iOS)
+        c.runInBackground = config.runInBackground
+        #endif
+        
         _impl = CBLReplicator(config: c);
         _config = config
     }
@@ -92,7 +97,6 @@ public final class Replicator {
     public var config: ReplicatorConfiguration {
         return _config
     }
-    
     
     
     /// The replicator's current status: its activity level and progress. Observable.

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -64,6 +64,23 @@ public struct ReplicatorConfiguration {
     /// and/or pulled.
     public var documentIDs: [String]?
     
+    #if os(iOS)
+    /// Allows the replicator to run when the app goes into the background.
+    /// The default value is NO which means that the replicator will suspend itself when the app
+    /// goes into the background, and will automatically resume when the app is brought into
+    /// the foreground. The replicator will also resume when the -start method is called; this
+    /// allows the replicator to be started or run when the app is already in the background.
+    /// The replicator will suspend itself or stop (for a non-continuous replicator) when the
+    /// replicator is inactive or the background task is expired.
+    ///
+    /// If the runInBackground property is set to YES, the replicator
+    /// will allow to continue running in the background without suspension; it is the
+    /// app's responsibility to manage the replicator running status when the app enters into the
+    /// background, and comes back to the foreground.
+    public var runInBackground: Bool
+    #endif
+    ///
+    
     /// Initialize a ReplicatorConfiguration with the given local database and remote database URL.
     ///
     /// - Parameters:
@@ -74,6 +91,10 @@ public struct ReplicatorConfiguration {
         self.target = targetURL
         self.replicatorType = .pushAndPull
         self.continuous = false
+        
+        #if os(iOS)
+        self.runInBackground = false
+        #endif
     }
     
     
@@ -87,6 +108,10 @@ public struct ReplicatorConfiguration {
         self.target = targetDatabase
         self.replicatorType = .pushAndPull
         self.continuous = false
+        
+        #if os(iOS)
+        self.runInBackground = false
+        #endif
     }
 }
 


### PR DESCRIPTION
* Add runInBackground option to the ReplicatorConfiguration. The default value is NO.

* When runInBackground is not enabled, the replicator will be suspended or stopped if the replicator is not continuous after it becomes inactive.

* When runInBackground is enabled, the replicator will not continue to run in the background and it’s application’s responsibility to manage the background task.

* Created a new serial queue for replicator instead of using main queue; the notification is still posted on the main queue.

* Made start / stop running inside the replicator dispatch queue.

* MYBackgroundMonitor is not compiled on XCode9; wait for https://github.com/snej/MYUtilities/pull/16 to be merged.