### PR TITLE
Fixed #1967 : Make Document, Dictionary, and Array thread-safe

### DIFF
--- a/Objective-C/CBLArray.mm
+++ b/Objective-C/CBLArray.mm
@@ -42,7 +42,7 @@ using namespace fleeceapi;
 - (instancetype) initEmpty {
     self = [super init];
     if (self) {
-        _sharedLock = [self _sharedLock];
+        [self setupSharedLock];
     }
     return self;
 }
@@ -54,7 +54,7 @@ using namespace fleeceapi;
     self = [super init];
     if (self) {
         _array.initInSlot(mv, parent);
-        _sharedLock = [self _sharedLock];
+        [self setupSharedLock];
     }
     return self;
 }
@@ -66,17 +66,17 @@ using namespace fleeceapi;
     self = [super init];
     if (self) {
         _array.initAsCopyOf(mArray, isMutable);
-        _sharedLock = [self _sharedLock];
+        [self setupSharedLock];
     }
     return self;
 }
 
 
-- (NSObject*) _sharedLock {
+- (void) setupSharedLock {
     id db = nil;
     if (_array.context() != MContext::gNullContext)
         db = ((DocContext*)_array.context())->database();
-    return db != nil ? db : self;
+    _sharedLock = db != nil ? db : self;
 }
 
 
@@ -86,7 +86,7 @@ using namespace fleeceapi;
 
 
 - (CBLMutableArray*) mutableCopyWithZone:(NSZone *)zone {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return [[CBLMutableArray alloc] initWithCopyOfMArray: _array isMutable: true];
     }
 }
@@ -133,91 +133,91 @@ static id _getObject(MArray<id> &array, NSUInteger index, Class asClass =nil) {
 
 
 - (nullable id) valueAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return _getObject(_array, index);
     }
 }
 
 
 - (nullable NSString*) stringAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return _getObject(_array, index, [NSString class]);
     }
 }
 
 
 - (nullable NSNumber*) numberAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return _getObject(_array, index, [NSNumber class]);
     }
 }
 
 
 - (NSInteger) integerAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return asInteger(_get(_array, index), _array);
     }
 }
 
 
 - (long long) longLongAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return asLongLong(_get(_array, index), _array);
     }
 }
 
 
 - (float) floatAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return asFloat(_get(_array, index), _array);
     }
 }
 
 
 - (double) doubleAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return asDouble(_get(_array, index), _array);
     }
 }
 
 
 - (BOOL) booleanAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return asBool(_get(_array, index), _array);
     }
 }
 
 
 - (nullable NSDate*) dateAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return asDate(_getObject(_array, index));
     }
 }
 
 
 - (nullable CBLBlob*) blobAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return _getObject(_array, index, [CBLBlob class]);
     }
 }
 
 
 - (nullable CBLArray*) arrayAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return _getObject(_array, index, [CBLArray class]);
     }
 }
 
 
 - (nullable CBLDictionary*) dictionaryAtIndex: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return _getObject(_array, index, [CBLDictionary class]);
     }
 }
 
 
 - (NSUInteger) count {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         return _array.count();
     }
 }
@@ -227,7 +227,7 @@ static id _getObject(MArray<id> &array, NSUInteger index, Class asClass =nil) {
 
 
 - (NSArray*) toArray {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         auto count = _array.count();
         NSMutableArray* result = [NSMutableArray arrayWithCapacity: count];
         for (NSUInteger i = 0; i < count; i++)
@@ -286,7 +286,7 @@ static id _getObject(MArray<id> &array, NSUInteger index, Class asClass =nil) {
 
 
 - (CBLFragment*) objectAtIndexedSubscript: (NSUInteger)index {
-    CBL_LOCK(self.sharedLock) {
+    CBL_LOCK(_sharedLock) {
         if (index >= _array.count())
             return nil;
     }

--- a/Objective-C/CBLDictionary.mm
+++ b/Objective-C/CBLDictionary.mm
@@ -76,10 +76,13 @@ using namespace fleeceapi;
 
 
 - (CBLMutableDictionary*) mutableCopyWithZone:(NSZone *)zone {
-    return [[CBLMutableDictionary alloc] initWithCopyOfMDict: _dict isMutable: true];
+    CBL_LOCK(self.sharedLock) {
+        return [[CBLMutableDictionary alloc] initWithCopyOfMDict: _dict isMutable: true];
+    }
 }
 
 
+// Called under the database's lock:
 - (void) fl_encodeToFLEncoder: (FLEncoder)enc {
     Encoder encoder(enc);
     _dict.encodeTo(encoder);
@@ -96,7 +99,9 @@ using namespace fleeceapi;
 
 
 - (NSUInteger) count {
-    return _dict.count();
+    CBL_LOCK(self.sharedLock) {
+        return _dict.count();
+    }
 }
 
 
@@ -107,19 +112,23 @@ using namespace fleeceapi;
     // I cache the keys array because my -countByEnumeratingWithState method delegates to it,
     // but it's not actually retained by anything related to the enumeration, so it's otherwise
     // possible for the array to be dealloced while the enumeration is going on.
-    if (!_keys) {
-        NSMutableArray* keys = [NSMutableArray arrayWithCapacity: _dict.count()];
-        for (MDict<id>::iterator i(_dict); i; ++i)
-            [keys addObject: i.nativeKey()];
-        _keys = keys;
+    CBL_LOCK(self.sharedLock) {
+        if (!_keys) {
+            NSMutableArray* keys = [NSMutableArray arrayWithCapacity: _dict.count()];
+            for (MDict<id>::iterator i(_dict); i; ++i)
+                [keys addObject: i.nativeKey()];
+            _keys = keys;
+        }
+        return _keys;
     }
-    return _keys;
 }
 
 
 - (void) keysChanged {
     // My subclass CBLMutableDictionary calls this when it's mutated, to invalidate the array
-    _keys = nil;
+    CBL_LOCK(self.sharedLock) {
+        _keys = nil;
+    }
 }
 
 
@@ -142,62 +151,86 @@ static id _getObject(MDict<id> &dict, NSString* key, Class asClass =nil) {
 
 
 - (nullable id) valueForKey: (NSString*)key {
-    return _getObject(_dict, key, nil);
+    CBL_LOCK(self.sharedLock) {
+        return _getObject(_dict, key, nil);
+    }
 }
 
 
 - (nullable NSString*) stringForKey: (NSString*)key {
-    return _getObject(_dict, key, [NSString class]);
+    CBL_LOCK(self.sharedLock) {
+        return _getObject(_dict, key, [NSString class]);
+    }
 }
 
 
 - (nullable NSNumber*) numberForKey: (NSString*)key {
-    return _getObject(_dict, key, [NSNumber class]);
+    CBL_LOCK(self.sharedLock) {
+        return _getObject(_dict, key, [NSNumber class]);
+    }
 }
 
 
 - (NSInteger) integerForKey: (NSString*)key {
-    return asInteger(_get(_dict, key), _dict);
+    CBL_LOCK(self.sharedLock) {
+        return asInteger(_get(_dict, key), _dict);
+    }
 }
 
 
 - (long long) longLongForKey: (NSString*)key {
-    return asLongLong(_get(_dict, key), _dict);
+    CBL_LOCK(self.sharedLock) {
+        return asLongLong(_get(_dict, key), _dict);
+    }
 }
 
 
 - (float) floatForKey: (NSString*)key {
-    return asFloat(_get(_dict, key), _dict);
+    CBL_LOCK(self.sharedLock) {
+        return asFloat(_get(_dict, key), _dict);
+    }
 }
 
 
 - (double) doubleForKey: (NSString*)key {
-    return asDouble(_get(_dict, key), _dict);
+    CBL_LOCK(self.sharedLock) {
+        return asDouble(_get(_dict, key), _dict);
+    }
 }
 
 
 - (BOOL) booleanForKey: (NSString*)key {
-    return asBool(_get(_dict, key), _dict);
+    CBL_LOCK(self.sharedLock) {
+        return asBool(_get(_dict, key), _dict);
+    }
 }
 
 
 - (nullable NSDate*) dateForKey: (NSString*)key {
-    return asDate(_getObject(_dict, key, nil));
+    CBL_LOCK(self.sharedLock) {
+        return asDate(_getObject(_dict, key, nil));
+    }
 }
 
 
 - (nullable CBLBlob*) blobForKey: (NSString*)key {
-    return _getObject(_dict, key, [CBLBlob class]);
+    CBL_LOCK(self.sharedLock) {
+        return _getObject(_dict, key, [CBLBlob class]);
+    }
 }
 
 
 - (nullable CBLArray*) arrayForKey: (NSString*)key {
-    return _getObject(_dict, key, [CBLArray class]);
+    CBL_LOCK(self.sharedLock) {
+        return _getObject(_dict, key, [CBLArray class]);
+    }
 }
 
 
 - (nullable CBLDictionary*) dictionaryForKey: (NSString*)key {
-    return _getObject(_dict, key, [CBLDictionary class]);
+    CBL_LOCK(self.sharedLock) {
+        return _getObject(_dict, key, [CBLDictionary class]);
+    }
 }
 
 
@@ -205,7 +238,9 @@ static id _getObject(MDict<id> &dict, NSString* key, Class asClass =nil) {
 
 
 - (BOOL) containsValueForKey: (NSString*)key {
-    return !_get(_dict, key).isEmpty();
+    CBL_LOCK(self.sharedLock) {
+        return !_get(_dict, key).isEmpty();
+    }
 }
 
 
@@ -213,11 +248,13 @@ static id _getObject(MDict<id> &dict, NSString* key, Class asClass =nil) {
 
 
 - (NSDictionary<NSString*,id>*) toDictionary {
-    NSMutableDictionary* result = [NSMutableDictionary dictionaryWithCapacity: _dict.count()];
-    for (MDict<id>::iterator i(_dict); i; ++i) {
-        result[i.nativeKey()] = [i.nativeValue() cbl_toPlainObject];
+    CBL_LOCK(self.sharedLock) {
+        NSMutableDictionary* result = [NSMutableDictionary dictionaryWithCapacity: _dict.count()];
+        for (MDict<id>::iterator i(_dict); i; ++i) {
+            result[i.nativeKey()] = [i.nativeValue() cbl_toPlainObject];
+        }
+        return result;
     }
-    return result;
 }
 
 
@@ -264,28 +301,42 @@ static id _getObject(MDict<id> &dict, NSString* key, Class asClass =nil) {
     if (self.count != other.count)
         return NO;
     
-    for (MDict<id>::iterator i(_dict); i; ++i) {
-        NSString* key = i.nativeKey();
-        id value = i.nativeValue();
-        if (value) {
-            if (![value isEqual: [other valueForKey: key]])
-                return NO;
-        } else {
-            if ([other valueForKey: key] || ![other containsValueForKey: key])
-                return NO;
+    CBL_LOCK(self.sharedLock) {
+        for (MDict<id>::iterator i(_dict); i; ++i) {
+            NSString* key = i.nativeKey();
+            id value = i.nativeValue();
+            if (value) {
+                if (![value isEqual: [other valueForKey: key]])
+                    return NO;
+            } else {
+                if ([other valueForKey: key] || ![other containsValueForKey: key])
+                    return NO;
+            }
         }
     }
-    
     return YES;
 }
 
 
 - (NSUInteger) hash {
-    NSUInteger hash = 0;
-    for (MDict<id>::iterator i(_dict); i; ++i) {
-        hash += ([i.nativeKey() hash] ^ [i.nativeValue() hash]);
+    CBL_LOCK(self.sharedLock) {
+        NSUInteger hash = 0;
+        for (MDict<id>::iterator i(_dict); i; ++i) {
+            hash += ([i.nativeKey() hash] ^ [i.nativeValue() hash]);
+        }
+        return hash;
     }
-    return hash;
+}
+
+
+#pragma mark - Lock
+
+
+- (NSObject*) sharedLock {
+    CBLDatabase* db = nil;
+    if (_dict.context() != MContext::gNullContext)
+        db = ((DocContext*)_dict.context())->database();
+    return db != nil ? db : self;
 }
 
 

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -135,12 +135,14 @@ using namespace fleeceapi;
 - (void) updateDictionary {
     if (_fleeceData) {
         _root.reset(new MRoot<id>(new cbl::DocContext(_database, _c4Doc), Dict(_fleeceData), self.isMutable));
-        _dict = _root->asNative();
+        CBL_LOCK(_database) {
+            _dict = _root->asNative();
+        }
     } else {
         // New document:
         _root.reset();
         _dict = self.isMutable ? (id)[[CBLNewDictionary alloc] init]
-                               : [[CBLDictionary alloc] initEmpty];
+        : [[CBLDictionary alloc] initEmpty];
     }
 }
 

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -142,7 +142,7 @@ using namespace fleeceapi;
         // New document:
         _root.reset();
         _dict = self.isMutable ? (id)[[CBLNewDictionary alloc] init]
-        : [[CBLDictionary alloc] initEmpty];
+                               : [[CBLDictionary alloc] initEmpty];
     }
 }
 

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -109,6 +109,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLArray ()
 
+@property (atomic, readonly) NSObject* sharedLock;
+
 - (instancetype) initEmpty;
 
 @end
@@ -117,8 +119,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLDictionary ()
 
+@property (atomic, readonly) NSObject* sharedLock;
+
 - (instancetype) initEmpty;
 - (void) keysChanged;
+
 @end
 
 /////////////////

--- a/Objective-C/Internal/CBLLock.h
+++ b/Objective-C/Internal/CBLLock.h
@@ -21,9 +21,5 @@
 #pragma once
 
 #if CBL_THREADSAFE
-    #if DEBUG
-        #define CBL_LOCK(m) assert(m); @synchronized(m)
-    #else
-        #define CBL_LOCK(m) @synchronized(m)
-    #endif
+    #define CBL_LOCK(m) @synchronized(m)
 #endif

--- a/Objective-C/Tests/ConcurrentTest.m
+++ b/Objective-C/Tests/ConcurrentTest.m
@@ -180,7 +180,7 @@
 
 
 // https://github.com/couchbase/couchbase-lite-ios/issues/1967
-- (void) failingTestConcurrentReadForUpdatesDocs {
+- (void) testConcurrentReadForUpdatesDocs {
     const NSUInteger kNDocs = 100;
     const NSUInteger kNRounds = 10;
     const NSUInteger kNConcurrents = 5;
@@ -202,7 +202,7 @@
 
 
 // https://github.com/couchbase/couchbase-lite-ios/issues/1967
-- (void) failingTestConcurrentUpdateSeperateDocInstances {
+- (void) testConcurrentUpdateSeperateDocInstances {
     const NSUInteger kNDocs = 1;
     const NSUInteger kNRounds = 10;
     const NSUInteger kNConcurrents = 5;


### PR DESCRIPTION
* Made Document, Dictionary, and Array thread-safe. The MutableDocument, MutableDictionary, and MutableArray are not guarantee to be thread-safe.

*  Created a shared lock which could either be the database object or the self object to lock all of the mcollection’s operations.

#1967