### PR TITLE
Reimplemented fragments to be more lightweight

### DIFF
--- a/Objective-C/CBLArray.h
+++ b/Objective-C/CBLArray.h
@@ -351,7 +351,7 @@ NS_ASSUME_NONNULL_BEGIN
                the CBLFragment will represent a nil value.
  @return The CBLFragment object.
  */
-- (CBLFragment*) objectAtIndexedSubscript: (NSUInteger)index;
+- (nullable CBLFragment*) objectAtIndexedSubscript: (NSUInteger)index;
 
 @end
 

--- a/Objective-C/CBLArray.m
+++ b/Objective-C/CBLArray.m
@@ -412,8 +412,9 @@
 
 
 - (CBLFragment*) objectAtIndexedSubscript: (NSUInteger)index {
-    id value = index < self.count ? [self objectAtIndex: index] : nil;
-    return [[CBLFragment alloc] initWithValue: value parent: self parentKey: @(index)];
+    if (index >= self.count)
+        return nil;
+    return [[CBLFragment alloc] initWithParent: self index: index];
 }
 
 

--- a/Objective-C/CBLArrayFragment.h
+++ b/Objective-C/CBLArrayFragment.h
@@ -9,6 +9,8 @@
 #import "CBLReadOnlyArrayFragment.h"
 @class CBLFragment;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** CBLArrayFragment protocol provides subscript access to CBLFragment objects by index. */
 @protocol CBLArrayFragment <CBLReadOnlyArrayFragment>
 
@@ -18,6 +20,8 @@
  @param index The index.
  @return The CBLFragment object.
  */
-- (CBLFragment*) objectAtIndexedSubscript: (NSUInteger)index;
+- (nullable CBLFragment*) objectAtIndexedSubscript: (NSUInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/CBLDictionary.h
+++ b/Objective-C/CBLDictionary.h
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param key The key.
  @return The CBLFragment object.
  */
-- (CBLFragment*) objectForKeyedSubscript: (NSString*)key;
+- (nullable CBLFragment*) objectForKeyedSubscript: (NSString*)key;
 
 @end
 

--- a/Objective-C/CBLDictionary.mm
+++ b/Objective-C/CBLDictionary.mm
@@ -332,8 +332,7 @@
 
 
 - (CBLFragment*) objectForKeyedSubscript: (NSString*)key {
-    id value = [self objectForKey: key];
-    return [[CBLFragment alloc] initWithValue: value parent: self parentKey: key];
+    return [[CBLFragment alloc] initWithParent: self key: key];
 }
 
 

--- a/Objective-C/CBLDictionaryFragment.h
+++ b/Objective-C/CBLDictionaryFragment.h
@@ -10,6 +10,8 @@
 #import "CBLReadOnlyDictionaryFragment.h"
 @class CBLFragment;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** 
  CBLDictionaryFragment protocol provides subscript access to CBLFragment objects by key. 
  */
@@ -21,7 +23,8 @@
  @param key The key.
  @return The CBLFragment object.
  */
-- (CBLFragment*) objectForKeyedSubscript: (NSString*)key;
+- (nullable CBLFragment*) objectForKeyedSubscript: (NSString*)key;
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Objective-C/CBLDocumentFragment.m
+++ b/Objective-C/CBLDocumentFragment.m
@@ -34,7 +34,7 @@
 
 
 - (CBLFragment*) objectForKeyedSubscript: (NSString*)key {
-    return _doc ? _doc[key] : [[CBLFragment alloc] initWithValue: nil parent: nil parentKey: nil];
+    return _doc ? _doc[key] : nil;
 }
 
 

--- a/Objective-C/CBLFragment.m
+++ b/Objective-C/CBLFragment.m
@@ -7,132 +7,17 @@
 //
 
 #import "CBLFragment.h"
-#import "CBLData.h"
 #import "CBLDocument+Internal.h"
-#import "CBLJSON.h"
-
-@implementation CBLFragment {
-    id _value;
-    id _parent;
-    id _parentKey;
-    NSUInteger _index;
-}
 
 
-- /* internal */ (instancetype) initWithValue: (id)value parent: (id)parent parentKey: (id)parentKey {
-    self = [super initWithValue: value];
-    if (self) {
-        _value = value;
-        _parent = parent;
-        _parentKey = parentKey;
-    }
-    return self;
-}
-
-
-#pragma mark - SUBSCRIPTING
-
-
-- (CBLFragment*) objectForKeyedSubscript: (NSString*)key {
-    if ([_value conformsToProtocol: @protocol(CBLDictionary)])
-        return [_value objectForKeyedSubscript: key];
-    return [[CBLFragment alloc] initWithValue: nil parent: nil parentKey: nil];
-}
-
-
-- (CBLFragment*) objectAtIndexedSubscript: (NSUInteger)index {
-    if ([_value conformsToProtocol: @protocol(CBLArray)])
-        return [_value objectAtIndexedSubscript: index];
-    return [[CBLFragment alloc] initWithValue: nil parent: nil parentKey: nil];
-}
-
-
-#pragma mark - SET
+@implementation CBLFragment
 
 
 - (void) setValue: (NSObject*)value {
-    if ([_parent conformsToProtocol: @protocol(CBLDictionary)]) {
-        NSString* key = (NSString*)_parentKey;
-        [_parent setObject: value forKey: key];
-        _value = [_parent objectForKey: key];
-    } else if ([_parent conformsToProtocol: @protocol(CBLArray)]) {
-        NSInteger index = [_parentKey integerValue];
-        if (index >= 0 && (NSUInteger)index < ((CBLArray*)_parent).count) {
-            [_parent setObject: value atIndex: index];
-            _value = [_parent objectAtIndex: index];
-        }
-    }
-}
-
-
-#pragma mark - GET
-
-
-- (NSInteger) integerValue {
-    return [$castIf(NSNumber, _value) integerValue];
-}
-
-
-- (float) floatValue {
-    return [$castIf(NSNumber, _value) floatValue];
-}
-
-
-- (double) doubleValue {
-    return [$castIf(NSNumber, _value) doubleValue];
-}
-
-
-- (BOOL) booleanValue {
-    return [CBLData booleanValueForObject: _value];
-}
-
-
-- (NSObject*) object {
-    return _value;
-}
-
-
-- (NSString*) string {
-    return $castIf(NSString, _value);
-}
-
-
-- (NSNumber*) number {
-    return $castIf(NSNumber, _value);
-}
-
-
-- (NSDate*) date {
-    return [CBLJSON dateWithJSONObject: self.string];
-}
-
-
-- (CBLBlob*) blob {
-    return $castIf(CBLBlob, _value);
-}
-
-
-- (CBLArray*) array {
-    return $castIf(CBLArray, _value);
-}
-
-
-- (CBLDictionary*) dictionary {
-    return $castIf(CBLDictionary, _value);
-}
-
-
-- (NSObject*) value {
-    return _value;
-}
-
-
-#pragma mark - EXISTENCE
-
-
-- (BOOL) exists {
-    return _value != nil;
+    if (_key)
+        [_parent setObject: value forKey: _key];
+    else
+        [_parent setObject: value atIndex: _index];
 }
 
 

--- a/Objective-C/CBLQueryResult.mm
+++ b/Objective-C/CBLQueryResult.mm
@@ -113,8 +113,9 @@
 
 
 - (CBLReadOnlyFragment*) objectAtIndexedSubscript: (NSUInteger)index {
-    id value = index < self.count ? [self fleeceValueToObjectAtIndex: index] : nil;
-    return [[CBLReadOnlyFragment alloc] initWithValue: value];
+    if (index >= self.count)
+        return nil;
+    return [[CBLReadOnlyFragment alloc] initWithParent: self index: index];
 }
 
 

--- a/Objective-C/CBLReadOnlyArray.mm
+++ b/Objective-C/CBLReadOnlyArray.mm
@@ -152,8 +152,9 @@
 
 
 - (CBLReadOnlyFragment*) objectAtIndexedSubscript: (NSUInteger)index {
-    id value = index < self.count ? [self fleeceValueToObjectAtIndex: index] : nil;
-    return [[CBLReadOnlyFragment alloc] initWithValue: value];
+    if (index >= self.count)
+        return nil;
+    return [[CBLReadOnlyFragment alloc] initWithParent: self index: index];
 }
 
 

--- a/Objective-C/CBLReadOnlyArrayFragment.h
+++ b/Objective-C/CBLReadOnlyArrayFragment.h
@@ -8,6 +8,8 @@
 
 @class CBLReadOnlyFragment;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** 
  CBLReadOnlyArrayFragment protocol provides subscript access to CBLReadOnlyFragment
  objects by index. 
@@ -20,6 +22,9 @@
  @param index The index.
  @return The CBLReadOnlyFragment object.
  */
-- (CBLReadOnlyFragment*) objectAtIndexedSubscript: (NSUInteger)index;
+- (nullable CBLReadOnlyFragment*) objectAtIndexedSubscript: (NSUInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/Objective-C/CBLReadOnlyDictionary.mm
+++ b/Objective-C/CBLReadOnlyDictionary.mm
@@ -117,8 +117,7 @@
 
 
 - (BOOL) containsObjectForKey: (NSString*)key {
-    FLValueType type = FLValue_GetType([self fleeceValueForKey: key]);
-    return type != kFLUndefined;
+    return [self fleeceValueForKey: key] != nullptr;
 }
 
 
@@ -148,7 +147,9 @@
 
 
 - (CBLReadOnlyFragment*) objectForKeyedSubscript: (NSString*)key {
-    return [[CBLReadOnlyFragment alloc] initWithValue: [self fleeceValueToObjectForKey: key]];
+    if (![self containsObjectForKey: key])
+        return nil;
+    return [[CBLReadOnlyFragment alloc] initWithParent: self key: key];
 }
 
 

--- a/Objective-C/CBLReadOnlyDictionaryFragment.h
+++ b/Objective-C/CBLReadOnlyDictionaryFragment.h
@@ -8,6 +8,8 @@
 
 @class CBLReadOnlyFragment;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** 
  CBLReadOnlyDictionaryFragment protocol provides subscript access to CBLReadOnlyFragment
  objects by key.
@@ -20,6 +22,8 @@
  @param key The key.
  @return The CBLReadOnlyFragment object.
  */
-- (CBLReadOnlyFragment*) objectForKeyedSubscript: (NSString*)key;
+- (nullable CBLReadOnlyFragment*) objectForKeyedSubscript: (NSString*)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -107,18 +107,15 @@ NS_ASSUME_NONNULL_BEGIN
 /////////////////
 
 @interface CBLReadOnlyFragment ()
+{
+    @protected
+    id _parent;
+    NSString* _key;           // Nil if this is an indexed subscript
+    NSUInteger _index;        // Ignored if this is a keyed subscript
+}
 
-- (instancetype) initWithValue: (nullable id)value;
-
-@end
-
-/////////////////
-
-@interface CBLFragment ()
-
-- (instancetype) initWithValue: (nullable id)value
-                        parent: (nullable id)parent
-                     parentKey: (nullable id)parentKey;
+- (instancetype) initWithParent: (id)parent key: (NSString*)parentKey;
+- (instancetype) initWithParent: (id)parent index: (NSUInteger)parentIndex;
 
 @end
 

--- a/Objective-C/Tests/FragmentTest.m
+++ b/Objective-C/Tests/FragmentTest.m
@@ -372,7 +372,6 @@
     CBLDocument* doc = [self createDocument: @"doc1" dictionary: dict];
     [self saveDocument: doc eval: ^(CBLDocument* d) {
         CBLFragment* fragment = d[@"nested-array"][2];
-        AssertNotNil(fragment);
         AssertFalse(fragment.exists);
         AssertNil(fragment.string); 
         AssertNil(fragment.date); 
@@ -499,15 +498,14 @@
     [doc[@"array"].array addObject: @10.10];
     [doc[@"array"].array addObject: @YES];
     [doc[@"array"].array addObject: date];
-    
+    Assert([[doc objectForKey: @"array"] isKindOfClass: [CBLArray class]]);
+
     [self saveDocument: doc eval: ^(CBLDocument* d) {
-        AssertNotNil(d[@"array"][-1]);
         AssertFalse(d[@"array"][-1].exists);
         for(int i = 0; i < 5; i++){
             AssertNotNil(d[@"array"][i]);
             Assert(d[@"array"][i].exists);
         }
-        AssertNotNil(d[@"array"][5]);
         AssertFalse(d[@"array"][5].exists);
         
         AssertEqualObjects(@"string", d[@"array"][0].value);
@@ -530,11 +528,9 @@
     [doc[@"array"].array addObject: dict];
     
     [self saveDocument: doc eval: ^(CBLDocument* d) {
-        AssertNotNil(d[@"array"][-1]);
         AssertFalse(d[@"array"][-1].exists);
         AssertNotNil(d[@"array"][0]);
         Assert(d[@"array"][0].exists);
-        AssertNotNil(d[@"array"][1]);
         AssertFalse(d[@"array"][1].exists);
         
         AssertEqualObjects(d[@"array"][0][@"name"].string, @"Jason");
@@ -551,11 +547,9 @@
                                       @"address": @{@"street": @"1 Main Street",
                                                    @"phones": @{@"mobile": @"650-123-4567"}}}];
     [self saveDocument: doc eval: ^(CBLDocument* d) {
-        AssertNotNil(d[@"array"][-1]);
         AssertFalse(d[@"array"][-1].exists);
         AssertNotNil(d[@"array"][0]);
         Assert(d[@"array"][0].exists);
-        AssertNotNil(d[@"array"][1]);
         AssertFalse(d[@"array"][1].exists);
         
         AssertEqualObjects(d[@"array"][0][@"name"].string, @"Jason");
@@ -617,7 +611,6 @@
     doc[@"array"][0][3].value = @1;
     
     [self saveDocument: doc eval: ^(CBLDocument* d) {
-        AssertNotNil(d[@"array"][0][3]);
         AssertFalse(d[@"array"][0][3].exists);
     }];
 }

--- a/Swift/Fragment.swift
+++ b/Swift/Fragment.swift
@@ -88,8 +88,8 @@ public class Fragment: ReadOnlyFragment, DictionaryFragment, ArrayFragment {
     // MARK: Internal
     
     
-    init(_ impl: CBLFragment) {
-        super.init(impl)
+    init(_ impl: CBLFragment?) {
+        super.init(impl ?? Fragment.kNonexistent)
     }
     
     
@@ -99,5 +99,8 @@ public class Fragment: ReadOnlyFragment, DictionaryFragment, ArrayFragment {
     private var fragmentImpl: CBLFragment {
         return _impl as! CBLFragment
     }
-    
+
+
+    static let kNonexistent = CBLFragment()
+
 }

--- a/Swift/ReadOnlyFragment.swift
+++ b/Swift/ReadOnlyFragment.swift
@@ -160,11 +160,14 @@ public class ReadOnlyFragment: ReadOnlyFragmentProtocol,
     // MARK: Internal
     
     
-    init(_ impl: CBLReadOnlyFragment) {
-        _impl = impl
+    init(_ impl: CBLReadOnlyFragment?) {
+        _impl = impl ?? ReadOnlyFragment.kNonexistentRO
     }
     
     
     let _impl: CBLReadOnlyFragment
+
+
+    static let kNonexistentRO = CBLReadOnlyFragment()
     
 }


### PR DESCRIPTION
(This is not dependent on the PR I submitted last week.)

* Parent returns nil if it knows the fragment doesn't exist
* Fragments are always initialized with parent and key/index; the value is derived lazily
* Numeric and boolean accessors don't create any intermediate NSObjects
* Chained subscripts reuse the same fragment object
* Removed expensive -conformsToProtocol: checks in setter
* All of CBLFragment turned out to be unnecessary except the setter
* Fixed a bug where booleanValue returned NO for non-numeric values