### PR TITLE
Fixed merging of conflicts involving a deletion

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -967,11 +967,14 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
     CBLStringBytes losingRevID = localDoc.revID;
     
     NSData* mergedBody = nil;
+    C4RevisionFlags mergedFlags = 0;
     if (resolvedDoc != remoteDoc) {
         // Unless the remote revision is being used as-is, we need a new revision:
         mergedBody = [resolvedDoc encode: outError];
         if (!mergedBody)
             return false;
+        if (resolvedDoc.isDeleted)
+            mergedFlags |= kRevDeleted;
     }
     
     // Tell LiteCore to do the resolution:
@@ -981,6 +984,7 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
                                winningRevID,
                                losingRevID,
                                data2slice(mergedBody),
+                               mergedFlags,
                                &c4err)
         || !c4doc_save(rawDoc, 0, &c4err)) {
         return convertError(c4err, outError);

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -156,7 +156,7 @@ using namespace fleeceapi;
         _fleeceData = nullptr;
         
         if (c4doc) {
-            C4Slice body = c4doc.selectedRev.body;
+            C4Slice body = c4doc.body;
             if (body.size > 0)
                 _fleeceData = FLValue_AsDict(FLValue_FromTrustedData({body.buf, body.size}));
         }
@@ -174,7 +174,7 @@ using namespace fleeceapi;
 
 - (NSData*) encode: (NSError**)outError {
     // CBLMutableDocument overrides this
-    fleece::slice body = _c4Doc.rawDoc->selectedRev.body;
+    fleece::slice body = _c4Doc.body;
     return body ? body.copiedNSData() : [NSData data];
 }
 
@@ -209,7 +209,7 @@ using namespace fleeceapi;
 
 - (NSString*) revID {
     CBL_LOCK(self) {
-        return _c4Doc != nil ?  slice2string(_c4Doc.rawDoc->selectedRev.revID) : nil;
+        return _c4Doc != nil ?  slice2string(_c4Doc.revID) : nil;
     }
 }
 
@@ -217,7 +217,7 @@ using namespace fleeceapi;
 - (NSUInteger) generation {
     // CBLMutableDocument overrides this
     CBL_LOCK(self) {
-        return _c4Doc != nil ? c4rev_getGeneration(_c4Doc.rawDoc->selectedRev.revID) : 0;
+        return _c4Doc != nil ? c4rev_getGeneration(_c4Doc.revID) : 0;
     }
 }
 

--- a/Objective-C/Internal/CBLC4Document.h
+++ b/Objective-C/Internal/CBLC4Document.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) C4String revID;
 
-@property (readonly, nonatomic) C4Revision selectedRev;
+@property (readonly, nonatomic) C4Slice body;
 
 + (instancetype) document: (C4Document*)document;
 

--- a/Objective-C/Internal/CBLC4Document.mm
+++ b/Objective-C/Internal/CBLC4Document.mm
@@ -44,22 +44,22 @@
 
 
 - (C4DocumentFlags) flags {
-    return _rawDoc->flags;
+    return _rawDoc->selectedRev.flags;
 }
 
 
 - (C4SequenceNumber) sequence {
-    return _rawDoc->sequence;
+    return _rawDoc->selectedRev.sequence;
 }
 
 
 - (C4String) revID {
-    return _rawDoc->revID;
+    return _rawDoc->selectedRev.revID;
 }
 
 
-- (C4Revision) selectedRev {
-    return _rawDoc->selectedRev;
+- (C4Slice) body {
+    return _rawDoc->selectedRev.body;
 }
 
 


### PR DESCRIPTION
Fixes resolution of conflicts when a doc has been deleted locally but updated on the server.

* Updated LiteCore to get its half of the fix.
* When creating a merge revision to resolve a conflict, make it a
  deletion when necessary (using the new param of c4doc_resolveConflict.)
* Fixed a bug where CBLC4Document's properties referred to the current
  revision, not the selected revision (which is different when a
  conflict is being resolved.)
* Re-enabled testPullConflictDeleteWins_SG, now that it passes.

For couchbase/couchbase-lite-core#433