### PR TITLE
Fixed #1757 setting cookie in header could not be effective

### DIFF
--- a/Source/CBLCookieStorage.h
+++ b/Source/CBLCookieStorage.h
@@ -56,4 +56,6 @@ extern NSString* const CBLCookieStorageCookiesChangedNotification;
 
 - (void) setCookieFromResponse: (NSHTTPURLResponse*)response;
 
+- (void) setCookieFromString: (NSString*)string forURL: (NSURL*)url;
+
 @end

--- a/Source/CBLCookieStorage.m
+++ b/Source/CBLCookieStorage.m
@@ -467,4 +467,12 @@ NSString* const CBLCookieStorageCookiesChangedNotification = @"CookieStorageCook
         [self setCookie: cookie];
 }
 
+- (void) setCookieFromString: (NSString*)string forURL: (NSURL*)url {
+    NSDictionary* header = @{@"Set-Cookie": string};
+    NSArray* cookies = [NSHTTPCookie cookiesWithResponseHeaderFields: header
+                                                              forURL: url];
+    for (NSHTTPCookie* cookie in cookies)
+        [self setCookie: cookie];
+}
+
 @end

--- a/Source/CBLRemoteRequest.m
+++ b/Source/CBLRemoteRequest.m
@@ -115,9 +115,8 @@ typedef enum {
 - (void) setCookieStorage:(CBLCookieStorage *)cookieStorage {
     if (_cookieStorage != cookieStorage) {
         _cookieStorage = cookieStorage;
-        // Let the cookie storage add a Cookie: header, unless the app has specified its own cookes:
-        if (![_request valueForHTTPHeaderField: @"Cookie"])
-            [_cookieStorage addCookieHeaderToRequest: _request];
+        // Let the cookie storage add a Cookie header:
+        [_cookieStorage addCookieHeaderToRequest: _request];
     }
 }
 

--- a/Source/CBLRestReplicator.m
+++ b/Source/CBLRestReplicator.m
@@ -290,7 +290,16 @@ static NSString* const kSyncGatewayServerHeaderPrefix = @"Couchbase Sync Gateway
     config.allowsCellularAccess = _settings.canUseCellNetwork;
     NSMutableDictionary* headers = _settings.requestHeaders.mutableCopy;
     if (headers) {
-        if( config.HTTPAdditionalHeaders)
+        if (headers[@"Cookie"]) {
+            // https://github.com/couchbase/couchbase-lite-ios/issues/1757:
+            // Put the cookie in the cookie storage; the same cookie in the
+            // cookie storagte will be overwritten if they are matched:
+            [db.cookieStorage setCookieFromString: headers[@"Cookie"]
+                                           forURL: _settings.remote];
+            [headers removeObjectForKey: @"Cookie"];
+        }
+        
+        if (config.HTTPAdditionalHeaders)
             [headers addEntriesFromDictionary: config.HTTPAdditionalHeaders];
         config.HTTPAdditionalHeaders = headers;
     }

--- a/Source/ChangeTracker/CBLChangeTracker.m
+++ b/Source/ChangeTracker/CBLChangeTracker.m
@@ -225,15 +225,11 @@ DefineLogDomain(ChangeTracker);
 
         // Add headers from my .requestHeaders property:
         [self.requestHeaders enumerateKeysAndObjectsUsingBlock: ^(id key, id value, BOOL *stop) {
-            if ([key caseInsensitiveCompare: @"Cookie"] == 0)
-                urlRequest.HTTPShouldHandleCookies = NO;
             [urlRequest setValue: value forHTTPHeaderField: key];
         }];
         
-        if (urlRequest.HTTPShouldHandleCookies) {
-            [self.cookieStorage addCookieHeaderToRequest: urlRequest];
-        }
-
+        [self.cookieStorage addCookieHeaderToRequest: urlRequest];
+        
         // Let the Authorizer add its own headers:
         [$castIfProtocol(CBLCustomHeadersAuthorizer, _authorizer) authorizeURLRequest: urlRequest];
 


### PR DESCRIPTION
Problem:

* We set all CBLReplicator.headers to the NSURLSessionConfiguration.HTTPAdditionalHeaders so that the headers will be automatically set to the NSURLRequest. However if the HTTPAdditionalHeaders  contains Cookie and there is already cookies set the the NSURLRequest by the cookie storage, the Cookie in the HTTPAdditionalHeaders will be ignored.

* SGW has a feature to auto-refresh the session before the session gets expired. The new session cookie will be sent to the Replicator vis the NSURLResponse and will be saved into the cookie storage. When the refresh happens, the cookie originally set in the HTTPAdditionalHeaders will be ignore. However the new cookie set to the header after restarting the SGW will be ignore too.  (#1757 and #1715)

Solution:

When starting the replicator, transfer Cookie set in the CBLReplicator.headers to the cookie storage. This allows the Cookie set in the header to replace the Cookie in the storage if they are matched. This also simplify the logic to have only one single source of the cookies.