### PR TITLE
Fixed #1758 Updated designed doc’s map function not get re-compiled

### DIFF
--- a/Source/API/CBLView.m
+++ b/Source/API/CBLView.m
@@ -92,7 +92,7 @@ NSString* const kCBLViewChangeNotification = @"CBLViewChange";
 }
 
 
-@synthesize name=_name, storage=_storage, collation=_collation;
+@synthesize name=_name, storage=_storage, collation=_collation, isDesignDoc=_isDesignDoc;
 
 
 - (NSString*) description {
@@ -153,9 +153,11 @@ NSString* const kCBLViewChangeNotification = @"CBLViewChange";
 - (CBLMapBlock) mapBlock {
     CBLMapBlock map = self.registeredMapBlock;
     // Invoke view compiler if it's available:
-    if (!map && [self respondsToSelector: @selector(compileFromDesignDoc)])
+    if (self.isDesignDoc ||
+        (!map && [self respondsToSelector: @selector(compileFromDesignDoc)])) {
         if ([self compileFromDesignDoc] == kCBLStatusOK)
             map = self.registeredMapBlock;
+    }
     return map;
 }
 

--- a/Source/CBLView+Internal.h
+++ b/Source/CBLView+Internal.h
@@ -53,6 +53,8 @@ BOOL CBLQueryRowValueIsEntireDoc(id value);
 
 @property (readonly) NSArray* viewsInGroup;
 
+@property (nonatomic) BOOL isDesignDoc;
+
 /** Updates the view's index (incrementally) if necessary.
     If the index is updated, the other views in the viewGroup will be updated as a bonus.
     @return  200 if updated, 304 if already up-to-date, else an error code */

--- a/Source/CBLView+REST.m
+++ b/Source/CBLView+REST.m
@@ -16,16 +16,18 @@
 
 
 - (CBLStatus) compileFromDesignDoc {
-    if (self.registeredMapBlock != nil)
-        return kCBLStatusOK;
-
     // see if there's a design doc with a CouchDB-style view definition we can compile:
     NSString* language;
     NSDictionary* viewProps = $castIf(NSDictionary, [self.database getDesignDocFunction: self.name
                                                                                     key: @"views"
                                                                                language: &language]);
-    if (!viewProps)
-        return kCBLStatusNotFound;
+    if (!viewProps) {
+        if (self.registeredMapBlock != nil)
+            return kCBLStatusOK;
+        else
+            return kCBLStatusNotFound;
+    }
+    
     LogTo(View, @"%@: Attempting to compile %@ from design doc", self.name, language);
     if (![CBLView compiler])
         return kCBLStatusNotImplemented;
@@ -34,6 +36,15 @@
 
 
 - (CBLStatus) compileFromProperties: (NSDictionary*)viewProps language: (NSString*)language {
+    // Version string is based on a digest of the properties:
+    NSError* error;
+    NSString* version = CBLHexSHA1Digest([CBJSONEncoder canonicalEncoding: viewProps error: &error]);
+    if (!version)
+        Warn(@"View %@ could not generate version string from the view properties: %@", self, error);
+    
+    if ([version isEqualToString: self.mapVersion])
+        return kCBLStatusOK; // Same as the current version
+    
     if (!language)
         language = @"javascript";
     NSString* mapSource = viewProps[@"map"];
@@ -53,10 +64,7 @@
             return kCBLStatusCallbackError;
         }
     }
-
-    // Version string is based on a digest of the properties:
-    NSError* error;
-    NSString* version = CBLHexSHA1Digest([CBJSONEncoder canonicalEncoding: viewProps error: &error]);
+    
     [self setMapBlock: mapBlock reduceBlock: reduceBlock version: version];
 
     self.documentType = $castIf(NSString, viewProps[@"documentType"]);

--- a/Source/CBLView+REST.m
+++ b/Source/CBLView+REST.m
@@ -16,17 +16,16 @@
 
 
 - (CBLStatus) compileFromDesignDoc {
+    if (!self.isDesignDoc && self.registeredMapBlock) /* Native design doc like view */
+        return kCBLStatusOK;
+    
     // see if there's a design doc with a CouchDB-style view definition we can compile:
     NSString* language;
     NSDictionary* viewProps = $castIf(NSDictionary, [self.database getDesignDocFunction: self.name
                                                                                     key: @"views"
                                                                                language: &language]);
-    if (!viewProps) {
-        if (self.registeredMapBlock != nil)
-            return kCBLStatusOK;
-        else
-            return kCBLStatusNotFound;
-    }
+    if (!viewProps)
+        return kCBLStatusNotFound;
     
     LogTo(View, @"%@: Attempting to compile %@ from design doc", self.name, language);
     if (![CBLView compiler])
@@ -71,6 +70,10 @@
     NSDictionary* options = $castIf(NSDictionary, viewProps[@"options"]);
     self.collation = ($equal(options[@"collation"], @"raw")) ? kCBLViewCollationRaw
                                                              : kCBLViewCollationUnicode;
+    
+    // Mark as a design doc view:
+    self.isDesignDoc = YES;
+    
     return kCBLStatusOK;
 }
 

--- a/Unit-Tests/Router_Tests.m
+++ b/Unit-Tests/Router_Tests.m
@@ -586,8 +586,6 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
                 }
           }, kCBLStatusCreated, nil);
     
-    NSLog(@"%@", result);
-    
     // Query view and check the result:
     id null = [NSNull null];
     Send(self, @"GET", @"/db/_design/design/_view/view", kCBLStatusOK,


### PR DESCRIPTION
If view’s properties is not nil, always compare the version (SHA1 hash of the new view’s properties) whether it is the same as the current version or not. If version is not the same, recompile the map/reduce fn and re-register the map/reduce fn.

#1758