### PR TITLE
Fixed #1948 Make database operations thread safe

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -373,6 +373,10 @@
 		9384D8631FC4163D00FE89D8 /* FullTextFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9384D8621FC4163D00FE89D8 /* FullTextFunction.swift */; };
 		9385F2661FC38F8900032037 /* CBLListenerToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 9385F2651FC38F8900032037 /* CBLListenerToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9385F2671FC38F8900032037 /* CBLListenerToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 9385F2651FC38F8900032037 /* CBLListenerToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9385F2C91FC5FF4D00032037 /* CBLLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 9385F2C81FC5FF4D00032037 /* CBLLock.h */; };
+		9385F2CA1FC5FF4D00032037 /* CBLLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 9385F2C81FC5FF4D00032037 /* CBLLock.h */; };
+		9385F3031FC645AE00032037 /* ConcurrentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9385F3021FC645AE00032037 /* ConcurrentTest.m */; };
+		9385F3041FC645D300032037 /* ConcurrentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9385F3021FC645AE00032037 /* ConcurrentTest.m */; };
 		938CDF161E807EEB002EE790 /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CDF151E807EEB002EE790 /* Query.swift */; };
 		938CDF181E807F08002EE790 /* Select.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CDF171E807F08002EE790 /* Select.swift */; };
 		938CDF1A1E807F14002EE790 /* From.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CDF191E807F14002EE790 /* From.swift */; };
@@ -983,6 +987,8 @@
 		9384D84D1FC4163100FE89D8 /* FullTextExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullTextExpression.swift; sourceTree = "<group>"; };
 		9384D8621FC4163D00FE89D8 /* FullTextFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullTextFunction.swift; sourceTree = "<group>"; };
 		9385F2651FC38F8900032037 /* CBLListenerToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLListenerToken.h; sourceTree = "<group>"; };
+		9385F2C81FC5FF4D00032037 /* CBLLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLLock.h; sourceTree = "<group>"; };
+		9385F3021FC645AE00032037 /* ConcurrentTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ConcurrentTest.m; sourceTree = "<group>"; };
 		938CDF151E807EEB002EE790 /* Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
 		938CDF171E807F08002EE790 /* Select.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Select.swift; sourceTree = "<group>"; };
 		938CDF191E807F14002EE790 /* From.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = From.swift; sourceTree = "<group>"; };
@@ -1421,6 +1427,7 @@
 				934F4CA11E241FB500F90659 /* CBLParseDate.h */,
 				9381959A1EB9A6FC0032CC51 /* CBLStatus.h */,
 				9381959B1EB9A6FC0032CC51 /* CBLStatus.mm */,
+				9385F2C81FC5FF4D00032037 /* CBLLock.h */,
 			);
 			name = Support;
 			sourceTree = "<group>";
@@ -1652,6 +1659,7 @@
 				9378C5961E25B473001BB196 /* CBLTestCase.m */,
 				27FDBF411F02FE5C0087CC1C /* ConflictTest.h */,
 				93384F731EB14ABA00976B41 /* ConflictTest.m */,
+				9385F3021FC645AE00032037 /* ConcurrentTest.m */,
 				932A88561F4CDDAD0005AFB8 /* DatabaseEncryptionTest.m */,
 				9378C5901E25B3F0001BB196 /* DatabaseTest.m */,
 				9352945E1E51708E005CE4E8 /* DictionaryTest.m */,
@@ -1789,6 +1797,7 @@
 				93B503751E64B0B4002C4680 /* CBLBlobStream.h in Headers */,
 				9384D8471FC407BA00FE89D8 /* CBLFullTextMatchExpression.h in Headers */,
 				9383A58B1F1EE8EF0083053D /* CBLQueryResult.h in Headers */,
+				9385F2CA1FC5FF4D00032037 /* CBLLock.h in Headers */,
 				93B75C1B1E79EF690033B61B /* CBLQueryExpression.h in Headers */,
 				93B41CB11F04706100A7F114 /* CBLReplicatorChange.h in Headers */,
 				2753AFF61EC39CA200C12E98 /* CBLHTTPLogic.h in Headers */,
@@ -1905,6 +1914,7 @@
 				933208161E77415E000D9993 /* CBLQueryOrdering.h in Headers */,
 				9384D8461FC407BA00FE89D8 /* CBLFullTextMatchExpression.h in Headers */,
 				93EC436E1FB53AC400D54BB4 /* CBLDatabase+NSPredicate.h in Headers */,
+				9385F2C91FC5FF4D00032037 /* CBLLock.h in Headers */,
 				9383A58A1F1EE8EF0083053D /* CBLQueryResult.h in Headers */,
 				9332082A1E774171000D9993 /* CBLQuery+Internal.h in Headers */,
 				93B41CB01F04706100A7F114 /* CBLReplicatorChange.h in Headers */,
@@ -2664,6 +2674,7 @@
 				938CFA2D1E442B4200291631 /* DocumentTest.m in Sources */,
 				93CD018D1E95546200AFB3FA /* PredicateQueryTest.m in Sources */,
 				93CD01901E95546200AFB3FA /* DictionaryTest.m in Sources */,
+				9385F3041FC645D300032037 /* ConcurrentTest.m in Sources */,
 				93CD018E1E95546200AFB3FA /* QueryTest.m in Sources */,
 				273E555D1F79AF69000182F1 /* ArrayTest.m in Sources */,
 				931C146B1EAAF0960094F9B2 /* FragmentTest.m in Sources */,
@@ -2779,6 +2790,7 @@
 				9378C59E1E269F14001BB196 /* DocumentTest.m in Sources */,
 				93384F741EB14ABA00976B41 /* ConflictTest.m in Sources */,
 				9352945F1E51708E005CE4E8 /* DictionaryTest.m in Sources */,
+				9385F3031FC645AE00032037 /* ConcurrentTest.m in Sources */,
 				932A88571F4CDDAD0005AFB8 /* DatabaseEncryptionTest.m in Sources */,
 				27E35A821E8B3B3A00E103F9 /* ReplicatorTest.m in Sources */,
 				93DD9BA81EB419BB00E502A2 /* ArrayTest.m in Sources */,

--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -46,13 +46,13 @@ typedef NS_ENUM(uint32_t, CBLLogLevel) {
 @interface CBLDatabase : NSObject
 
 /** The database's name. */
-@property (readonly, nonatomic) NSString* name;
+@property (readonly, atomic) NSString* name;
 
 /** The database's path. If the database is closed or deleted, nil value will be returned. */
-@property (readonly, nonatomic, nullable) NSString* path;
+@property (readonly, atomic, nullable) NSString* path;
 
 /** The number of documents in the database. */
-@property (readonly, nonatomic) uint64_t count;
+@property (readonly, atomic) uint64_t count;
 
 /** 
  The database's configuration. If the configuration is not specify when initializing

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -37,6 +37,7 @@ using namespace fleece;
     CBLDatabaseConfiguration* _config;
     CBLPredicateQuery* _allDocsQuery;
     
+    NSObject* _listenersMutex;
     C4DatabaseObserver* _dbObs;
     NSMutableSet* _dbListenerTokens;
     
@@ -46,6 +47,7 @@ using namespace fleece;
 
 
 @synthesize name=_name;
+@synthesize dispatchQueue=_dispatchQueue;
 @synthesize c4db=_c4db, sharedKeys=_sharedKeys;
 @synthesize replications=_replications, activeReplications=_activeReplications;
 
@@ -59,7 +61,7 @@ static const C4DatabaseConfig kDBConfig = {
 
 static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     CBLDatabase *db = (__bridge CBLDatabase *)context;
-    dispatch_async(dispatch_get_main_queue(), ^{        //TODO: Support other queues
+    dispatch_async(db.dispatchQueue, ^{
         [db postDatabaseChanged];
     });
 }
@@ -69,7 +71,7 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
                                 void *context)
 {
     CBLDatabase *db = (__bridge CBLDatabase *)context;
-    dispatch_async(dispatch_get_main_queue(), ^{        //TODO: Support other queues
+    dispatch_async(db.dispatchQueue, ^{
         [db postDocumentChanged: slice2string(docID)];
     });
 }
@@ -99,6 +101,9 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
         _config = config != nil? [config copy] : [CBLDatabaseConfiguration new];
         if (![self open: outError])
             return nil;
+        
+        _dispatchQueue = dispatch_queue_create("CBLDatabase", DISPATCH_QUEUE_SERIAL);
+        _listenersMutex = [NSObject new];
         _replications = [NSMapTable strongToWeakObjectsMapTable];
         _activeReplications = [NSMutableSet new];
     }
@@ -123,12 +128,16 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (NSString*) path {
-    return _c4db != nullptr ? sliceResult2FilesystemPath(c4db_getPath(_c4db)) : nil;
+    CBL_LOCK(self) {
+        return _c4db != nullptr ? sliceResult2FilesystemPath(c4db_getPath(_c4db)) : nil;
+    }
 }
 
 
 - (uint64_t) count {
-    return _c4db != nullptr ? c4db_getDocumentCount(_c4db) : 0;
+    CBL_LOCK(self) {
+        return _c4db != nullptr ? c4db_getDocumentCount(_c4db) : 0;
+    }
 }
 
 
@@ -141,7 +150,9 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (CBLDocument*) documentWithID: (NSString*)documentID {
-    return [self documentWithID: documentID mustExist: YES error: nil];
+    CBL_LOCK(self) {
+        return [self documentWithID: documentID error: nil];
+    }
 }
 
 
@@ -149,8 +160,9 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (BOOL) containsDocumentWithID: (NSString*)docID {
-    id doc = [self documentWithID: docID mustExist: YES error: nil];
-    return doc != nil;
+    CBL_LOCK(self) {
+        return [self documentWithID: docID error: nil] != nil;
+    }
 }
 
 
@@ -166,41 +178,47 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (CBLDocument*) saveDocument: (CBLMutableDocument*)document error: (NSError**)error {
-    if (![self prepareDocument: document error: error])
-        return nil;
-    return [self saveDocument: document asDeletion: NO error: error];
+    CBL_LOCK(self) {
+        if (![self prepareDocument: document error: error])
+            return nil;
+        return [self saveDocument: document asDeletion: NO error: error];
+    }
 }
 
 
 - (BOOL) deleteDocument: (CBLDocument*)document error: (NSError**)error {
-    if (![self prepareDocument: document error: error])
-        return NO;
-    return [self saveDocument: document asDeletion: YES error: error] != nil;
+    CBL_LOCK(self) {
+        if (![self prepareDocument: document error: error])
+            return NO;
+        return [self saveDocument: document asDeletion: YES error: error] != nil;
+    }
 }
 
 
 - (BOOL) purgeDocument: (CBLDocument*)document error: (NSError**)error {
-    if (![self prepareDocument: document error: error])
-        return NO;
-    
-    if (!document.exists)
-        return createError(kCBLStatusNotFound, error);
-    
-    C4Transaction transaction(self.c4db);
-    if (!transaction.begin())
-        return convertError(transaction.error(),  error);
-    
-    C4Error err;
-    if (c4doc_purgeRevision(document.c4Doc.rawDoc, C4Slice(), &err) >= 0) {
-        if (c4doc_save(document.c4Doc.rawDoc, 0, &err)) {
-            // Save succeeded; now commit:
-            if (!transaction.commit())
-                return convertError(transaction.error(), error);
-            
-            return YES;
+    CBL_LOCK(self) {
+        if (![self prepareDocument: document error: error])
+            return NO;
+        
+        if (!document.exists)
+            return createError(kCBLStatusNotFound, error);
+        
+        C4Transaction transaction(self.c4db);
+        if (!transaction.begin())
+            return convertError(transaction.error(),  error);
+        
+        C4Error err;
+        if (c4doc_purgeRevision(document.c4Doc.rawDoc, C4Slice(), &err) >= 0) {
+            if (c4doc_save(document.c4Doc.rawDoc, 0, &err)) {
+                // Save succeeded; now commit:
+                if (!transaction.commit())
+                    return convertError(transaction.error(), error);
+                
+                return YES;
+            }
         }
+        return convertError(err, error);
     }
-    return convertError(err, error);
 }
 
 
@@ -208,21 +226,24 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (BOOL) inBatch: (NSError**)outError usingBlock: (void (^)())block {
-    [self mustBeOpen];
-    
-    C4Transaction transaction(_c4db);
-    if (outError)
-        *outError = nil;
-    
-    if (!transaction.begin())
-        return convertError(transaction.error(), outError);
-    
-    block();
-    
-    if (!transaction.commit())
-        return convertError(transaction.error(), outError);
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        C4Transaction transaction(_c4db);
+        if (outError)
+            *outError = nil;
+        
+        if (!transaction.begin())
+            return convertError(transaction.error(), outError);
+        
+        block();
+        
+        if (!transaction.commit())
+            return convertError(transaction.error(), outError);
+    }
     
     [self postDatabaseChanged];
+    
     return YES;
 }
 
@@ -231,57 +252,65 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (BOOL) close: (NSError**)outError {
-    if (_c4db == nullptr)
+    CBL_LOCK(self) {
+        if (_c4db == nullptr)
+            return YES;
+        
+        CBLLog(Database, @"Closing %@ at path %@", self, self.path);
+        
+        _allDocsQuery = nil;
+        
+        C4Error err;
+        if (!c4db_close(_c4db, &err))
+            return convertError(err, outError);
+        
+        [self freeC4Observer];
+        [self freeC4DB];
+        
         return YES;
-    
-    CBLLog(Database, @"Closing %@ at path %@", self, self.path);
-    
-    _allDocsQuery = nil;
-    
-    C4Error err;
-    if (!c4db_close(_c4db, &err))
-        return convertError(err, outError);
-    
-    [self freeC4Observer];
-    [self freeC4DB];
-    
-    return YES;
+    }
 }
 
 
 - (BOOL) delete: (NSError**)outError {
-    [self mustBeOpen];
-    
-    C4Error err;
-    if (!c4db_delete(_c4db, &err))
-        return convertError(err, outError);
-    
-    [self freeC4Observer];
-    [self freeC4DB];
-    
-    return YES;
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        C4Error err;
+        if (!c4db_delete(_c4db, &err))
+            return convertError(err, outError);
+        
+        [self freeC4Observer];
+        [self freeC4DB];
+        
+        return YES;
+    }
 }
 
 
 - (BOOL) compact: (NSError**)outError {
-    [self mustBeOpen];
-    
-    C4Error err;
-    if (!c4db_compact(_c4db, &err))
-        return convertError(err, outError);
-    return YES;
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        C4Error err;
+        if (!c4db_compact(_c4db, &err))
+            return convertError(err, outError);
+        return YES;
+    }
 }
 
 
 - (BOOL) setEncryptionKey: (nullable CBLEncryptionKey*)key error: (NSError**)outError {
-    [self mustBeOpen];
-    
-    C4Error err;
-    C4EncryptionKey encKey = c4EncryptionKey(key);
-    if (!c4db_rekey(_c4db, &encKey, &err))
-        return convertError(err, outError);
-    
-    return YES;
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        C4Error err;
+        C4EncryptionKey encKey = c4EncryptionKey(key);
+        if (!c4db_rekey(_c4db, &encKey, &err))
+            return convertError(err, outError);
+        
+        return YES;
+    }
 }
 
 
@@ -375,8 +404,11 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 - (id<CBLListenerToken>) addChangeListenerWithQueue: (nullable dispatch_queue_t)queue
                                            listener: (void (^)(CBLDatabaseChange*))listener
 {
-    [self mustBeOpen];
-    return [self addDatabaseChangeListener: listener queue: queue];
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        return [self addDatabaseChangeListener: listener queue: queue];
+    }
 }
 
 
@@ -391,18 +423,23 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
                                                    queue: (nullable dispatch_queue_t)queue
                                                 listener: (void (^)(CBLDocumentChange*))listener
 {
-    [self mustBeOpen];
-    return [self addDocumentChangeListenerWithDocumentID: id listener: listener queue: queue];
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        return [self addDocumentChangeListenerWithDocumentID: id listener: listener queue: queue];
+    }
 }
 
 
 - (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token {
-    [self mustBeOpen];
-    
-    if ([token isKindOfClass: [CBLDocumentChangeListenerToken class]])
-        [self removeDocumentChangeListenerWithToken: token];
-    else
-        [self removeDatabaseChangeListenerWithToken: token];
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        if ([token isKindOfClass: [CBLDocumentChangeListenerToken class]])
+            [self removeDocumentChangeListenerWithToken: token];
+        else
+            [self removeDatabaseChangeListenerWithToken: token];
+    }
 }
 
 
@@ -410,39 +447,45 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (NSArray<NSString*>*) indexes {
-    [self mustBeOpen];
-    
-    C4SliceResult data = c4db_getIndexes(_c4db, nullptr);
-    FLValue value = FLValue_FromTrustedData((FLSlice)data);
-    return FLValue_GetNSObject(value, _sharedKeys, nullptr);
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        C4SliceResult data = c4db_getIndexes(_c4db, nullptr);
+        FLValue value = FLValue_FromTrustedData((FLSlice)data);
+        return FLValue_GetNSObject(value, _sharedKeys, nullptr);
+    }
 }
 
 
 - (BOOL) createIndex: (CBLIndex*)index withName: (NSString*)name error: (NSError**)outError {
-    [self mustBeOpen];
-    
-    NSData* json = [NSJSONSerialization dataWithJSONObject: index.indexItems
-                                                   options: 0
-                                                     error: outError];
-    if (!json)
-        return NO;
-    
-    CBLStringBytes bName(name);
-    C4IndexType type = index.indexType;
-    C4IndexOptions options = index.indexOptions;
-    
-    C4Error c4err;
-    return c4db_createIndex(_c4db, bName, {json.bytes, json.length}, type, &options, &c4err) ||
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        NSData* json = [NSJSONSerialization dataWithJSONObject: index.indexItems
+                                                       options: 0
+                                                         error: outError];
+        if (!json)
+            return NO;
+        
+        CBLStringBytes bName(name);
+        C4IndexType type = index.indexType;
+        C4IndexOptions options = index.indexOptions;
+        
+        C4Error c4err;
+        return c4db_createIndex(_c4db, bName, {json.bytes, json.length}, type, &options, &c4err) ||
         convertError(c4err, outError);
+    }
 }
 
 
 - (BOOL)deleteIndexForName:(NSString *)name error:(NSError **)outError {
-    [self mustBeOpen];
-    
-    CBLStringBytes bName(name);
-    C4Error c4err;
-    return c4db_deleteIndex(_c4db, bName, &c4err) || convertError(c4err, outError);
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        CBLStringBytes bName(name);
+        C4Error c4err;
+        return c4db_deleteIndex(_c4db, bName, &c4err) || convertError(c4err, outError);
+    }
 }
 
 
@@ -450,22 +493,34 @@ static void docObserverCallback(C4DocumentObserver* obs, C4Slice docID, C4Sequen
 
 
 - (CBLPredicateQuery*) createQueryWhere: (nullable id)where {
-    [self mustBeOpen];
-    
-    auto query = [[CBLPredicateQuery alloc] initWithDatabase: self];
-    query.where = where;
-    return query;
+    CBL_LOCK(self) {
+        [self mustBeOpen];
+        
+        auto query = [[CBLPredicateQuery alloc] initWithDatabase: self];
+        query.where = where;
+        return query;
+    }
+}
+
+
+- (void) withLock: (void(^)(void))block {
+    CBL_LOCK(self) {
+        block();
+    }
 }
 
 
 - (C4BlobStore*) getBlobStore: (NSError**)outError {
-    if (![self mustBeOpen: outError])
-        return nil;
-    C4Error err;
-    C4BlobStore *blobStore = c4db_getBlobStore(_c4db, &err);
-    if (!blobStore)
-        convertError(err, outError);
-    return blobStore;
+    CBL_LOCK(self) {
+        if (![self mustBeOpen: outError])
+            return nil;
+        
+        C4Error err;
+        C4BlobStore *blobStore = c4db_getBlobStore(_c4db, &err);
+        if (!blobStore)
+            convertError(err, outError);
+        return blobStore;
+    }
 }
 
 
@@ -593,14 +648,13 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
 
 
 - (nullable CBLDocument*) documentWithID: (NSString*)documentID
-                               mustExist: (bool)mustExist
                                    error: (NSError**)outError
 {
     [self mustBeOpen];
     
     return [[CBLDocument alloc] initWithDatabase: self
                                       documentID: documentID
-                                       mustExist: mustExist
+                                       mustExist: YES
                                   includeDeleted: NO
                                            error: outError];
 }
@@ -622,62 +676,80 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
 - (id<CBLListenerToken>) addDatabaseChangeListener: (void (^)(CBLDatabaseChange*))listener
                                              queue: (dispatch_queue_t)queue
 {
-    if (!_dbListenerTokens) {
-        _dbListenerTokens = [NSMutableSet set];
-        _dbObs = c4dbobs_create(_c4db, dbObserverCallback, (__bridge void *)self);
+    CBL_LOCK(_listenersMutex) {
+        if (!_dbListenerTokens) {
+            _dbListenerTokens = [NSMutableSet set];
+            _dbObs = c4dbobs_create(_c4db, dbObserverCallback, (__bridge void *)self);
+        }
+        
+        id token = [[CBLChangeListenerToken alloc] initWithListener: listener
+                                                              queue: queue];
+        
+        
+        [_dbListenerTokens addObject: token];
+        return token;
     }
-    
-    id token = [[CBLChangeListenerToken alloc] initWithListener: listener
-                                                          queue: queue];
-    [_dbListenerTokens addObject: token];
-    return token;
 }
 
 
 - (void) removeDatabaseChangeListenerWithToken: (id<CBLListenerToken>)token {
-    [_dbListenerTokens removeObject: token];
-    
-    if (_dbListenerTokens.count == 0) {
-        c4dbobs_free(_dbObs);
-        _dbObs = nil;
-        _dbListenerTokens = nil;
+    CBL_LOCK(_listenersMutex) {
+        [_dbListenerTokens removeObject: token];
+        
+        if (_dbListenerTokens.count == 0) {
+            c4dbobs_free(_dbObs);
+            _dbObs = nil;
+            _dbListenerTokens = nil;
+        }
     }
 }
 
 
 - (void) postDatabaseChanged {
-    if (!_dbObs || !_c4db || c4db_isInTransaction(_c4db))
-        return;
+    NSMutableArray* allChanges;
     
-    const uint32_t kMaxChanges = 100u;
-    C4DatabaseChange changes[kMaxChanges];
-    bool external = false;
-    uint32_t nChanges = 0u;
-    NSMutableArray* docIDs = [NSMutableArray new];
-    do {
-        // Read changes in batches of kMaxChanges:
-        bool newExternal;
-        nChanges = c4dbobs_getChanges(_dbObs, changes, kMaxChanges, &newExternal);
-        if (nChanges == 0 || external != newExternal || docIDs.count > 1000) {
-            if(docIDs.count > 0) {
-                CBLDatabaseChange* change = [[CBLDatabaseChange alloc] initWithDocumentIDs: docIDs
-                                                                                isExternal: external];
-                for (CBLChangeListenerToken* token in _dbListenerTokens) {
-                    void (^listener)(CBLDatabaseChange*) = token.listener;
-                    dispatch_async(token.queue, ^{
-                        listener(change);
-                    });
+    CBL_LOCK(self) {
+        if (!_dbObs || !_c4db || c4db_isInTransaction(_c4db))
+            return;
+        
+        allChanges = [NSMutableArray array];
+        
+        const uint32_t kMaxChanges = 100u;
+        C4DatabaseChange changes[kMaxChanges];
+        bool external = false;
+        uint32_t nChanges = 0u;
+        NSMutableArray* docIDs = [NSMutableArray new];
+        do {
+            // Read changes in batches of kMaxChanges:
+            bool newExternal;
+            nChanges = c4dbobs_getChanges(_dbObs, changes, kMaxChanges, &newExternal);
+            if (nChanges == 0 || external != newExternal || docIDs.count > 1000) {
+                if(docIDs.count > 0) {
+                    CBLDatabaseChange* change = [[CBLDatabaseChange alloc] initWithDocumentIDs: docIDs
+                                                                                    isExternal: external];
+                    [allChanges addObject: change];
+                    docIDs = [NSMutableArray new];
                 }
-                docIDs = [NSMutableArray new];
+            }
+            
+            external = newExternal;
+            for(uint32_t i = 0; i < nChanges; i++) {
+                NSString *docID =slice2string(changes[i].docID);
+                [docIDs addObject: docID];
+            }
+        } while(nChanges > 0);
+    }
+    
+    CBL_LOCK(_listenersMutex) {
+        for (CBLDatabaseChange* change in allChanges) {
+            for (CBLChangeListenerToken* token in _dbListenerTokens) {
+                void (^listener)(CBLDatabaseChange*) = token.listener;
+                dispatch_async(token.queue, ^{
+                    listener(change);
+                });
             }
         }
-        
-        external = newExternal;
-        for(uint32_t i = 0; i < nChanges; i++) {
-            NSString *docID =slice2string(changes[i].docID);
-            [docIDs addObject: docID];
-        }
-    } while(nChanges > 0);
+    }
 }
 
 
@@ -685,60 +757,68 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
                                                         listener: (void (^)(CBLDocumentChange*))listener
                                                            queue: (dispatch_queue_t)queue
 {
-    if (!_docListenerTokens)
-        _docListenerTokens = [NSMutableDictionary dictionary];
-    
-    NSMutableSet* tokens = _docListenerTokens[documentID];
-    if (!tokens) {
-        tokens = [NSMutableSet set];
-        [_docListenerTokens setObject: tokens forKey: documentID];
+    CBL_LOCK(_listenersMutex) {
+        if (!_docListenerTokens)
+            _docListenerTokens = [NSMutableDictionary dictionary];
         
-        CBLStringBytes bDocID(documentID);
-        C4DocumentObserver* o =
-        c4docobs_create(_c4db, bDocID, docObserverCallback, (__bridge void *)self);
+        NSMutableSet* tokens = _docListenerTokens[documentID];
+        if (!tokens) {
+            tokens = [NSMutableSet set];
+            [_docListenerTokens setObject: tokens forKey: documentID];
+            
+            CBLStringBytes bDocID(documentID);
+            C4DocumentObserver* o =
+            c4docobs_create(_c4db, bDocID, docObserverCallback, (__bridge void *)self);
+            
+            if (!_docObs)
+                _docObs = [NSMutableDictionary dictionary];
+            [_docObs setObject: [NSValue valueWithPointer: o] forKey: documentID];
+        }
         
-        if (!_docObs)
-            _docObs = [NSMutableDictionary dictionary];
-        [_docObs setObject: [NSValue valueWithPointer: o] forKey: documentID];
+        id token = [[CBLDocumentChangeListenerToken alloc] initWithDocumentID: documentID
+                                                                     listener: listener
+                                                                        queue: queue];
+        [tokens addObject: token];
+        return token;
     }
-    
-    id token = [[CBLDocumentChangeListenerToken alloc] initWithDocumentID: documentID
-                                                                 listener: listener
-                                                                    queue: queue];
-    [tokens addObject: token];
-    return token;
 }
 
 
 - (void) removeDocumentChangeListenerWithToken: (CBLDocumentChangeListenerToken*)token {
-    NSString* documentID = token.documentID;
-    NSMutableSet* listeners = _docListenerTokens[documentID];
-    if (listeners) {
-        [listeners removeObject: token];
-        if (listeners.count == 0) {
-            NSValue* obsValue = [_docObs objectForKey: documentID];
-            if (obsValue) {
-                C4DocumentObserver* obs = (C4DocumentObserver*)obsValue.pointerValue;
-                c4docobs_free(obs);
+    CBL_LOCK(_listenersMutex) {
+        NSString* documentID = token.documentID;
+        NSMutableSet* listeners = _docListenerTokens[documentID];
+        if (listeners) {
+            [listeners removeObject: token];
+            if (listeners.count == 0) {
+                NSValue* obsValue = [_docObs objectForKey: documentID];
+                if (obsValue) {
+                    C4DocumentObserver* obs = (C4DocumentObserver*)obsValue.pointerValue;
+                    c4docobs_free(obs);
+                }
+                [_docObs removeObjectForKey: documentID];
+                [_docListenerTokens removeObjectForKey:documentID];
             }
-            [_docObs removeObjectForKey: documentID];
-            [_docListenerTokens removeObjectForKey:documentID];
         }
     }
 }
 
 
 - (void) postDocumentChanged: (NSString*)documentID {
-    if (!_docObs[documentID] || !_c4db ||  c4db_isInTransaction(_c4db))
-        return;
+    CBL_LOCK(self) {
+        if (!_docObs[documentID] || !_c4db ||  c4db_isInTransaction(_c4db))
+            return;
+    }
     
-    CBLDocumentChange* change = [[CBLDocumentChange alloc] initWithDocumentID: documentID];
-    NSSet* listeners = [_docListenerTokens objectForKey: documentID];
-    for (CBLDocumentChangeListenerToken* token in listeners) {
-        void (^listener)(CBLDocumentChange*) = token.listener;
-        dispatch_async(token.queue, ^{
-            listener(change);
-        });
+    CBL_LOCK(_listenersMutex) {
+        CBLDocumentChange* change = [[CBLDocumentChange alloc] initWithDocumentID: documentID];
+        NSSet* listeners = [_docListenerTokens objectForKey: documentID];
+        for (CBLDocumentChangeListenerToken* token in listeners) {
+            void (^listener)(CBLDocumentChange*) = token.listener;
+            dispatch_async(token.queue, ^{
+                listener(change);
+            });
+        }
     }
 }
 
@@ -926,77 +1006,79 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
 - (bool) resolveConflictInDocument: (NSString*)docID
                      usingResolver: (id<CBLConflictResolver>)resolver
                              error: (NSError**)outError {
-    C4Transaction t(_c4db);
-    t.begin();
-
-    auto doc = [[CBLDocument alloc] initWithDatabase: self
-                                          documentID: docID
-                                           mustExist: YES
-                                      includeDeleted: YES
-                                               error: outError];
-    if (!doc)
-        return false;
-
-    // Read the conflicting remote revision:
-    auto otherDoc = [[CBLDocument alloc] initWithDatabase: self
-                                               documentID: docID
-                                                mustExist: YES
-                                           includeDeleted: YES
-                                                    error: outError];
-    if (!otherDoc || ![otherDoc selectConflictingRevision])
-        return false;
-
-    // Read the common ancestor revision (if it's available):
-    auto baseDoc = [[CBLDocument alloc] initWithDatabase: self
+    CBL_LOCK(self) {
+        C4Transaction t(_c4db);
+        t.begin();
+        
+        auto doc = [[CBLDocument alloc] initWithDatabase: self
                                               documentID: docID
                                                mustExist: YES
                                           includeDeleted: YES
                                                    error: outError];
-    if (![baseDoc selectCommonAncestorOfDoc: doc andDoc: otherDoc] || ![baseDoc toDictionary])
-        baseDoc = nil;
-
-    // Call the conflict resolver:
-    if (!resolver)
-        resolver = self.effectiveConflictResolver;
-    auto conflict = [[CBLConflict alloc] initWithMine: doc theirs: otherDoc base: baseDoc];
-    CBLLog(Database, @"Resolving doc '%@' with %@ (mine=%@, theirs=%@, base=%@",
-           docID, resolver.class, doc.revID, otherDoc.revID, baseDoc.revID);
-    CBLDocument* resolved = [resolver resolve: conflict];
-    if (!resolved)
-        return convertError({LiteCoreDomain, kC4ErrorConflict}, outError);
-    
-    // Figure out what revision to delete and what if anything to add:
-    CBLStringBytes winningRevID, losingRevID;
-    NSData* mergedBody = nil;
-    if (resolved == otherDoc) {
-        winningRevID = otherDoc.revID;
-        losingRevID = doc.revID;
-    } else {
-        winningRevID = doc.revID;
-        losingRevID = otherDoc.revID;
-        if (resolved != doc) {
-            resolved.database = self;
-            mergedBody = [resolved encode: outError];
-            if (!mergedBody)
-                return false;
+        if (!doc)
+            return false;
+        
+        // Read the conflicting remote revision:
+        auto otherDoc = [[CBLDocument alloc] initWithDatabase: self
+                                                   documentID: docID
+                                                    mustExist: YES
+                                               includeDeleted: YES
+                                                        error: outError];
+        if (!otherDoc || ![otherDoc selectConflictingRevision])
+            return false;
+        
+        // Read the common ancestor revision (if it's available):
+        auto baseDoc = [[CBLDocument alloc] initWithDatabase: self
+                                                  documentID: docID
+                                                   mustExist: YES
+                                              includeDeleted: YES
+                                                       error: outError];
+        if (![baseDoc selectCommonAncestorOfDoc: doc andDoc: otherDoc] || ![baseDoc toDictionary])
+            baseDoc = nil;
+        
+        // Call the conflict resolver:
+        if (!resolver)
+            resolver = self.effectiveConflictResolver;
+        auto conflict = [[CBLConflict alloc] initWithMine: doc theirs: otherDoc base: baseDoc];
+        CBLLog(Database, @"Resolving doc '%@' with %@ (mine=%@, theirs=%@, base=%@",
+               docID, resolver.class, doc.revID, otherDoc.revID, baseDoc.revID);
+        CBLDocument* resolved = [resolver resolve: conflict];
+        if (!resolved)
+            return convertError({LiteCoreDomain, kC4ErrorConflict}, outError);
+        
+        // Figure out what revision to delete and what if anything to add:
+        CBLStringBytes winningRevID, losingRevID;
+        NSData* mergedBody = nil;
+        if (resolved == otherDoc) {
+            winningRevID = otherDoc.revID;
+            losingRevID = doc.revID;
+        } else {
+            winningRevID = doc.revID;
+            losingRevID = otherDoc.revID;
+            if (resolved != doc) {
+                resolved.database = self;
+                mergedBody = [resolved encode: outError];
+                if (!mergedBody)
+                    return false;
+            }
         }
-    }
-
-    // Tell LiteCore to do the resolution:
-    C4Document *rawDoc = doc.c4Doc.rawDoc;
-    C4Error c4err;
-    if (!c4doc_resolveConflict(rawDoc,
-                               winningRevID,
-                               losingRevID,
-                               data2slice(mergedBody),
-                               &c4err)
+        
+        // Tell LiteCore to do the resolution:
+        C4Document *rawDoc = doc.c4Doc.rawDoc;
+        C4Error c4err;
+        if (!c4doc_resolveConflict(rawDoc,
+                                   winningRevID,
+                                   losingRevID,
+                                   data2slice(mergedBody),
+                                   &c4err)
             || !c4doc_save(rawDoc, 0, &c4err)) {
-        return convertError(c4err, outError);
+            return convertError(c4err, outError);
+        }
+        CBLLog(Database, @"Conflict resolved as doc '%@' rev %.*s",
+               docID, (int)rawDoc->revID.size, rawDoc->revID.buf);
+        
+        return t.commit() || convertError(t.error(), outError);
     }
-    CBLLog(Database, @"Conflict resolved as doc '%@' rev %.*s",
-           docID, (int)rawDoc->revID.size, rawDoc->revID.buf);
-
-    return t.commit() || convertError(t.error(), outError);
 }
 
 @end

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -46,7 +46,6 @@ using namespace fleeceapi;
 
 - (instancetype) initWithDatabase: (CBLDatabase*)database
                        documentID: (NSString*)documentID
-                        mustExist: (BOOL)mustExist
                    includeDeleted: (BOOL)includeDeleted
                             error: (NSError**)outError
 {
@@ -55,7 +54,7 @@ using namespace fleeceapi;
         _database = database;
         CBLStringBytes docId(documentID);
         C4Error err;
-        auto doc = c4doc_get(database.c4db, docId, mustExist, &err);
+        auto doc = c4doc_get(database.c4db, docId, true, &err);
         if (!doc) {
             convertError(err, outError);
             return nil;

--- a/Objective-C/CBLMutableDocument.mm
+++ b/Objective-C/CBLMutableDocument.mm
@@ -30,8 +30,8 @@
 @implementation CBLMutableDocument
 {
     NSError* _encodingError;
+    BOOL _isDeleted;
 }
-
 
 #pragma mark - Initializer
 
@@ -181,6 +181,16 @@
 
 - (NSUInteger) generation {
     return super.generation + !!self.changed;
+}
+
+
+- (void) markAsDeleted {
+    _isDeleted = YES;
+}
+
+
+- (BOOL) isDeleted {
+    return _isDeleted ? _isDeleted : super.isDeleted;
 }
 
 

--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -500,11 +500,9 @@
     if (![self check: outError])
         return nil;
     
-    NSString* result;
     CBL_LOCK(self.database) {
-        result = sliceResult2string(c4query_explain(_c4Query));
+        return sliceResult2string(c4query_explain(_c4Query));
     }
-    return result;
 }
 
 

--- a/Objective-C/CBLQueryResult.mm
+++ b/Objective-C/CBLQueryResult.mm
@@ -46,7 +46,10 @@ using namespace fleeceapi;
 
 
 - (NSUInteger) count {
-    CBL_LOCK(self) {
+    // TODO: We should make it strong reference instead:
+    // https://github.com/couchbase/couchbase-lite-ios/issues/1983
+    CBLDatabase* db = _rs.database;
+    CBL_LOCK(db) {
         return c4query_columnCount(_rs.c4Query);
     }
 }

--- a/Objective-C/CBLQueryResult.mm
+++ b/Objective-C/CBLQueryResult.mm
@@ -46,7 +46,9 @@ using namespace fleeceapi;
 
 
 - (NSUInteger) count {
-    return c4query_columnCount(_rs.c4Query);
+    CBL_LOCK(self) {
+        return c4query_columnCount(_rs.c4Query);
+    }
 }
 
 

--- a/Objective-C/CBLQueryResultSet.mm
+++ b/Objective-C/CBLQueryResultSet.mm
@@ -95,10 +95,10 @@ namespace cbl {
     if (self.randomAccess)
         return nil;
     
-    CBLDatabase* strongDB = self.database;
-    Assert(strongDB, @"Database has been released.");
-    
-    CBL_LOCK(strongDB) {
+    // TODO: We should make it strong reference instead:
+    // https://github.com/couchbase/couchbase-lite-ios/issues/1983
+    CBLDatabase* db = self.database;
+    CBL_LOCK(db) {
         id row = nil;
         if (c4queryenum_next(_c4enum, &_error)) {
             row = self.currentObject;
@@ -120,10 +120,10 @@ namespace cbl {
 
 // Called by CBLQueryResultsArray
 - (id) objectAtIndex: (NSUInteger)index {
-    CBLDatabase* strongDB = self.database;
-    Assert(strongDB, @"Database has been released.");
-    
-    CBL_LOCK(strongDB) {
+    // TODO: We should make it strong reference instead:
+    // https://github.com/couchbase/couchbase-lite-ios/issues/1983
+    CBLDatabase* db = self.database;
+    CBL_LOCK(db) {
         if (!c4queryenum_seek(_c4enum, index, &_error)) {
             NSString* message = sliceResult2string(c4error_getMessage(_error));
             [NSException raise: NSInternalInconsistencyException
@@ -135,11 +135,11 @@ namespace cbl {
 
 
 - (NSArray*) allObjects {
-    CBLDatabase* strongDB = self.database;
-    Assert(strongDB, @"Database has been released.");
-    
     NSInteger count;
-    CBL_LOCK(strongDB) {
+    // TODO: We should make it strong reference instead:
+    // https://github.com/couchbase/couchbase-lite-ios/issues/1983
+    CBLDatabase* db = self.database;
+    CBL_LOCK(db) {
         count = (NSInteger)c4queryenum_getRowCount(_c4enum, nullptr);
     }
     
@@ -165,15 +165,12 @@ namespace cbl {
     if (outError)
         *outError = nil;
     
-    CBLDatabase* strongDB = self.database;
-    if (!strongDB) {
-        CBLWarn(Query, @"Database has already been released.");
-        return nil;
-    }
-    
     C4Error c4error;
     C4QueryEnumerator *newEnum;
-    CBL_LOCK(strongDB) {
+    // TODO: We should make it strong reference instead:
+    // https://github.com/couchbase/couchbase-lite-ios/issues/1983
+    CBLDatabase* db = self.database;
+    CBL_LOCK(db) {
         newEnum = c4queryenum_refresh(_c4enum, &c4error);
     }
     if (!newEnum) {

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -180,8 +180,12 @@ static NSTimeInterval retryDelay(unsigned retryCount) {
         .callbackContext = (__bridge void*)self,
         // TODO: Add .validationFunc (public API TBD)
     };
-    C4Error err;
-    _repl = c4repl_new(_config.database.c4db, addr, dbName, otherDB.c4db, params, &err);
+    
+    __block C4Error err;
+    [_config.database withLock: ^{
+        _repl = c4repl_new(_config.database.c4db, addr, dbName, otherDB.c4db, params, &err);
+    }];
+    
     C4ReplicatorStatus status;
     if (_repl) {
         status = c4repl_getStatus(_repl);

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -181,10 +181,10 @@ static NSTimeInterval retryDelay(unsigned retryCount) {
         // TODO: Add .validationFunc (public API TBD)
     };
     
-    __block C4Error err;
-    [_config.database withLock: ^{
+    C4Error err;
+    CBL_LOCK(_config.database) {
         _repl = c4repl_new(_config.database.c4db, addr, dbName, otherDB.c4db, params, &err);
-    }];
+    }
     
     C4ReplicatorStatus status;
     if (_repl) {

--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable struct c4BlobStore*) getBlobStore: (NSError**)outError;
 - (bool) resolveConflictInDocument: (NSString*)docID
-                     usingResolver: (nullable id<CBLConflictResolver>)resolver
+                     usingResolver: (id<CBLConflictResolver>)resolver
                              error: (NSError**)outError;
 
 @end

--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -33,11 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CBLDatabase ()
 
 @property (readonly, nonatomic, nullable) C4Database* c4db;
+@property (readonly, nonatomic) dispatch_queue_t dispatchQueue;
 @property (readonly, nonatomic) NSMapTable<NSURL*,CBLReplicator*>* replications;
 @property (readonly, nonatomic) NSMutableSet* activeReplications;
 
 @property (readonly, nonatomic) FLSharedKeys sharedKeys;
 
+- (void) withLock: (void(^)(void))block;
 - (nullable struct c4BlobStore*) getBlobStore: (NSError**)outError;
 - (bool) resolveConflictInDocument: (NSString*)docID
                      usingResolver: (nullable id<CBLConflictResolver>)resolver

--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -39,7 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) FLSharedKeys sharedKeys;
 
-- (void) withLock: (void(^)(void))block;
 - (nullable struct c4BlobStore*) getBlobStore: (NSError**)outError;
 - (bool) resolveConflictInDocument: (NSString*)docID
                      usingResolver: (nullable id<CBLConflictResolver>)resolver

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -33,6 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) setEncodingError: (NSError*)error;
 
+/** For conflict resolver to know that the document is being deleted. */
+- (void) markAsDeleted;
+
 @end
 
 //////////////////
@@ -66,7 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype) initWithDatabase: (CBLDatabase*)database
                        documentID: (NSString*)documentID
-                        mustExist: (BOOL)mustExist
                    includeDeleted: (BOOL)includeDeleted
                             error: (NSError**)outError;
 

--- a/Objective-C/Internal/CBLLock.h
+++ b/Objective-C/Internal/CBLLock.h
@@ -1,0 +1,21 @@
+//
+//  CBLLock.h
+//  CouchbaseLite
+//
+//  Created by Pasin Suriyentrakorn on 11/22/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+
+#ifndef CBLLock_h
+#define CBLLock_h
+
+#if CBL_THREADSAFE
+    #if DEBUG
+        #define CBL_LOCK(m) assert(m); @synchronized(m)
+    #else
+        #define CBL_LOCK(m) @synchronized(m)
+    #endif
+#endif
+
+#endif /* CBLLock_h */

--- a/Objective-C/Internal/CBLLock.h
+++ b/Objective-C/Internal/CBLLock.h
@@ -7,8 +7,7 @@
 //
 
 
-#ifndef CBLLock_h
-#define CBLLock_h
+#pragma once
 
 #if CBL_THREADSAFE
     #if DEBUG
@@ -17,5 +16,3 @@
         #define CBL_LOCK(m) @synchronized(m)
     #endif
 #endif
-
-#endif /* CBLLock_h */

--- a/Objective-C/Internal/CBLPrefix.h
+++ b/Objective-C/Internal/CBLPrefix.h
@@ -17,6 +17,11 @@
 extern "C" {
 #endif
 
+#ifndef CBL_THREADSAFE
+#define CBL_THREADSAFE 1
+#endif
+    
+#import "CBLLock.h"
 #import "CollectionUtils.h"
 #import "Test.h"
 

--- a/Objective-C/Tests/ConcurrentTest.m
+++ b/Objective-C/Tests/ConcurrentTest.m
@@ -1,0 +1,323 @@
+//
+//  ConcurrentTest.m
+//  CBL ObjC Tests
+//
+//  Created by Pasin Suriyentrakorn on 11/22/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#import "CBLTestCase.h"
+#import "CollectionUtils.h"
+
+#define kDocumentTestBlob @"i'm blob"
+
+@interface ConcurrentTest : CBLTestCase
+
+@end
+
+@implementation ConcurrentTest
+
+
+- (void) setProperties: (id <CBLMutableDictionary>)dictionary
+                custom: (nullable NSDictionary*)custom
+{
+    [dictionary setValue: @"Daniel" forKey: @"firstName"];
+    [dictionary setValue: @"Tiger" forKey: @"lastName"];
+    [dictionary setInteger: 10 forKey: @"score"];
+    
+    NSData* data = [@"Concurrent Test" dataUsingEncoding: NSUTF8StringEncoding];
+    CBLBlob* blob = [[CBLBlob alloc] initWithContentType: @"text/plain" data: data];
+    [dictionary setValue: blob forKey: @"blob"];
+    
+    CBLMutableDictionary* address = [[CBLMutableDictionary alloc] init];
+    [dictionary setValue: address forKey: @"address"];
+    
+    // Array:
+    CBLMutableArray* array = array = [[CBLMutableArray alloc] init];
+    [array addValue: @"650-123-0001"];
+    [array addValue: @"650-123-0002"];
+    [dictionary setValue: array forKey: @"phones"];
+    
+    // Date:
+    [dictionary setValue: [NSDate date] forKey: @"date"];
+    
+    // Custom:
+    for (NSString* key in custom) {
+        [dictionary setValue: custom[key] forKey: key];
+    }
+}
+
+
+- (CBLMutableDocument*) createDoc {
+    CBLMutableDocument* doc = [[CBLMutableDocument alloc] init];
+    [self setProperties: doc custom: nil];
+    return doc;
+}
+
+
+- (NSArray*) createAndSaveDocs: (NSUInteger)nDocs  error: (NSError**)error {
+    NSMutableArray* docs = [NSMutableArray arrayWithCapacity: nDocs];
+    for (NSUInteger i = 0; i < nDocs; i++) {
+        CBLMutableDocument* doc = [self createDoc];
+        CBLDocument* savedDoc = [self.db saveDocument: doc error: error];
+        if (!savedDoc)
+            return nil;
+        [docs addObject: savedDoc];
+    }
+    return docs;
+}
+
+
+- (BOOL) updateDoc: (CBLMutableDocument*)doc
+            custom: (nullable NSDictionary*)custom
+             error: (NSError**)error
+{
+    [self setProperties: doc custom: custom];
+    return [self.db saveDocument: doc error: error] != nil;
+}
+
+
+- (BOOL) updateDocIDs: (NSArray*)docIds
+               rounds: (NSUInteger)rounds
+               custom: (nullable NSDictionary*)custom
+                error: (NSError**)error
+{
+    for (NSUInteger r = 0; r < rounds; r++) {
+        for (NSString* docId in docIds) {
+            CBLMutableDocument* doc = [[self.db documentWithID: docId] toMutable];
+            [self updateDoc: doc custom: custom error: error];
+        }
+    }
+    return YES;
+}
+
+
+- (void) verifyWhere: (nullable CBLQueryExpression*)expr
+                test: (void (^)(uint64_t n, CBLQueryRow *row))block {
+    CBLQuery* q = [CBLQuery select: @[[CBLQuerySelectResult expression: [CBLQueryMeta id]]]
+                              from: [CBLQueryDataSource database: self.db]
+                             where: expr];
+    NSError* error;
+    NSEnumerator* e = [q execute: &error];
+    Assert(e, @"Query failed: %@", error);
+    uint64_t n = 0;
+    for (CBLQueryRow *row in e) {
+        block(++n, row);
+    }
+}
+
+
+- (void) concurrentRuns: (NSUInteger)nRuns
+          waitUntilDone: (BOOL)wait
+              withBlock: (void (^)(NSUInteger rIndex))block
+{
+    NSMutableArray* expects = [NSMutableArray arrayWithCapacity: nRuns];
+    for (NSUInteger i = 0; i < nRuns; i++) {
+        NSString* name = [NSString stringWithFormat: @"Queue-%ld", (long)i];
+        XCTestExpectation* exp = [self expectationWithDescription: name];
+        [expects addObject: exp];
+        dispatch_queue_t queue = dispatch_queue_create([name UTF8String],  NULL);
+        dispatch_async(queue, ^{
+            block(i);
+            [exp fulfill];
+        });
+    }
+    
+    if (wait && expects.count > 0) {
+        [self waitForExpectations: expects timeout: 60.0];
+    }
+}
+
+
+#pragma mark - Database
+
+
+- (void) testConcurrentCreateDocs {
+    const NSUInteger kNDocs = 100;
+    const NSUInteger kNConcurrents = 5;
+    
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        NSError* error;
+        Assert([self createAndSaveDocs: kNDocs error: &error],
+               @"Error creating docs: %@", error);
+    }];
+    
+    AssertEqual(self.db.count, kNDocs * kNConcurrents);
+}
+
+
+- (void) testConcurrentReadDocs {
+    const NSUInteger kNDocs = 100;
+    const NSUInteger kNRounds = 20;
+    const NSUInteger kNConcurrents = 5;
+    
+    
+    NSArray* docs = [self createAndSaveDocs: kNDocs error: nil];
+    NSArray* docIds = [docs my_map: ^id(CBLDocument* doc) {
+        return doc.id;
+    }];
+    
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        for (NSUInteger r = 0; r < kNRounds; r++) {
+            for (NSString* docId in docIds) {
+                CBLDocument* doc = [self.db documentWithID: docId];
+                Assert(doc != nil);
+            }
+        }
+    }];
+}
+
+
+// https://github.com/couchbase/couchbase-lite-ios/issues/1967
+- (void) failingTestConcurrentReadForUpdatesDocs {
+    const NSUInteger kNDocs = 100;
+    const NSUInteger kNRounds = 10;
+    const NSUInteger kNConcurrents = 5;
+    
+    NSArray* docs = [self createAndSaveDocs: kNDocs error: nil];
+    NSArray* docIds = [docs my_map: ^id(CBLDocument* doc) {
+        return doc.id;
+    }];
+    
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        for (NSUInteger r = 0; r < kNRounds; r++) {
+            for (NSString* docId in docIds) {
+                CBLMutableDocument* mDoc = [[self.db documentWithID: docId] toMutable];
+                Assert(mDoc != nil);
+            }
+        }
+    }];
+}
+
+
+// https://github.com/couchbase/couchbase-lite-ios/issues/1967
+- (void) failingTestConcurrentUpdateSeperateDocInstances {
+    const NSUInteger kNDocs = 1;
+    const NSUInteger kNRounds = 10;
+    const NSUInteger kNConcurrents = 5;
+    
+    NSArray* docs = [self createAndSaveDocs: kNDocs error: nil];
+    NSArray* docIds = [docs my_map: ^id(CBLDocument* doc) {
+        return doc.id;
+    }];
+    
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        NSString* tag = [NSString stringWithFormat:@"Update%ld", (long)rIndex];
+        NSError* error;
+        Assert([self updateDocIDs: docIds rounds: kNRounds custom: @{@"tag": tag} error: &error],
+               @"Error updating doc: %@", error);
+    }];
+    
+    __block NSUInteger count = 0;
+    
+    for (NSUInteger i = 0; i < kNConcurrents; i++) {
+        NSString* tag = [NSString stringWithFormat:@"Update%ld", (long)i];
+        CBLQueryExpression* expr = [[CBLQueryExpression property: @"tag"] equalTo: tag];
+        [self verifyWhere: expr test: ^(uint64_t n, CBLQueryRow *row) {
+            count++;
+        }];
+    }
+    
+    AssertEqual(count, kNDocs);
+}
+
+
+- (void) testConcurrentDeleteDocs {
+    const NSUInteger kNDocs = 5;
+    const NSUInteger kNConcurrents = 5;
+    
+    NSArray* docs = [self createAndSaveDocs: kNDocs error: nil];
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        for (CBLDocument* doc in docs) {
+            NSError* error;
+            Assert([self.db deleteDocument: doc error: &error], @"Error when delete: %@", error);
+        }
+    }];
+    
+    AssertEqual(self.db.count, 0u);
+}
+
+
+- (void) testConcurrentInBatch {
+    const NSUInteger kNDocs = 100;
+    const NSUInteger kNConcurrents = 5;
+    
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        NSError* error;
+        [self.db inBatch: &error usingBlock: ^{
+            NSError* err;
+            Assert([self createAndSaveDocs: kNDocs error: &err],
+                   @"Error creating docs: %@", err);
+        }];
+    }];
+    
+    AssertEqual(self.db.count, kNDocs * kNConcurrents);
+}
+
+
+- (void) testConcurrentPurgeDocs {
+    const NSUInteger kNDocs = 100;
+    const NSUInteger kNConcurrents = 5;
+    
+    NSArray* docs = [self createAndSaveDocs: kNDocs error: nil];
+    
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        for (CBLDocument* doc in docs) {
+            NSError* error;
+            if (![self.db purgeDocument: doc error: &error])
+                AssertEqual(error.code, 404);
+        }
+    }];
+    AssertEqual(self.db.count, 0u);
+}
+
+
+- (void) testConcurrentCompact {
+    const NSUInteger kNDocs = 100;
+    const NSUInteger kNRounds = 10;
+    const NSUInteger kNConcurrents = 5;
+    
+    [self createAndSaveDocs: kNDocs error: nil];
+    [self concurrentRuns: kNConcurrents waitUntilDone: YES withBlock: ^(NSUInteger rIndex) {
+        for (NSUInteger i = 0; i < kNRounds; i++) {
+            NSError* error;
+            Assert([self.db compact: &error], @"Error when compact: %@", error);
+        }
+    }];
+}
+
+
+- (void) testDatabaseChange {
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Create"];
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Change"];
+    [self.db addChangeListener: ^(CBLDatabaseChange *change) {
+        [self waitForExpectations: @[exp1] timeout: 5.0]; // Test deadlock
+        [exp2 fulfill];
+    }];
+    
+    [self concurrentRuns: 1 waitUntilDone: NO withBlock: ^(NSUInteger rIndex) {
+        [_db saveDocument: [[CBLMutableDocument alloc] initWithID: @"doc1"]  error: nil];
+        [exp1 fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout: 10.0 handler:^(NSError * _Nullable error) { }];
+}
+
+
+- (void) testDocumentChange {
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Create"];
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Change"];
+    [self.db addDocumentChangeListenerWithID: @"doc1" listener: ^(CBLDocumentChange *change) {
+        [self waitForExpectations: @[exp1] timeout: 5.0]; // Test deadlock
+        [exp2 fulfill];
+    }];
+    
+    [self concurrentRuns: 1 waitUntilDone: NO withBlock: ^(NSUInteger rIndex) {
+        [_db saveDocument: [[CBLMutableDocument alloc] initWithID: @"doc1"]  error: nil];
+        [exp1 fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout: 10.0 handler:^(NSError * _Nullable error) { }];
+}
+
+@end


### PR DESCRIPTION
* Created CBL_LOCK(m) macro for locking.
* Applied the lock to non-thread safe database operations by following the guideline from https://github.com/couchbase/couchbase-lite-core/wiki/Thread-Safety.

#1948