### PR TITLE
Fixed #1927 session cookie overwritten by the cookie in shared storage

### DIFF
--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -116,6 +116,7 @@ static void doCompletedReceive(C4Socket* s, size_t byteCount) {
         _options = AllocedDict(options);
 
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL: url];
+        request.HTTPShouldHandleCookies = NO;
         _logic = [[CBLHTTPLogic alloc] initWithURLRequest: request];
         _logic.handleRedirects = YES;
 


### PR DESCRIPTION
Set request.HTTPShouldHandleCookies to NO so that the CBLHTTPLogic will not add the cookies from the shared cookie storage. Also we don’t actually use the shared cookie storage.