### PR TITLE
Fixed #2144 and #2130 : Attachment files to be push are all opened at once

### DIFF
--- a/Source/CBLMultiStreamWriter.m
+++ b/Source/CBLMultiStreamWriter.m
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import "CBLMultiStreamWriter.h"
+#import "CBL_Attachment.h"
 
 
 DefineLogDomain(MultiStreamWriter);
@@ -177,6 +178,8 @@ DefineLogDomain(MultiStreamWriter);
         return [NSInputStream inputStreamWithFileAtPath: [input path]];
     else if ([input isKindOfClass: [NSInputStream class]])
         return input;
+    else if ([input isKindOfClass: [CBL_Attachment class]])
+        return [(CBL_Attachment*)input getContentStreamDecoded: NO andLength: nil];
     else {
         Assert(NO, @"Invalid input class %@ for CBLMultiStreamWriter", [input class]);
         return nil;

--- a/Source/CBLMultipartWriter.m
+++ b/Source/CBLMultipartWriter.m
@@ -104,12 +104,11 @@
     [self setNextPartsHeaders: $dict({@"Content-Disposition", disposition},
                                      {@"Content-Type", attachment.contentType},
                                      {@"Content-Encoding", attachment.encodingName})];
-    uint64_t contentLength;
-    NSInputStream *contentStream = [attachment getContentStreamDecoded: NO
-                                                             andLength: &contentLength];
-    if (!contentStream)
+    
+    if (!attachment.hasContent)
         return kCBLStatusAttachmentNotFound;
     
+    uint64_t contentLength = attachment.blobStreamLength;
     uint64_t declaredLength = attachment.possiblyEncodedLength;
     if (contentLength == 0)
         contentLength = declaredLength;
@@ -117,7 +116,7 @@
         Warn(@"Attachment '%@' length mismatch; actually %llu, declared %llu",
              attachment.name, contentLength, declaredLength);
     
-    [self addStream: contentStream length: contentLength];
+    [self addInput: attachment length: contentLength];
     return kCBLStatusOK;
 }
 

--- a/Source/CBL_Attachment.h
+++ b/Source/CBL_Attachment.h
@@ -51,6 +51,9 @@
 /** Equal to the encodedLength if there is an encoding, else length. */
 @property (readwrite) uint64_t possiblyEncodedLength;
 
+/** Length of the blob file; zero if encrypted. */
+@property (readonly, nonatomic) uint64_t blobStreamLength;
+
 - (NSInputStream*) getContentStreamDecoded: (BOOL)decoded
                                  andLength: (uint64_t*)outLength;
 

--- a/Source/CBL_Attachment.m
+++ b/Source/CBL_Attachment.m
@@ -238,6 +238,10 @@ static NSString* blobKeyToDigest(CBLBlobKey key) {
 }
 
 
+- (uint64_t) blobStreamLength {
+    return [_database.attachmentStore blobStreamLengthForKey: _blobKey];
+}
+
 - (NSInputStream*) getContentStreamDecoded: (BOOL)decoded
                                  andLength: (uint64_t*)outLength
 {

--- a/Source/CBL_BlobStore.h
+++ b/Source/CBL_BlobStore.h
@@ -42,6 +42,7 @@ typedef struct CBLBlobKey {
 - (BOOL) hasBlobForKey: (CBLBlobKey)key;
 - (NSData*) blobForKey: (CBLBlobKey)key;
 - (uint64_t) lengthOfBlobForKey: (CBLBlobKey)key;
+- (uint64_t) blobStreamLengthForKey: (CBLBlobKey)key;
 - (NSInputStream*) blobInputStreamForKey: (CBLBlobKey)key
                                   length: (UInt64*)outLength;
 

--- a/Source/CBL_BlobStore.m
+++ b/Source/CBL_BlobStore.m
@@ -212,6 +212,14 @@ UsingLogDomain(Database);
     return blob;
 }
 
+
+- (uint64_t) blobStreamLengthForKey: (CBLBlobKey)key {
+    if (_encryptionKey)
+        return 0;
+    return [self lengthOfBlobForKey: key];
+}
+
+
 - (NSInputStream*) blobInputStreamForKey: (CBLBlobKey)key
                                   length: (UInt64*)outLength
 {


### PR DESCRIPTION
* Made CBLMultipartWriter add the attachment object instead of opened stream to the list of the multipart inputs, which will be later opened as streams when writing to the output.
* In the CBLMultiStreamWriter’s -streamForInput: mode, if the input in an CBL_Attachment object, returns an opened attachment stream.

#2144 #2130