### PR TITLE
Fixed #1918: Skip the removal rev when getting ancestor rev ids

### DIFF
--- a/Source/CBLBulkDownloader.m
+++ b/Source/CBLBulkDownloader.m
@@ -54,7 +54,8 @@
         NSArray<CBL_RevID*>* possibleAncestors;
         possibleAncestors = [database.storage getPossibleAncestorRevisionIDs: rev
                                                        limit: kMaxNumberOfAttsSince
-                                                  haveBodies: (attachments ? &haveBodies : NULL)];
+                                                  haveBodies: (attachments ? &haveBodies : NULL)
+                                              withBodiesOnly: attachments];
         NSMutableDictionary* key = $mdict({@"id",  rev.docID},
                                           {@"rev", rev.revIDString});
         if (possibleAncestors) {

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -678,7 +678,8 @@ static BOOL sAutoCompact = YES;
         return @[revID];  // Already have it!
     return [_storage getPossibleAncestorRevisionIDs: rev
                                               limit: (unsigned)limit
-                                         haveBodies: NULL];
+                                         haveBodies: NULL
+                                     withBodiesOnly: NO];
 }
 
 

--- a/Source/CBLRestPuller.m
+++ b/Source/CBLRestPuller.m
@@ -425,7 +425,8 @@
     NSArray<CBL_RevID*>* possibleAncestors;
     possibleAncestors = [db.storage getPossibleAncestorRevisionIDs: rev
                                                          limit: kMaxNumberOfAttsSince
-                                                    haveBodies: (attachments ? &haveBodies : NULL)];
+                                                    haveBodies: (attachments ? &haveBodies : NULL)
+                                                withBodiesOnly: attachments];
     if (possibleAncestors) {
         [path appendString: (haveBodies ? @"&atts_since=" : @"&revs_from=")];
         [path appendString: escapedRevIDArray(possibleAncestors)];

--- a/Source/CBL_Router+Handlers.m
+++ b/Source/CBL_Router+Handlers.m
@@ -378,7 +378,8 @@
         CBL_Revision* rev = [[CBL_Revision alloc] initWithDocID: docID revID: maxRevID deleted: NO];
         NSArray<CBL_RevID*>* ancestors = [_db.storage getPossibleAncestorRevisionIDs: rev
                                                                                limit: 0
-                                                                          haveBodies: NULL];
+                                                                          haveBodies: NULL
+                                                                      withBodiesOnly: NO];
         if (ancestors.count > 0)
             docInfo[@"possible_ancestors"] = [ancestors my_map:^id(CBL_RevID* rev) {
                 return rev.asString;

--- a/Source/CBL_Storage.h
+++ b/Source/CBL_Storage.h
@@ -126,10 +126,12 @@
     @param limit  The maximum number of results to return, or if 0, unlimited.
     @param outHaveBodies  On return, if not NULL, then *outHaveBodies will be YES if all the
                           revisions returned have their JSON bodies available, otherwise NO.
+    @param withBodiesOnly  Specifies whether or not to search for non-empty and non-removed revisions.
     @return  An array of revIDs of existing revisions that could be ancestors of `rev`. */
 - (NSArray<CBL_RevID*>*) getPossibleAncestorRevisionIDs: (CBL_Revision*)rev
                                                   limit: (unsigned)limit
-                                             haveBodies: (BOOL*)outHaveBodies;
+                                             haveBodies: (BOOL*)outHaveBodies
+                                         withBodiesOnly: (BOOL)withBodiesOnly;
 
 /** Returns the most recent member of revIDs that appears in rev's ancestry.
     In other words: Look at the revID properties of rev, its parent, grandparent, etc.

--- a/Unit-Tests/DatabaseInternal_Tests.m
+++ b/Unit-Tests/DatabaseInternal_Tests.m
@@ -1196,6 +1196,10 @@ static CBLDatabaseChange* announcement(CBLDatabase* db, CBL_Revision* rev, CBL_R
                 (@[r3.revID, r2.revID, r1.revID]));
     AssertEqual([db.storage getPossibleAncestorRevisionIDs: revToFind limit: 0 haveBodies: &haveBodies withBodiesOnly: YES],
                 (@[r2.revID, r1.revID]));
+    AssertEqual([db.storage getPossibleAncestorRevisionIDs: revToFind limit: 0 haveBodies: NULL withBodiesOnly: NO],
+                (@[r3.revID, r2.revID, r1.revID]));
+    AssertEqual([db.storage getPossibleAncestorRevisionIDs: revToFind limit: 0 haveBodies: NULL withBodiesOnly: YES],
+                (@[r2.revID, r1.revID]));
 }
 
 


### PR DESCRIPTION
This logic is ported from .NET (https://github.com/couchbase/couchbase-lite-net/commit/07c1374d373b4d0ce8a4bedb640294aeec232d71) to fix channel removal potentially disrupts attachments issue (#1918)

The following code are slightly different from .NET:

https://github.com/couchbase/couchbase-lite-ios/blob/2c86216a1f8e921b1e9cc1a1bacf652d11903dd9/Source/CBLBulkDownloader.m#L58 (.NET always true)

https://github.com/couchbase/couchbase-lite-ios/blob/2c86216a1f8e921b1e9cc1a1bacf652d11903dd9/Source/CBLRestPuller.m#L429 (.NET always true)

https://github.com/couchbase/couchbase-lite-ios/blob/2c86216a1f8e921b1e9cc1a1bacf652d11903dd9/Source/CBL_ForestDBStorage.mm#L459-L465 (.NET doesn't load the revision body).