### PR TITLE
Improve tests of replication to SG

### DIFF
--- a/Objective-C/Tests/iOS/Info-Tests.plist
+++ b/Objective-C/Tests/iOS/Info-Tests.plist
@@ -18,5 +18,20 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>local</key>
+			<dict>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Objective-C/Tests/iOS/Info.plist
+++ b/Objective-C/Tests/iOS/Info.plist
@@ -41,5 +41,20 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>local</key>
+			<dict>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
* These tests can be enabled via an environment variable without having to edit the source
* SG hostname and port can be customized
* eraseRemoteEndpoint now detects HTTP errors
* Added ATS exceptions to Info.plist so iOS can make non-SSL connections