### PR TITLE
Declare NSError domain and codes in public API, and improve error mapping

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		273E55471F79AF5E000182F1 /* ConflictTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 93384F731EB14ABA00976B41 /* ConflictTest.m */; };
 		273E555D1F79AF69000182F1 /* ArrayTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 93DD9BA71EB419BB00E502A2 /* ArrayTest.m */; };
 		273E555E1F79AF79000182F1 /* MiscTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 93384F8B1EB151C100976B41 /* MiscTest.m */; };
+		2747666420191BFA007B39D1 /* CBLErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 27476651201912B5007B39D1 /* CBLErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27476665201946A3007B39D1 /* CBLErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 27476651201912B5007B39D1 /* CBLErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		275229C71E776BC100E630FA /* CBLReplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 275229C51E776BC100E630FA /* CBLReplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		275229C81E776BC100E630FA /* CBLReplicator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 275229C61E776BC100E630FA /* CBLReplicator.mm */; };
 		2753AFF51EC39CA200C12E98 /* CBLHTTPLogic.h in Headers */ = {isa = PBXBuildFile; fileRef = 2753AFF11EC39CA200C12E98 /* CBLHTTPLogic.h */; };
@@ -790,6 +792,7 @@
 		2704F1C71E395F3300A3B405 /* CBLConflictResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLConflictResolver.h; sourceTree = "<group>"; };
 		2704F1C81E395F3300A3B405 /* CBLConflictResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLConflictResolver.m; sourceTree = "<group>"; };
 		2728509C1E99CA4D009CA22F /* CBLReplicator+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "CBLReplicator+Internal.h"; path = "../CBLReplicator+Internal.h"; sourceTree = "<group>"; };
+		27476651201912B5007B39D1 /* CBLErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLErrors.h; sourceTree = "<group>"; };
 		274D6C272011529D00DAB7DD /* CBLLog+Admin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLLog+Admin.h"; sourceTree = "<group>"; };
 		275229C51E776BC100E630FA /* CBLReplicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLReplicator.h; sourceTree = "<group>"; };
 		275229C61E776BC100E630FA /* CBLReplicator.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLReplicator.mm; sourceTree = "<group>"; };
@@ -1333,6 +1336,7 @@
 				93E17EF71ED3ABE200671CA1 /* CBLDocumentChange.m */,
 				932A88231F4CCB3E0005AFB8 /* CBLEncryptionKey.h */,
 				932A88241F4CCB3E0005AFB8 /* CBLEncryptionKey.m */,
+				27476651201912B5007B39D1 /* CBLErrors.h */,
 				9385F2651FC38F8900032037 /* CBLListenerToken.h */,
 			);
 			name = Database;
@@ -1885,6 +1889,7 @@
 				93DBCFF72004B5FD0017CA83 /* CBLEndpoint.h in Headers */,
 				9384D8471FC407BA00FE89D8 /* CBLFullTextMatchExpression.h in Headers */,
 				9383A58B1F1EE8EF0083053D /* CBLQueryResult.h in Headers */,
+				27476665201946A3007B39D1 /* CBLErrors.h in Headers */,
 				9385F2CA1FC5FF4D00032037 /* CBLLock.h in Headers */,
 				93B75C1B1E79EF690033B61B /* CBLQueryExpression.h in Headers */,
 				93B41CB11F04706100A7F114 /* CBLReplicatorChange.h in Headers */,
@@ -1992,6 +1997,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2747666420191BFA007B39D1 /* CBLErrors.h in Headers */,
 				938B36A4200745FF004485D8 /* CBLQueryResultArray.h in Headers */,
 				93EC42E61FB3930E00D54BB4 /* CBLQueryArrayExpression.h in Headers */,
 				9384D8401FC405D200FE89D8 /* CBLQueryFullTextFunction.h in Headers */,

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -645,8 +645,8 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
     if (!document.database) {
         document.database = self;
     } else if (document.database != self) {
-        return createError(kCBLStatusForbidden,
-                           @"The document is from the different database.", error);
+        return createError(CBLErrorInvalidParameter,
+                           @"The document is from a different database.", error);
     }
     return YES;
 }
@@ -1049,7 +1049,7 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
         BOOL success = [self saveResolvedDocument: resolved
                                       forConflict: conflict
                                             error: &err];
-        if ($equal(err.domain, @"LiteCore") && err.code == kC4ErrorConflict)
+        if ($equal(err.domain, CBLErrorDomain) && err.code == CBLErrorConflict)
             continue;
         
         if (outError)

--- a/Objective-C/CBLErrors.h
+++ b/Objective-C/CBLErrors.h
@@ -1,0 +1,80 @@
+//
+//  CBLErrors.h
+//  CBL ObjC
+//
+//  Created by Jens Alfke on 1/24/18.
+//  Copyright © 2018 Couchbase. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+/** NSError domain for Couchbase Lite errors. */
+extern NSErrorDomain const CBLErrorDomain;
+
+
+NS_ERROR_ENUM(CBLErrorDomain) {
+    CBLErrorAssertionFailed = 1,    // Internal assertion failure
+    CBLErrorUnimplemented,          // Oops, an unimplemented API call
+    CBLErrorNoSequences,            // This KeyStore does not support sequences
+    CBLErrorUnsupportedEncryption,  // Unsupported encryption algorithm
+    CBLErrorNoTransaction,          // Function must be called within a transaction
+    CBLErrorBadRevisionID,          // Invalid revision ID syntax
+    CBLErrorBadVersionVector,       // Invalid version vector syntax
+    CBLErrorCorruptRevisionData,    // Revision contains corrupted/unreadable data
+    CBLErrorCorruptIndexData,       // Index contains corrupted/unreadable data
+    CBLErrorTokenizerError, /*10*/  // can't create text tokenizer for FTS
+    CBLErrorNotOpen,                // Database/KeyStore/index is not open
+    CBLErrorNotFound,               // Document not found
+    CBLErrorDeleted,                // Document has been deleted
+    CBLErrorConflict,               // Document update conflict
+    CBLErrorInvalidParameter,       // Invalid function parameter or struct value
+    CBLErrorDatabaseError,          // Lower-level database error (SQLite)
+    CBLErrorUnexpectedError,        // Internal unexpected C++ exception
+    CBLErrorCantOpenFile,           // Database file can't be opened; may not exist
+    CBLErrorIOError,                // File I/O error
+    CBLErrorCommitFailed, /*20*/    // Transaction commit failed
+    CBLErrorMemoryError,            // Memory allocation failed (out of memory?)
+    CBLErrorNotWriteable,           // File is not writeable
+    CBLErrorCorruptData,            // Data is corrupted
+    CBLErrorBusy,                   // Database is busy/locked
+    CBLErrorNotInTransaction,       // Function cannot be called while in a transaction
+    CBLErrorTransactionNotClosed,   // Database can't be closed while a transaction is open
+    CBLErrorIndexBusy,              // (unused)
+    CBLErrorUnsupported,            // Operation not supported in this database
+    CBLErrorNotADatabaseFile,       // File is not a database, or encryption key is wrong
+    CBLErrorWrongFormat, /*30*/     // Database exists but not in the format/storage requested
+    CBLErrorCrypto,                 // Encryption/decryption error
+    CBLErrorInvalidQuery,           // Invalid query
+    CBLErrorMissingIndex,           // No such index, or query requires a nonexistent index
+    CBLErrorInvalidQueryParam,      // Unknown query param name, or param number out of range
+    CBLErrorRemoteError,            // Unknown error from remote server
+    CBLErrorDatabaseTooOld,         // Database file format is older than what I can open
+    CBLErrorDatabaseTooNew,         // Database file format is newer than what I can open
+    CBLErrorBadDocID,               // Invalid document ID
+    CBLErrorCantUpgradeDatabase,    // Database can't be upgraded (might be unsupported dev version)
+    // Note: These are equivalent to the C4Error codes declared in LiteCore's c4Base.h
+
+    CBLErrorHTTPBase                = 10000,    // ---- HTTP status codes start here
+    CBLErrorHTTPAuthRequired        = 10401,    // Missing or incorrect user authentication
+    CBLErrorHTTPForbidden           = 10403,    // User doesn't have permission to access resource
+    CBLErrorHTTPNotFound            = 10404,    // Resource not found
+    CBLErrorHTTPConflict            = 10409,    // Update conflict
+    CBLErrorHTTPProxyAuthRequired   = 10407,    // HTTP proxy requires authentication
+    CBLErrorHTTPEntityTooLarge      = 10413,    // Data is too large to upload
+    CBLErrorHTTPImATeapot           = 10418,    // HTCPCP/1.0 error (RFC 2324)
+    CBLErrorHTTPInternalServerError = 10500,    // Something's wrong with the server
+    CBLErrorHTTPNotImplemented      = 10501,    // Unimplemented server functionality
+    CBLErrorHTTPServiceUnavailable  = 10503,    // Service is down temporarily(?)
+
+    CBLErrorWebSocketBase             = 11000,  // ---- WebSocket status codes start here
+    CBLErrorWebSocketGoingAway        = 11001,  // Peer has to close, e.g. because host app is quitting
+    CBLErrorWebSocketProtocolError    = 11002,  // Protocol violation: invalid framing data
+    CBLErrorWebSocketDataError        = 11003,  // Message payload cannot be handled
+    CBLErrorWebSocketAbnormalClose    = 11006,  // TCP socket closed unexpectedly
+    CBLErrorWebSocketBadMessageFormat = 11007,  // Unparseable WebSocket message
+    CBLErrorWebSocketPolicyError      = 11008,  // Message violated unspecified policy
+    CBLErrorWebSocketMessageTooBig    = 11009,  // Message is too large for peer to handle
+    CBLErrorWebSocketMissingExtension = 11010,  // Peer doesn't provide a necessary extension
+    CBLErrorWebSocketCantFulfill      = 11011,  // Can't fulfill request due to "unexpected condition"
+};

--- a/Objective-C/CBLPredicateQuery+Predicates.mm
+++ b/Objective-C/CBLPredicateQuery+Predicates.mm
@@ -16,11 +16,6 @@ extern "C" {
 #import "Test.h"
 }
 
-#define kBadQuerySpecError -1
-#define CBLErrorDomain @"CouchbaseLite"
-#define mkError(ERR, FMT, ...)  MYReturnError(ERR, kBadQuerySpecError, CBLErrorDomain, \
-                                              FMT, ## __VA_ARGS__)
-
 
 typedef NS_OPTIONS(NSUInteger, CollationOptions) {
     kUnicode                = 1,

--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -661,7 +661,7 @@
         
         if ([map objectForKey: name]) {
             NSString* desc = [NSString stringWithFormat: @"Duplicate select result named %@", name];
-            createError(kCBLStatusInvalidQuery, desc, outError);
+            createError(CBLErrorInvalidQuery, desc, outError);
             return nil;
         }
         

--- a/Objective-C/CouchbaseLite.exp
+++ b/Objective-C/CouchbaseLite.exp
@@ -58,3 +58,8 @@
 .objc_class_name_CBLURLEndpoint
 .objc_class_name_CBLValueIndex
 .objc_class_name_CBLValueIndexItem
+
+# NSString constants:
+_CBLErrorDomain
+_kCBLAllPropertiesName
+

--- a/Objective-C/CouchbaseLite.h
+++ b/Objective-C/CouchbaseLite.h
@@ -29,6 +29,7 @@ FOUNDATION_EXPORT const unsigned char CouchbaseLiteVersionString[];
 #import "CBLDocumentFragment.h"
 #import "CBLEncryptionKey.h"
 #import "CBLEndpoint.h"
+#import "CBLErrors.h"
 #import "CBLFragment.h"
 #import "CBLFullTextIndex.h"
 #import "CBLIndex.h"

--- a/Objective-C/Internal/CBLMisc.m
+++ b/Objective-C/Internal/CBLMisc.m
@@ -62,8 +62,5 @@ BOOL CBLIsFileExistsError( NSError* error ) {
     NSString* domain = error.domain;
     NSInteger code = error.code;
     return ($equal(domain, NSPOSIXErrorDomain) && code == EEXIST)
-#ifndef GNUSTEP
-    || ($equal(domain, NSCocoaErrorDomain) && code == NSFileWriteFileExistsError)
-#endif
-    ;
+        || ($equal(domain, NSCocoaErrorDomain) && code == NSFileWriteFileExistsError);
 }

--- a/Objective-C/Internal/CBLPredicateQuery+Internal.h
+++ b/Objective-C/Internal/CBLPredicateQuery+Internal.h
@@ -8,6 +8,7 @@
 
 #import "CBLPredicateQuery.h"
 #import "CBLQueryRow.h"
+#import "CBLErrors.h"
 #import "c4.h"
 @class CBLQueryEnumerator;
 
@@ -15,9 +16,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 
-#define kBadQuerySpecError -1
-#define CBLErrorDomain @"CouchbaseLite"
-#define mkError(ERR, FMT, ...)  MYReturnError(ERR, kBadQuerySpecError, CBLErrorDomain, \
+#define mkError(ERR, FMT, ...)  MYReturnError(ERR, CBLErrorInvalidQuery, CBLErrorDomain, \
                                               FMT, ## __VA_ARGS__)
 
 /** Used by CBLQueryEnumerator) */

--- a/Objective-C/Internal/CBLPropertyExpression.h
+++ b/Objective-C/Internal/CBLPropertyExpression.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString* kCBLAllPropertiesName;
+extern NSString* const kCBLAllPropertiesName;
 
 @interface CBLPropertyExpression : CBLQueryExpression
 

--- a/Objective-C/Internal/CBLPropertyExpression.m
+++ b/Objective-C/Internal/CBLPropertyExpression.m
@@ -9,7 +9,7 @@
 #import "CBLPropertyExpression.h"
 #import "CBLQueryExpression+Internal.h"
 
-NSString* kCBLAllPropertiesName = @"";
+NSString* const kCBLAllPropertiesName = @"";
 
 @implementation CBLPropertyExpression
 

--- a/Objective-C/Internal/CBLStatus.h
+++ b/Objective-C/Internal/CBLStatus.h
@@ -8,19 +8,11 @@
 
 #pragma once
 #import <Foundation/Foundation.h>
+#import "CBLErrors.h"
 #import "Fleece.h"
 #import "c4.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-typedef enum {
-    kCBLStatusForbidden = 403,
-    kCBLStatusNotFound = 404,
-    kCBLStatusNotAllow = 405,
-    
-    // Non-HTTP error:
-    kCBLStatusInvalidQuery = 490
-} CBLStatus;
 
 BOOL convertError(const C4Error &error, NSError* _Nullable * outError);
 
@@ -29,8 +21,8 @@ BOOL convertError(const FLError &error, NSError* _Nullable * outError);
 // Converts an NSError back to a C4Error (used by the WebSocket implementation)
 void convertError(NSError* error, C4Error *outError);
 
-BOOL createError(CBLStatus status, NSError* _Nullable * outError);
+BOOL createError(int status, NSError* _Nullable * outError);
 
-BOOL createError(CBLStatus status, NSString  * _Nullable  desc, NSError* _Nullable * outError);
+BOOL createError(int status, NSString  * _Nullable  desc, NSError* _Nullable * outError);
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/CBLStatus.mm
+++ b/Objective-C/Internal/CBLStatus.mm
@@ -10,35 +10,37 @@
 #import "CBLCoreBridge.h"
 #import <netdb.h>
 
-NSString* const kCBLErrorDomain = @"CouchbaseLite";
+NSErrorDomain const CBLErrorDomain          = @"CouchbaseLite";
+
+static NSErrorDomain const SQLiteErrorDomain    = @"CouchbaseLite.SQLite";
+static NSErrorDomain const FleeceErrorDomain    = @"CouchbaseLite.Fleece";
 
 
-static bool toC4Error(int cfNetworkErrorCode, C4Error *outError);
-static bool toCFNetworkError(C4Error err, int *outCode);
-
-
-static NSDictionary* statusDesc = @{
-    @(kCBLStatusForbidden) : @"forbidden",
-    @(kCBLStatusNotFound)  : @"not found"
-};
+static bool cfNetworkToC4Error(int cfNetworkErrorCode, C4Error *outError);
+static bool c4ToCFNetworkError(C4Error err, NSString* __autoreleasing *outDomain, int *outCode);
 
 
 BOOL convertError(const C4Error &c4err, NSError** outError) {
     NSCAssert(c4err.code != 0 && c4err.domain != 0, @"No C4Error");
-    static NSString* const kNSErrorDomains[kC4MaxErrorDomainPlus1] =
-        {nil, @"LiteCore", NSPOSIXErrorDomain, @"3", @"SQLite", @"Fleece", @"Network", @"WebSocket"};
+    static NSErrorDomain const kNSErrorDomains[kC4MaxErrorDomainPlus1] =
+        {nil, CBLErrorDomain, NSPOSIXErrorDomain, nil, SQLiteErrorDomain,
+         FleeceErrorDomain, nil, CBLErrorDomain};
     if (outError) {
         NSString* msgStr = sliceResult2string(c4error_getMessage(c4err));
-        NSString* domain = kNSErrorDomains[c4err.domain];
-        int code = c4err.code;
+        NSString* domain;
+        int code;
 
-        if (toCFNetworkError(c4err, &code)) {
-            // NSURLDomain is more commonly seen in Cocoa APIs, but kCFErrorDomainCFNetwork is a
-            // superset with more error codes. Use the former if the code is in range:
-            if (code <= -995 && code >= -3007)
-                domain = NSURLErrorDomain;
-            else
-                domain = (__bridge id)kCFErrorDomainCFNetwork;
+        if (!c4ToCFNetworkError(c4err, &domain, &code)) {
+            domain = kNSErrorDomains[c4err.domain];
+            code = c4err.code;
+            if (c4err.domain == WebSocketDomain)
+                code += CBLErrorHTTPBase;   // WebSocket and HTTP statuses are offset by 10000
+        }
+
+        if (domain == nil) {
+            C4Warn("Unable to map C4Error(%d,%d) to an NSError", c4err.domain, c4err.code);
+            domain = CBLErrorDomain;
+            code = CBLErrorUnexpectedError;
         }
 
         *outError = [NSError errorWithDomain: domain code: code
@@ -51,7 +53,7 @@ BOOL convertError(const C4Error &c4err, NSError** outError) {
 BOOL convertError(const FLError &flErr, NSError** outError) {
     NSCAssert(flErr != 0, @"No C4Error");
     if (outError)
-        *outError = [NSError errorWithDomain: FLErrorDomain code: flErr userInfo: nil];
+        *outError = [NSError errorWithDomain: FleeceErrorDomain code: flErr userInfo: nil];
     return NO;
 }
 
@@ -73,54 +75,58 @@ void convertError(NSError* error, C4Error *outError) {
             else
                 c4err.code = kC4NetErrDNSFailure;
         } else {
-            toC4Error(code, &c4err);
+            cfNetworkToC4Error(code, &c4err);
         }
     }
     *outError = c4error_make(c4err.domain, c4err.code, c4str(message));
 }
 
 
-BOOL createError(CBLStatus status,  NSError** outError) {
+BOOL createError(int status,  NSError** outError) {
     return createError(status, nil, outError);
 }
 
 
-BOOL createError(CBLStatus status,  NSString* desc, NSError** outError) {
+BOOL createError(int status,  NSString* desc, NSError** outError) {
     if (outError) {
-        if (!desc)
-            desc = statusDesc[@(status)];
+        if (!desc) {
+            C4StringResult msg = c4error_getMessage({LiteCoreDomain, status});
+            desc = slice2string({msg.buf, msg.size});
+            c4slice_free(msg);
+        }
         NSDictionary* info = @{ NSLocalizedFailureReasonErrorKey: desc,
                                 NSLocalizedDescriptionKey: desc };
-        *outError = [NSError errorWithDomain: kCBLErrorDomain  code: status userInfo: info];
+        *outError = [NSError errorWithDomain: CBLErrorDomain code: status userInfo: info];
     }
     return NO;
 }
 
 
-// Maps CFNetworkErrors to C4Errors ... see <CFNetwork/CFNetworkErrors.h>
+// Maps CFNetworkErrors <-> C4Errors ... see <CFNetwork/CFNetworkErrors.h>
 static const struct {int code; C4Error c4err;} kCFNetworkErrorMap[] = {
     {kCFErrorHTTPConnectionLost,                {POSIXDomain, ECONNRESET}},
     {kCFURLErrorCannotConnectToHost,            {POSIXDomain, ECONNREFUSED}},
     {kCFURLErrorNetworkConnectionLost,          {POSIXDomain, ECONNRESET}},
+    {kCFURLErrorDNSLookupFailed,                {NetworkDomain, kC4NetErrDNSFailure}},
     {kCFHostErrorHostNotFound,                  {NetworkDomain, kC4NetErrUnknownHost}},
     {kCFURLErrorTimedOut,                       {NetworkDomain, kC4NetErrTimeout}},
+    {kCFErrorHTTPBadURL,                        {NetworkDomain, kC4NetErrInvalidURL}},
     {kCFURLErrorHTTPTooManyRedirects,           {NetworkDomain, kC4NetErrTooManyRedirects}},
     {kCFErrorHTTPRedirectionLoopDetected,       {NetworkDomain, kC4NetErrTooManyRedirects}},
-    {kCFErrorHTTPBadURL,                        {NetworkDomain, kC4NetErrInvalidURL}},
     {kCFURLErrorSecureConnectionFailed,         {NetworkDomain, kC4NetErrTLSHandshakeFailed}},
     {kCFURLErrorServerCertificateHasBadDate,    {NetworkDomain, kC4NetErrTLSCertExpired}},
     {kCFURLErrorServerCertificateNotYetValid,   {NetworkDomain, kC4NetErrTLSCertExpired}},
     {kCFURLErrorServerCertificateUntrusted,     {NetworkDomain, kC4NetErrTLSCertUntrusted}},
-    {kCFURLErrorServerCertificateHasUnknownRoot,{NetworkDomain, kC4NetErrTLSCertUnknownRoot}},
     {kCFURLErrorClientCertificateRequired,      {NetworkDomain, kC4NetErrTLSClientCertRequired}},
     {kCFURLErrorClientCertificateRejected,      {NetworkDomain, kC4NetErrTLSClientCertRejected}},
+    {kCFURLErrorServerCertificateHasUnknownRoot,{NetworkDomain, kC4NetErrTLSCertUnknownRoot}},
     {kCFErrorHTTPBadProxyCredentials,           {WebSocketDomain, 407}},
     {0}
     // This list is incomplete but covers most of what will actually occur
 };
 
 
-static bool toC4Error(int code, C4Error *outError) {
+static bool cfNetworkToC4Error(int code, C4Error *outError) {
     for (int i = 0; kCFNetworkErrorMap[i].code; ++i) {
         if (kCFNetworkErrorMap[i].code == code) {
             *outError = kCFNetworkErrorMap[i].c4err;
@@ -131,12 +137,25 @@ static bool toC4Error(int code, C4Error *outError) {
 }
 
 
-static bool toCFNetworkError(C4Error err, int *outCode) {
+static bool c4ToCFNetworkError(C4Error err, NSString* __autoreleasing *outDomain, int *outCode) {
     for (auto map = kCFNetworkErrorMap; map->code; ++map) {
         if (map->c4err.code == err.code && map->c4err.domain == err.domain) {
             *outCode = map->code;
+            // NSURLDomain is more commonly seen in Cocoa APIs, but kCFErrorDomainCFNetwork is a
+            // superset with more error codes. Use the former if the code is in range:
+            if (map->code <= -995 && map->code >= -3007)
+                *outDomain = NSURLErrorDomain;
+            else
+                *outDomain = (__bridge id)kCFErrorDomainCFNetwork;
             return true;
         }
+    }
+    if (err.domain == NetworkDomain) {
+        // Make sure that all NetworkDomain errors are converted
+        C4Warn("Unable to map C4Error(NetworkDomain,%d) to a specific NSURLErrorDomain code", err.code);
+        *outCode = NSURLErrorUnknown;
+        *outDomain = NSURLErrorDomain;
+        return true;
     }
     return false;
 }

--- a/Objective-C/Tests/ConflictTest.m
+++ b/Objective-C/Tests/ConflictTest.m
@@ -8,6 +8,7 @@
 
 #import "ConflictTest.h"
 #import "CBLDatabase+Internal.h"
+#import "CBLErrors.h"
 
 #include "c4.h"
 #include "c4Document+Fleece.h"
@@ -213,8 +214,8 @@
     CBLMutableDocument* doc = [self setupConflict];
     NSError* error;
     AssertFalse([_db saveDocument: doc error: &error], @"Save should have failed!");
-    AssertEqualObjects(error.domain, @"LiteCore");      //TODO: Should have CBL error domain/code
-    AssertEqual(error.code, kC4ErrorConflict);
+    AssertEqualObjects(error.domain, CBLErrorDomain);
+    AssertEqual(error.code, CBLErrorConflict);
 }
 
 

--- a/Objective-C/Tests/DatabaseEncryptionTest.m
+++ b/Objective-C/Tests/DatabaseEncryptionTest.m
@@ -47,7 +47,7 @@
     _seekrit = nil;
     
     // Try to reopen with password (fails):
-    [self expectError: @"LiteCore" code: 29 in: ^BOOL(NSError **err) {
+    [self expectError: CBLErrorDomain code: CBLErrorNotADatabaseFile in: ^BOOL(NSError **err) {
         return [self openSeekritWithPassword: @"wrong" error: err] != nil;
     }];
     
@@ -70,12 +70,12 @@
     _seekrit = nil;
     
     // Reopen without password (fails):
-    [self expectError: @"LiteCore" code: 29 in: ^BOOL(NSError ** err) {
+    [self expectError: CBLErrorDomain code: CBLErrorNotADatabaseFile in: ^BOOL(NSError ** err) {
         return [self openSeekritWithPassword: nil error: err] != nil;
     }];
     
     // Reopen with wrong password (fails):
-    [self expectError: @"LiteCore" code: 29 in: ^BOOL(NSError ** err) {
+    [self expectError: CBLErrorDomain code: CBLErrorNotADatabaseFile in: ^BOOL(NSError ** err) {
         return [self openSeekritWithPassword: @"wrong" error: err] != nil;
     }];
     
@@ -109,7 +109,7 @@
     _seekrit = nil;
     
     // Make sure old password doesn't work:
-    [self expectError: @"LiteCore" code: 29 in: ^BOOL(NSError ** err) {
+    [self expectError: CBLErrorDomain code: CBLErrorNotADatabaseFile in: ^BOOL(NSError ** err) {
         return [self openSeekritWithPassword: @"letmein" error: err] != nil;
     }];
 }

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -234,7 +234,7 @@
 
 - (void) testCreateWithEmptyDBNames {
     // create db with default configuration
-    [self expectError: @"LiteCore" code: 30 in: ^BOOL(NSError** error) {
+    [self expectError: CBLErrorDomain code: CBLErrorWrongFormat in: ^BOOL(NSError** error) {
         return [self openDBNamed: @"" error: error] != nil;
     }];
 }
@@ -408,7 +408,7 @@
     
     // update doc & store it into different instance
     [doc setValue: @2 forKey: @"key"];
-    [self expectError: @"CouchbaseLite" code: 403 in: ^BOOL(NSError** error2) {
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** error2) {
         return [otherDB saveDocument: doc error: error2] != nil;
     }]; // forbidden
     
@@ -432,7 +432,7 @@
     
     // update doc & store it into different db
     [doc setValue: @2 forKey: @"key"];
-    [self expectError: @"CouchbaseLite" code: 403 in: ^BOOL(NSError** error2) {
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** error2) {
         return [otherDB saveDocument: doc error: error2] != nil;
     }]; // forbidden
     
@@ -665,7 +665,7 @@
     AssertEqual(1, (long)otherDB.count);
     
     // purge document against other db instance
-    [self expectError: @"CouchbaseLite" code: 403 in: ^BOOL(NSError** error2) {
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** error2) {
         return [otherDB purgeDocument: doc error: error2];
     }]; // forbidden
     AssertEqual(1, (long)otherDB.count);
@@ -691,7 +691,7 @@
     AssertEqual(0, (long)otherDB.count);
     
     // purge document against other db
-    [self expectError: @"CouchbaseLite" code: 403 in: ^BOOL(NSError** error2) {
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** error2) {
         return [otherDB purgeDocument: doc error: error2];
     }]; // forbidden
     
@@ -841,7 +841,7 @@
 - (void) testCloseThenCallInBatch {
     NSError* error;
     BOOL success = [self.db inBatch: &error usingBlock: ^{
-        [self expectError: @"LiteCore" code: 26 in: ^BOOL(NSError** error2) {
+        [self expectError: CBLErrorDomain code: CBLErrorTransactionNotClosed in: ^BOOL(NSError** error2) {
             return [self.db close: error2];
         }];
         // 26 -> kC4ErrorTransactionNotClosed
@@ -928,7 +928,7 @@
 - (void) testDeleteThenCallInBatch {
     NSError* error;
     BOOL sucess = [self.db inBatch: &error usingBlock:^{
-        [self expectError: @"LiteCore" code: 26 in: ^BOOL(NSError** error2) {
+        [self expectError: CBLErrorDomain code: CBLErrorTransactionNotClosed in: ^BOOL(NSError** error2) {
             return [self.db delete: error2];
         }];
         // 26 -> kC4ErrorTransactionNotClosed: Function cannot be called while in a transaction
@@ -946,7 +946,7 @@
     AssertNotNil(otherDB);
     
     // delete db
-    [self expectError: @"LiteCore" code: 24 in: ^BOOL(NSError** error2) {
+    [self expectError: CBLErrorDomain code: CBLErrorBusy in: ^BOOL(NSError** error2) {
         return [self.db delete: error2];
     }];
     // 24 -> kC4ErrorBusy: Database is busy/locked
@@ -989,7 +989,7 @@
     
     // delete db with nil directory
     // 24 -> kC4ErrorBusy: Database is busy/locked
-    [self expectError: @"LiteCore" code: 24 in: ^BOOL(NSError** error2) {
+    [self expectError: CBLErrorDomain code: CBLErrorBusy in: ^BOOL(NSError** error2) {
         return [CBLDatabase deleteDatabase: @"db" inDirectory: nil error: error2];
     }];
 }
@@ -1035,7 +1035,7 @@
     AssertNotNil(db);
     AssertNil(error);
     
-    [self expectError: @"LiteCore" code: 24 in: ^BOOL(NSError** error2) {
+    [self expectError: CBLErrorDomain code: CBLErrorBusy in: ^BOOL(NSError** error2) {
         return [CBLDatabase deleteDatabase: @"db" inDirectory: dir error: error2];
     }];
 }

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -88,8 +88,8 @@
     
     NSError *error;
     AssertFalse([_db saveDocument: doc error: &error]);
-    AssertEqual(error.code, 38); // Invalid docID
-    AssertEqualObjects(error.domain, @"LiteCore");
+    AssertEqual(error.code, CBLErrorBadDocID);
+    AssertEqualObjects(error.domain, CBLErrorDomain);
 }
 
 

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -555,7 +555,7 @@
     if (!target)
         return;
     id config = [self configWithTarget: target type: kCBLReplicatorPull continuous: NO];
-    [self run: config errorCode: 401 errorDomain: @"WebSocket"];
+    [self run: config errorCode: CBLErrorHTTPAuthRequired errorDomain: CBLErrorDomain];
 }
 
 

--- a/Swift/Tests/ConflictTest.swift
+++ b/Swift/Tests/ConflictTest.swift
@@ -132,8 +132,8 @@ class ConflictTest: CBLTestCase {
         let doc = try setupConflict()
         XCTAssertThrowsError(try saveDocument(doc), "") { (e) in
             let error = e as NSError
-            XCTAssertEqual(error.domain, "LiteCore")
-            XCTAssertEqual(error.code, 14)
+            XCTAssertEqual(error.domain, CBLErrorDomain)
+            XCTAssertEqual(error.code, CBLErrorConflict)
         }
     }
     

--- a/Swift/Tests/DatabaseEncryptionTest.swift
+++ b/Swift/Tests/DatabaseEncryptionTest.swift
@@ -38,7 +38,7 @@ class DatabaseEncryptionTest: CBLTestCase {
         seekrit = nil
         
         // Try to reopen with password (fails):
-        expectError(domain: "LiteCore", code: 29) {
+        expectError(domain: CBLErrorDomain, code: CBLErrorNotADatabaseFile) {
             try _ = self.openSeekrit(password: "wrong")
         }
         
@@ -57,12 +57,12 @@ class DatabaseEncryptionTest: CBLTestCase {
         seekrit = nil
         
         // Reopen without password (fails):
-        expectError(domain: "LiteCore", code: 29) {
+        expectError(domain: CBLErrorDomain, code: CBLErrorNotADatabaseFile) {
             try _ = self.openSeekrit(password: nil)
         }
         
         // Reopen with wrong password (fails):
-        expectError(domain: "LiteCore", code: 29) {
+        expectError(domain: CBLErrorDomain, code: CBLErrorNotADatabaseFile) {
             try _ = self.openSeekrit(password: "wrong")
         }
         
@@ -90,7 +90,7 @@ class DatabaseEncryptionTest: CBLTestCase {
         seekrit = nil
         
         // Make sure old password doesn't work:
-        expectError(domain: "LiteCore", code: 29) {
+        expectError(domain: CBLErrorDomain, code: CBLErrorNotADatabaseFile) {
             try _ = self.openSeekrit(password: "letmein")
         }
     }

--- a/Swift/Tests/DocumentTest.swift
+++ b/Swift/Tests/DocumentTest.swift
@@ -87,7 +87,7 @@ class DocumentTest: CBLTestCase {
         
         XCTAssertNotNil(error)
         XCTAssertEqual(error!.code, 38)
-        XCTAssertEqual(error!.domain, "LiteCore")
+        XCTAssertEqual(error!.domain, CBLErrorDomain)
     }
     
     


### PR DESCRIPTION
* Added public header CBLErrors.h which declares CBLErrorDomain and constants for all the LiteCore errors, plus HTTP and WebSocket codes.
* CBLStatus.m maps all NetworkDomain errors to NSURLErrorDomain.
* CBLStatus.m maps WebSocketDomain to CBLErrorDomain but offsets the codes by +10000 (as declared in CBLErrors.h)
* CBLStatus constants were folded into CBLErrorDomain codes.

Fixes #2006