### PR TITLE
Fixed #1750 REST returns code when getting deleted doc with revid

### DIFF
--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -618,9 +618,15 @@ static NSArray* parseJSONRevArrayQuery(NSString* queryStr) {
             if (rev)
                 rev = [self applyOptions: options toRevision: rev status: &status];
             if (!rev) {
-                if (status == kCBLStatusDeleted)
-                    _response.statusReason = @"deleted";
-                else
+                if (status == kCBLStatusDeleted) {
+                    if (revID) {
+                        status = kCBLStatusOK;
+                        _response.bodyObject = $dict({@"_id", docID},
+                                                     {@"_rev", revID.asString},
+                                                     {@"_deleted", $true});
+                    } else
+                        _response.statusReason = @"deleted";
+                } else
                     _response.statusReason = @"missing";
                 return status;
             }

--- a/Unit-Tests/Router_Tests.m
+++ b/Unit-Tests/Router_Tests.m
@@ -261,12 +261,23 @@ static void CheckCacheable(Router_Tests* self, NSString* path) {
     
     // Delete doc:
     result = Send(self, @"DELETE", $sprintf(@"/db/doc1?rev=%@", revID), kCBLStatusOK, nil);
-    Assert([result[@"rev"] hasPrefix: @"2-"]);
+    NSString* newRevID = result[@"rev"];
+    Assert([newRevID hasPrefix: @"2-"]);
     
     // Get the deletes doc:
     Send(self, @"GET", @"/db/doc1", kCBLStatusDeleted, $dict({@"error", @"not_found"},
                                                              {@"reason", @"deleted"},
                                                              {@"status", @(404)}));
+    
+    // Get the deletes doc with previous revision id:
+    Send(self, @"GET", $sprintf(@"/db/doc1?rev=%@", revID), kCBLStatusOK, $dict({@"_id", @"doc1"},
+                                                                                {@"_rev", revID},
+                                                                                {@"foo", @"bar"}));
+    
+    // Get the deletes doc with the new revision id:
+    Send(self, @"GET", $sprintf(@"/db/doc1?rev=%@", newRevID), kCBLStatusOK, $dict({@"_id", @"doc1"},
+                                                                                {@"_rev", newRevID},
+                                                                                {@"_deleted", $true}));
 }
 
 


### PR DESCRIPTION
When getting a deleted doc with revid, need to return status OK with doc info and _deleted = true.

#1750