### PR TITLE
Fix #1898 without blocking the main thread

### DIFF
--- a/Source/CBLRestReplicator+Internal.h
+++ b/Source/CBLRestReplicator+Internal.h
@@ -15,7 +15,7 @@
 @interface CBLRestReplicator ()
 {
     @protected
-    BOOL _running, _online, _active;
+    BOOL _running, _online;
     CBL_ReplicatorSettings* _settings;
     CBLDatabase* __weak _db;
     NSString* _lastSequence;

--- a/Source/CBLRestReplicator.h
+++ b/Source/CBLRestReplicator.h
@@ -14,8 +14,10 @@
 /** Abstract base class for push or pull replications. */
 @interface CBLRestReplicator : NSObject <CBL_Replicator>
 
+@property (readonly, atomic) BOOL active; // for backgrounding and unit tests
+
 #if DEBUG
-@property (readonly) BOOL running, active; // for unit tests
+@property (readonly) BOOL running; // for unit tests
 #endif
 
 @end


### PR DESCRIPTION
* Reverted the fix back to 1.4.0 that executes background / foregrounding logic on the main thread.

* In CBLRestReplicator.m, make CBLRestReplicator’s `_active` property atomic.

* In CBLRestReplicator.m, moved calling `[self setupBackgrounding]` to the end of the `-start` method.

* In `-backgroundTaskExpired` of CBLRestReplicator+Backgrounding.m, set `_deepBackground = YES` on the main thread instead of on the replicator thread as it was in 1.4.0.

#1898