### PR TITLE
Fixed #2058 : Implement replicator backgrounding support

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -243,6 +243,14 @@
 		937441D81E7B8B0500CB8F11 /* CBLPredicateQuery+Predicates.mm in Sources */ = {isa = PBXBuildFile; fileRef = 937441D21E7B8B0500CB8F11 /* CBLPredicateQuery+Predicates.mm */; };
 		9374A852201165AE00BA0D9E /* CBLURLEndpoint+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9374A851201165AE00BA0D9E /* CBLURLEndpoint+Internal.h */; };
 		9374A853201165AE00BA0D9E /* CBLURLEndpoint+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9374A851201165AE00BA0D9E /* CBLURLEndpoint+Internal.h */; };
+		9374A89D201FC47E00BA0D9E /* MYBackgroundMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9374A88A201FC47D00BA0D9E /* MYBackgroundMonitor.m */; };
+		9374A89E201FC47E00BA0D9E /* MYBackgroundMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9374A89C201FC47D00BA0D9E /* MYBackgroundMonitor.h */; };
+		9374A89F201FC49800BA0D9E /* MYBackgroundMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9374A89C201FC47D00BA0D9E /* MYBackgroundMonitor.h */; };
+		9374A8A0201FC49800BA0D9E /* MYBackgroundMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9374A88A201FC47D00BA0D9E /* MYBackgroundMonitor.m */; };
+		9374A8A6201FC53600BA0D9E /* CBLReplicator+Backgrounding.h in Headers */ = {isa = PBXBuildFile; fileRef = 9374A8A4201FC53600BA0D9E /* CBLReplicator+Backgrounding.h */; };
+		9374A8A7201FC53600BA0D9E /* CBLReplicator+Backgrounding.h in Headers */ = {isa = PBXBuildFile; fileRef = 9374A8A4201FC53600BA0D9E /* CBLReplicator+Backgrounding.h */; };
+		9374A8A8201FC53600BA0D9E /* CBLReplicator+Backgrounding.m in Sources */ = {isa = PBXBuildFile; fileRef = 9374A8A5201FC53600BA0D9E /* CBLReplicator+Backgrounding.m */; };
+		9374A8A9201FC53600BA0D9E /* CBLReplicator+Backgrounding.m in Sources */ = {isa = PBXBuildFile; fileRef = 9374A8A5201FC53600BA0D9E /* CBLReplicator+Backgrounding.m */; };
 		93765EAD1EC181F3005E4050 /* Fragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93765EA71EC17FDF005E4050 /* Fragment.swift */; };
 		9378C5911E25B3F0001BB196 /* DatabaseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9378C5901E25B3F0001BB196 /* DatabaseTest.m */; };
 		9378C5971E25B473001BB196 /* CBLTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 9378C5961E25B473001BB196 /* CBLTestCase.m */; };
@@ -967,6 +975,10 @@
 		937441D11E7B8B0500CB8F11 /* CBLPredicateQuery.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLPredicateQuery.mm; sourceTree = "<group>"; };
 		937441D21E7B8B0500CB8F11 /* CBLPredicateQuery+Predicates.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "CBLPredicateQuery+Predicates.mm"; sourceTree = "<group>"; };
 		9374A851201165AE00BA0D9E /* CBLURLEndpoint+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLURLEndpoint+Internal.h"; sourceTree = "<group>"; };
+		9374A88A201FC47D00BA0D9E /* MYBackgroundMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MYBackgroundMonitor.m; sourceTree = "<group>"; };
+		9374A89C201FC47D00BA0D9E /* MYBackgroundMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MYBackgroundMonitor.h; sourceTree = "<group>"; };
+		9374A8A4201FC53600BA0D9E /* CBLReplicator+Backgrounding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLReplicator+Backgrounding.h"; sourceTree = "<group>"; };
+		9374A8A5201FC53600BA0D9E /* CBLReplicator+Backgrounding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CBLReplicator+Backgrounding.m"; sourceTree = "<group>"; };
 		93765EA71EC17FDF005E4050 /* Fragment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fragment.swift; sourceTree = "<group>"; };
 		93765EA91EC17FEA005E4050 /* MutableFragment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableFragment.swift; sourceTree = "<group>"; };
 		93765EAB1EC17FFE005E4050 /* DocumentFragment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentFragment.swift; sourceTree = "<group>"; };
@@ -1221,6 +1233,8 @@
 				2753AFF21EC39CA200C12E98 /* CBLHTTPLogic.m */,
 				27F961971ED8D9440060F804 /* CBLReachability.h */,
 				27F961981ED8D9440060F804 /* CBLReachability.m */,
+				9374A8A4201FC53600BA0D9E /* CBLReplicator+Backgrounding.h */,
+				9374A8A5201FC53600BA0D9E /* CBLReplicator+Backgrounding.m */,
 				2728509C1E99CA4D009CA22F /* CBLReplicator+Internal.h */,
 				93B41CC81F04730500A7F114 /* CBLReplicatorChange+Internal.h */,
 				276740B51EE7381E0036DE42 /* CBLTrustCheck.h */,
@@ -1421,6 +1435,8 @@
 				275FF6B71E47B2FC005F90DD /* ExceptionUtils.m */,
 				27B69A121F2A4B7400782145 /* MYAnonymousIdentity.h */,
 				27B69A131F2A4B7400782145 /* MYAnonymousIdentity.m */,
+				9374A89C201FC47D00BA0D9E /* MYBackgroundMonitor.h */,
+				9374A88A201FC47D00BA0D9E /* MYBackgroundMonitor.m */,
 				934F4BE91E1EF19000F90659 /* MYErrorUtils.h */,
 				934F4BEA1E1EF19000F90659 /* MYErrorUtils.m */,
 				934F4BEB1E1EF19000F90659 /* MYLogging.h */,
@@ -1916,6 +1932,7 @@
 				934A27931F30E5CA003946A7 /* CBLBinaryExpression.h in Headers */,
 				275F929D1E4D377C007FD5A2 /* CouchbaseLite.h in Headers */,
 				27D7219A1F8E97F400AA4458 /* CBLFleece.hh in Headers */,
+				9374A8A7201FC53600BA0D9E /* CBLReplicator+Backgrounding.h in Headers */,
 				937F01E21EFB269300060D64 /* CBLAuthenticator.h in Headers */,
 				93B503751E64B0B4002C4680 /* CBLBlobStream.h in Headers */,
 				93DBCFF72004B5FD0017CA83 /* CBLEndpoint.h in Headers */,
@@ -1925,6 +1942,7 @@
 				9385F2CA1FC5FF4D00032037 /* CBLLock.h in Headers */,
 				93B75C1B1E79EF690033B61B /* CBLQueryExpression.h in Headers */,
 				93B41CB11F04706100A7F114 /* CBLReplicatorChange.h in Headers */,
+				9374A89F201FC49800BA0D9E /* MYBackgroundMonitor.h in Headers */,
 				2753AFF61EC39CA200C12E98 /* CBLHTTPLogic.h in Headers */,
 				932A88261F4CCB3E0005AFB8 /* CBLEncryptionKey.h in Headers */,
 				93B5036F1E64B0A0002C4680 /* CBLMisc.h in Headers */,
@@ -2041,6 +2059,7 @@
 				9383A5951F1EEFCD0083053D /* CBLQueryResult+Internal.h in Headers */,
 				934A27921F30E5CA003946A7 /* CBLBinaryExpression.h in Headers */,
 				93A8434D1E3BB95200B4AF2D /* CBLBlob.h in Headers */,
+				9374A8A6201FC53600BA0D9E /* CBLReplicator+Backgrounding.h in Headers */,
 				27D721991F8E97F400AA4458 /* CBLFleece.hh in Headers */,
 				2704F1C91E395F3300A3B405 /* CBLConflictResolver.h in Headers */,
 				933208161E77415E000D9993 /* CBLQueryOrdering.h in Headers */,
@@ -2050,6 +2069,7 @@
 				9385F2C91FC5FF4D00032037 /* CBLLock.h in Headers */,
 				9383A58A1F1EE8EF0083053D /* CBLQueryResult.h in Headers */,
 				9332082A1E774171000D9993 /* CBLQuery+Internal.h in Headers */,
+				9374A89E201FC47E00BA0D9E /* MYBackgroundMonitor.h in Headers */,
 				93B41CB01F04706100A7F114 /* CBLReplicatorChange.h in Headers */,
 				937F026C1EFC662100060D64 /* CBLChangeListenerToken.h in Headers */,
 				932A88251F4CCB3E0005AFB8 /* CBLEncryptionKey.h in Headers */,
@@ -2656,6 +2676,7 @@
 				9312EBCE1F04490500D5D3B3 /* CBLDocumentChangeListenerToken.m in Sources */,
 				9322DCBE1F0F161A00C4ACF7 /* Joins.swift in Sources */,
 				93140F011F22AA5E006E18EF /* ResultSet.swift in Sources */,
+				9374A8A9201FC53600BA0D9E /* CBLReplicator+Backgrounding.m in Sources */,
 				937F02A41EFC7DD000060D64 /* CBLChangeListenerToken.m in Sources */,
 				27B69A151F2A4C6D00782145 /* MYAnonymousIdentity.m in Sources */,
 				93FD618E2020757500E7F6A1 /* CBLIndex.m in Sources */,
@@ -2712,6 +2733,7 @@
 				93E7BBAF1F3AB7BB00435430 /* Collation.swift in Sources */,
 				9384D82A1FC405BF00FE89D8 /* CBLQueryFullTextExpression.m in Sources */,
 				937A69261F1039370058277F /* CBLQueryParameters.m in Sources */,
+				9374A8A0201FC49800BA0D9E /* MYBackgroundMonitor.m in Sources */,
 				27E35A9D1E8C539600E103F9 /* CBLReplicator.mm in Sources */,
 				9381960C1EC112010032CC51 /* CBLMutableDictionary.mm in Sources */,
 				938196081EC10E930032CC51 /* MutableArrayObject.swift in Sources */,
@@ -2843,6 +2865,7 @@
 				934A279B1F30E5FA003946A7 /* CBLCompoundExpression.m in Sources */,
 				934F4CA81E241FB500F90659 /* CBLBase64.m in Sources */,
 				934A27AD1F30E641003946A7 /* CBLParameterExpression.m in Sources */,
+				9374A8A8201FC53600BA0D9E /* CBLReplicator+Backgrounding.m in Sources */,
 				275229C81E776BC100E630FA /* CBLReplicator.mm in Sources */,
 				72A87A061E2E0E70008466FF /* CBLBlobStream.mm in Sources */,
 				937A69051F0731230058277F /* CBLQueryFunction.m in Sources */,
@@ -2853,6 +2876,7 @@
 				9384D80B1FC3F75700FE89D8 /* CBLQueryArrayFunction.m in Sources */,
 				27A8B5131EC5351000BB4C07 /* CBLQueryEnumerator.mm in Sources */,
 				934F4CB71E241FB500F90659 /* CBLStringBytes.mm in Sources */,
+				9374A89D201FC47E00BA0D9E /* MYBackgroundMonitor.m in Sources */,
 				93EC42DC1FB384D200D54BB4 /* CBLFunctionExpression.m in Sources */,
 				93B41D661F0580E700A7F114 /* CBLQueryJoin.m in Sources */,
 				2704F1CA1E395F3300A3B405 /* CBLConflictResolver.m in Sources */,

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -78,6 +78,9 @@ static NSTimeInterval retryDelay(unsigned retryCount) {
     unsigned _retryCount;
     CBLReachability* _reachability;
     NSMutableSet* _listenerTokens;
+    
+    // TODO: Instead of having multiple boolean variables, we could
+    // have a enum based variable to represent the replicator state.
     BOOL _isStopping;
     BOOL _isSuspending;
 }
@@ -220,10 +223,10 @@ static NSTimeInterval retryDelay(unsigned retryCount) {
             [_config.database.activeReplications addObject: self];     // keeps me from being dealloced
         }
         
-#if TARGET_OS_IPHONE
+    #if TARGET_OS_IPHONE
         if (!_config.allowReplicatingInBackground)
             [self setupBackgrounding];
-#endif
+    #endif
     } else {
         status = {kC4Stopped, {}, err};
     }
@@ -383,9 +386,9 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
         } else if (c4Status.level == kC4Stopped) {
             _isStopping = NO;
             [self clearRepl];
-            #if TARGET_OS_IPHONE
-                [self endBackgrounding];
-            #endif
+        #if TARGET_OS_IPHONE
+            [self endBackgrounding];
+        #endif
             CBL_LOCK(_config.database) {
                 [_config.database.activeReplications removeObject: self];      // this is likely to dealloc me
             }

--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -92,6 +92,19 @@ typedef enum {
  */
 @property (nonatomic, nullable) NSArray<NSString*>* documentIDs;
 
+
+#if TARGET_OS_IPHONE
+/**
+ Allows the replicator to continue replicating in the background. The default
+ value is NO, which means that the replicator will suspend itself when the
+ replicator detects that the application is running in the background.
+ 
+ If setting the value to YES, please ensure that the application requests
+ for extending the background task properly.
+ */
+@property (nonatomic) BOOL allowReplicatingInBackground;
+#endif
+
 /** Not available */
 - (instancetype) init NS_UNAVAILABLE;
 

--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -97,10 +97,10 @@ typedef enum {
 /**
  Allows the replicator to continue replicating in the background. The default
  value is NO, which means that the replicator will suspend itself when the
- replicator detects that the application is running in the background.
+ replicator detects that the application is being backgrounded.
  
- If setting the value to YES, please ensure that the application requests
- for extending the background task properly.
+ If setting the value to YES, please ensure that your application delegate
+ requests background time from the OS until the replication finishes.
  */
 @property (nonatomic) BOOL allowReplicatingInBackground;
 #endif

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -66,83 +66,56 @@
 
 - (void) setReplicatorType: (CBLReplicatorType)replicatorType {
     [self checkReadonly];
-    
-    if (_replicatorType != replicatorType) {
-        _replicatorType = replicatorType;
-    }
+    _replicatorType = replicatorType;
 }
 
 
 - (void) setContinuous: (BOOL)continuous {
     [self checkReadonly];
-    
-    if (_continuous != continuous) {
-        _continuous = continuous;
-    }
+    _continuous = continuous;
 }
 
 
 - (void) setConflictResolver: (id<CBLConflictResolver>)conflictResolver {
     [self checkReadonly];
-    
-    if (_conflictResolver != conflictResolver) {
-        _conflictResolver = conflictResolver;
-    }
+    _conflictResolver = conflictResolver;
 }
 
 
 - (void) setAuthenticator: (CBLAuthenticator *)authenticator {
     [self checkReadonly];
-    
-    if (_authenticator != authenticator) {
-        _authenticator = authenticator;
-    }
+    _authenticator = authenticator;
 }
 
 
 - (void) setPinnedServerCertificate: (SecCertificateRef)pinnedServerCertificate {
     [self checkReadonly];
-    
-    if (_pinnedServerCertificate != pinnedServerCertificate) {
-        _pinnedServerCertificate = pinnedServerCertificate;
-    }
+    _pinnedServerCertificate = pinnedServerCertificate;
 }
 
 
 - (void) setHeaders: (NSDictionary<NSString *,NSString *> *)headers {
     [self checkReadonly];
-    
-    if (_headers != headers) {
-        _headers = headers;
-    }
+    _headers = headers;
 }
 
 
 - (void) setDocumentIDs: (NSArray<NSString *> *)documentIDs {
     [self checkReadonly];
-    
-    if (_documentIDs != documentIDs) {
-        _documentIDs = documentIDs;
-    }
+    _documentIDs = documentIDs;
 }
 
 
 - (void) setChannels: (NSArray<NSString *> *)channels {
     [self checkReadonly];
-    
-    if (_channels != channels) {
-        _channels = channels;
-    }
+    _channels = channels;
 }
 
 
 #if TARGET_OS_IPHONE
 - (void) setAllowReplicatingInBackground: (BOOL)allowReplicatingInBackground {
     [self checkReadonly];
-    
-    if (_allowReplicatingInBackground != allowReplicatingInBackground) {
-        _allowReplicatingInBackground = allowReplicatingInBackground;
-    }
+    _allowReplicatingInBackground = allowReplicatingInBackground;
 }
 #endif
 

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -41,6 +41,10 @@
 @synthesize documentIDs=_documentIDs, channels=_channels;
 @synthesize checkpointInterval=_checkpointInterval, heartbeatInterval=_heartbeatInterval;
 
+#if TARGET_OS_IPHONE
+@synthesize allowReplicatingInBackground=_allowReplicatingInBackground;
+#endif
+
 - (instancetype) initWithDatabase: (CBLDatabase*)database
                            target: (id<CBLEndpoint>)target
 {
@@ -132,6 +136,16 @@
 }
 
 
+#if TARGET_OS_IPHONE
+- (void) setAllowReplicatingInBackground: (BOOL)allowReplicatingInBackground {
+    [self checkReadonly];
+    
+    if (_allowReplicatingInBackground != allowReplicatingInBackground) {
+        _allowReplicatingInBackground = allowReplicatingInBackground;
+    }
+}
+#endif
+
 #pragma mark - Internal
 
 
@@ -139,6 +153,7 @@
                        readonly: (BOOL)readonly {
     self = [super init];
     if (self) {
+        _readonly = readonly;
         _database = config.database;
         _target = config.target;
         _replicatorType = config.replicatorType;
@@ -149,7 +164,9 @@
         _headers = config.headers;
         _documentIDs = config.documentIDs;
         _channels = config.channels;
-        _readonly = readonly;
+#if TARGET_OS_IPHONE
+        _allowReplicatingInBackground = config.allowReplicatingInBackground;
+#endif
     }
     return self;
 }

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -20,6 +20,7 @@
 #import "CBLReplicator.h"
 #import "CBLReplicatorConfiguration.h"
 #import "c4.h"
+@class MYBackgroundMonitor;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,7 +37,15 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 
-@interface CBLReplicator ()
+@interface CBLReplicator () {
+    // For CBLReplicator+Backgrounding:
+    BOOL _deepBackground;
+    BOOL _filesystemUnavailable;
+}
+
+@property (readonly, atomic) BOOL active;
+@property (atomic) BOOL suspended;
+@property (nonatomic) MYBackgroundMonitor* bgMonitor;
 
 @end
 

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
@@ -1,0 +1,38 @@
+//
+//  CBLReplicator+Backgrounding.h
+//  CouchbaseLite
+//
+//  Copyright (c) 2018 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if TARGET_OS_IPHONE
+
+#import <CouchbaseLite/CouchbaseLite.h>
+
+@interface CBLReplicator (Backgrounding)
+
+- (void) setupBackgrounding;
+
+- (void) endBackgrounding;
+
+- (void) endCurrentBackgroundTask;
+
+- (void) appBackgrounding; // Make the method available for testing
+
+- (void) appForegrounding; // Make the method available for testing
+
+@end
+
+#endif

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
@@ -1,0 +1,134 @@
+//
+//  CBLReplicator+Backgrounding.m
+//  CouchbaseLite
+//
+//  Copyright (c) 2018 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if TARGET_OS_IPHONE
+
+#import <UIKit/UIKit.h>
+#import "CBLReplicator+Backgrounding.h"
+#import "CBLReplicator+Internal.h"
+#import "MYBackgroundMonitor.h"
+
+
+@implementation CBLReplicator (Backgrounding)
+
+
+- (void) setupBackgrounding {
+    CBLLog(Sync, @"%@: Starting backgrounding monitor...", self);
+    NSFileProtectionType prot = self.fileProtection;
+    if ([prot isEqual: NSFileProtectionComplete] ||
+        [prot isEqual: NSFileProtectionCompleteUnlessOpen]) {
+        [NSNotificationCenter.defaultCenter addObserver: self
+                                               selector: @selector(fileAccessChanged:)
+                                                   name: UIApplicationProtectedDataWillBecomeUnavailable
+                                                 object: nil];
+        [NSNotificationCenter.defaultCenter addObserver: self
+                                               selector: @selector(fileAccessChanged:)
+                                                   name: UIApplicationProtectedDataDidBecomeAvailable
+                                                 object: nil];
+    }
+    
+    self.bgMonitor = [[MYBackgroundMonitor alloc] init];
+    __weak CBLReplicator* weakSelf = self;
+    self.bgMonitor.onAppBackgrounding = ^{ id strongSelf = weakSelf; [strongSelf appBackgrounding]; };
+    self.bgMonitor.onAppForegrounding = ^{ id strongSelf = weakSelf; [strongSelf appForegrounding]; };
+    self.bgMonitor.onBackgroundTaskExpired = ^{ id strongSelf = weakSelf; [strongSelf backgroundTaskExpired];};
+    [self.bgMonitor start];
+}
+
+
+- (NSFileProtectionType) fileProtection {
+    NSDictionary* attrs = [NSFileManager.defaultManager attributesOfItemAtPath: self.config.database.path error: NULL];
+    return attrs[NSFileProtectionKey] ?: NSFileProtectionNone;
+}
+
+
+- (void) endBackgrounding {
+    CBLLog(Sync, @"%@: Ending backgrounding monitor...", self);
+    [NSNotificationCenter.defaultCenter removeObserver: self
+                                                  name: UIApplicationProtectedDataWillBecomeUnavailable
+                                                object: nil];
+    [NSNotificationCenter.defaultCenter removeObserver: self
+                                                  name: UIApplicationProtectedDataDidBecomeAvailable
+                                                object: nil];
+    [self.bgMonitor stop];
+}
+
+
+// Called when the replicator goes idle
+- (void) endCurrentBackgroundTask {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([self.bgMonitor hasBackgroundTask]) {
+            _deepBackground = YES;
+            [self updateSuspended];
+            CBLLog(Sync, @"%@: ending background task as idle.", self);
+            [self.bgMonitor endBackgroundTask];  // will probably suspend the process immediately
+        }
+    });
+}
+
+
+////// All the methods below are called on the MAIN THREAD ////////
+
+
+- (void) appBackgrounding {
+    if (self.active && [self.bgMonitor beginBackgroundTaskNamed: self.description]) {
+        CBLLog(Sync, @"%@: App backgrounding, starting temporary background task", self);
+    } else {
+        CBLLog(Sync, @"%@: App backgrounding, not active, suspending the replicator", self);
+        _deepBackground = YES;
+        [self updateSuspended];
+    }
+}
+
+
+- (void) appForegrounding {
+    BOOL ended = [self.bgMonitor endBackgroundTask];
+    if (ended)
+        CBLLog(Sync, @"%@: App foregrounding, ending background task.", self);
+    if (_deepBackground) {
+        _deepBackground = NO;
+        [self updateSuspended];
+    }
+}
+
+
+- (void) backgroundTaskExpired {
+    CBLLog(Sync, @"%@: Background task time expired!", self);
+    _deepBackground = YES;
+    [self updateSuspended];
+}
+
+
+// Called when the app is about to lose access to files:
+- (void) fileAccessChanged: (NSNotification*)n {
+    CBLLog(Sync, @"%@: Device locked, database unavailable.", self);
+    _filesystemUnavailable = [n.name isEqual: UIApplicationProtectedDataWillBecomeUnavailable];
+    [self updateSuspended];
+}
+
+
+- (void) updateSuspended {
+    BOOL suspended = (_filesystemUnavailable || _deepBackground);
+    self.suspended = suspended;
+}
+
+
+@end
+
+#endif // TARGET_OS_IPHONE

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -102,6 +102,22 @@ public class ReplicatorConfiguration {
         }
     }
     
+    #if os(iOS)
+    /**
+     Allows the replicator to continue replicating in the background. The default
+     value is NO, which means that the replicator will suspend itself when the
+     replicator detects that the application is running in the background.
+     
+     If setting the value to YES, please ensure that the application requests
+     for extending the background task properly.
+     */
+    public var allowReplicatingInBackground: Bool = false {
+        willSet(newValue) {
+            checkReadOnly()
+        }
+    }
+    #endif
+    
     /// Initializes a ReplicatorConfiguration's builder with the given
     /// local database and the replication target.
     ///
@@ -127,6 +143,7 @@ public class ReplicatorConfiguration {
     private let readonly: Bool
     
     init(config: ReplicatorConfiguration, readonly: Bool) {
+        self.readonly = readonly
         self.database = config.database
         self.target = config.target
         self.replicatorType = config.replicatorType
@@ -137,7 +154,9 @@ public class ReplicatorConfiguration {
         self.headers = config.headers
         self.channels = config.channels
         self.documentIDs = config.documentIDs
-        self.readonly = readonly
+    #if os(iOS)
+        self.allowReplicatingInBackground = config.allowReplicatingInBackground
+    #endif
     }
     
     func checkReadOnly() {
@@ -161,6 +180,9 @@ public class ReplicatorConfiguration {
         c.headers = self.headers
         c.channels = self.channels
         c.documentIDs = self.documentIDs
+    #if os(iOS)
+        c.allowReplicatingInBackground = self.allowReplicatingInBackground
+    #endif
         return c
     }
 }


### PR DESCRIPTION
* Added ReplicatorConfiguration.allowReplicatingInBackground flag for disabling or enabling the feature.

* ReplicatorConfiguration.allowReplicatingInBackground=NO, the replicator will be suspended when the app goes into background and the replicator becomes idle. The replicator will be resumed when the app is brought foreground.

* ReplicatorConfiguration.allowReplicatingInBackground=YES, the replicator will keep running the background BUT it is the applicataion’s responsibility to extend the background task to keep the replicator running properly.

* If the replicator is started while the app is in background, the replicator will keep running until IDLE before getting suspended.

#2058