### PR TITLE
Replication conflict resolution should always update remote branch

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1060,7 +1060,7 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
 }
 
 
-- (BOOL) saveResolvedDocument: (CBLDocument*)resolved
+- (BOOL) saveResolvedDocument: (CBLDocument*)resolvedDoc
                   forConflict: (CBLConflict*)conflict
                         error: (NSError**)outError
 {
@@ -1069,39 +1069,36 @@ static C4EncryptionKey c4EncryptionKey(CBLEncryptionKey* key) {
         if (!t.begin())
             return convertError(t.error(), outError);
         
-        auto doc = conflict.mine;
-        auto otherDoc = conflict.theirs;
-        
-        // Figure out what revision to delete and what if anything to add:
-        CBLStringBytes winningRevID, losingRevID;
+        auto localDoc = conflict.mine;
+        auto remoteDoc = conflict.theirs;
+        if (resolvedDoc != localDoc)
+            resolvedDoc.database = self;
+
+        // The remote branch has to win, so that the doc revision history matches the server's.
+        CBLStringBytes winningRevID = remoteDoc.revID;
+        CBLStringBytes losingRevID = localDoc.revID;
+
         NSData* mergedBody = nil;
-        if (resolved == otherDoc) {
-            winningRevID = otherDoc.revID;
-            losingRevID = doc.revID;
-        } else {
-            winningRevID = doc.revID;
-            losingRevID = otherDoc.revID;
-            if (resolved != doc) {
-                resolved.database = self;
-                mergedBody = [resolved encode: outError];
-                if (!mergedBody)
-                    return false;
-            }
+        if (resolvedDoc != remoteDoc) {
+            // Unless the remote revision is being used as-is, we need a new revision:
+            mergedBody = [resolvedDoc encode: outError];
+            if (!mergedBody)
+                return false;
         }
         
         // Tell LiteCore to do the resolution:
-        C4Document *rawDoc = doc.c4Doc.rawDoc;
+        C4Document *rawDoc = localDoc.c4Doc.rawDoc;
         C4Error c4err;
         if (!c4doc_resolveConflict(rawDoc,
                                    winningRevID,
                                    losingRevID,
                                    data2slice(mergedBody),
                                    &c4err)
-            || !c4doc_save(rawDoc, 0, &c4err)) {
+                || !c4doc_save(rawDoc, 0, &c4err)) {
             return convertError(c4err, outError);
         }
         CBLLog(Database, @"Conflict resolved as doc '%@' rev %.*s",
-               doc.id, (int)rawDoc->revID.size, rawDoc->revID.buf);
+               localDoc.id, (int)rawDoc->revID.size, rawDoc->revID.buf);
         
         return t.commit() || convertError(t.error(), outError);
     }

--- a/Objective-C/CBLDatabaseConfiguration.h
+++ b/Objective-C/CBLDatabaseConfiguration.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- The conflict resolver for this replicator. Setting nil means using the default
+ The conflict resolver for this database. Setting nil means using the default
  conflict resolver, where the revision with more history wins.
  */
 @property (nonatomic) id<CBLConflictResolver> conflictResolver;

--- a/Objective-C/Tests/ConflictTest.h
+++ b/Objective-C/Tests/ConflictTest.h
@@ -10,28 +10,35 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface TestResolver : NSObject <CBLConflictResolver>
+@property (atomic) BOOL requireBaseRevision;
+@property (readonly, atomic) BOOL wasCalled;
+@end
+
 /** Default Conflict Resolution set to ConflictTest which 
     will just make the assertion false as shouldn't be called. */
-@interface DoNotResolve : NSObject <CBLConflictResolver>
+@interface DoNotResolve : TestResolver
 @end
 
-/** Select theirs version. */
-@interface TheirsWins : NSObject <CBLConflictResolver>
+/** Select my version. */
+@interface MineWins : TestResolver
 @end
 
+/** Select their version. */
+@interface TheirsWins : TestResolver
+@end
 
-/** Merge or select theirs version. */
-@interface MergeThenTheirsWins : NSObject <CBLConflictResolver>
-@property (atomic) BOOL requireBaseRevision;
+/** Merge, but if both sides changed the same property then use their value. */
+@interface MergeThenTheirsWins : TestResolver
 @end
 
 /** Return nil to give up the conflict resolving. The document save operation will return 
     the conflicting error. */
-@interface GiveUp : NSObject <CBLConflictResolver>
+@interface GiveUp : TestResolver
 @end
 
 /** Block based resolver */
-@interface BlockResolver : NSObject <CBLConflictResolver>
+@interface BlockResolver : TestResolver
 
 @property (atomic, readonly) CBLDocument* (^block)(CBLConflict*);
 

--- a/Objective-C/Tests/ConflictTest.m
+++ b/Objective-C/Tests/ConflictTest.m
@@ -16,11 +16,36 @@
 #include "Fleece+CoreFoundation.h"
 
 
+@implementation TestResolver
+
+@synthesize wasCalled=_wasCalled, requireBaseRevision=_requireBaseRevision;
+
+- (CBLDocument*) resolve: (CBLConflict*)conflict {
+    _wasCalled = YES;
+    if (_requireBaseRevision)
+        NSAssert(conflict.base != nil, @"Missing base");
+    return nil;
+}
+
+@end
+
+
 @implementation DoNotResolve
 
 - (CBLDocument*) resolve: (CBLConflict*)conflict {
+    [super resolve: conflict];
     NSAssert(NO, @"Resolver should not have been called!");
     return nil;
+}
+
+@end
+
+
+@implementation MineWins
+
+- (CBLDocument*) resolve: (CBLConflict *)conflict {
+    [super resolve: conflict];
+    return conflict.mine;
 }
 
 @end
@@ -29,6 +54,7 @@
 @implementation TheirsWins
 
 - (CBLDocument*) resolve: (CBLConflict *)conflict {
+    [super resolve: conflict];
     return conflict.theirs;
 }
 
@@ -37,11 +63,8 @@
 
 @implementation MergeThenTheirsWins
 
-@synthesize requireBaseRevision=_requireBaseRevision;
-
 - (CBLDocument*) resolve: (CBLConflict *)conflict {
-    if (_requireBaseRevision)
-        NSAssert(conflict.base != nil, @"Missing base");
+    [super resolve: conflict];
     CBLMutableDocument* resolved = [[CBLMutableDocument alloc] init];
     for (NSString* key in conflict.base) {
         [resolved setValue: [conflict.base valueForKey: key] forKey: key];
@@ -67,6 +90,7 @@
 @implementation GiveUp
 
 - (CBLDocument*) resolve: (CBLConflict *)conflict {
+    [super resolve: conflict];
     return nil;
 }
 
@@ -86,13 +110,14 @@
 }
 
 - (CBLDocument*) resolve: (CBLConflict *)conflict {
+    [super resolve: conflict];
     return self.block(conflict);
 }
 
 @end
 
-@interface ConflictTest : CBLTestCase
 
+@interface ConflictTest : CBLTestCase
 @end
 
 @implementation ConflictTest


### PR DESCRIPTION
After conflict resolution, the doc history must include the current
remote revision, otherwise the next push will create a conflict. So
during resolution the conflicting [remote] branch must 'win'.

Fixes #2041