### PR TITLE
Proxy fixes: TLS, redirect, test setup

### DIFF
--- a/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/CBL ObjC.xcscheme
+++ b/CouchbaseLite.xcodeproj/xcshareddata/xcschemes/CBL ObjC.xcscheme
@@ -28,8 +28,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableAddressSanitizer = "YES"
       enableASanStackUseAfterReturn = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -51,6 +50,23 @@
             ReferencedContainer = "container:CouchbaseLite.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CBL_TEST_HOST"
+            value = "localhost"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CBL_TEST_PROXY_HOST"
+            value = "127.0.0.1"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CBL_TEST_PROXY_PORT"
+            value = "8888"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption
             key = "MallocScribble"
@@ -63,7 +79,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
* When configuring NSStream TLS settings after making a proxy connnection, set the server name property to the actual server hostname, otherwise cert verification will expect the proxy’s hostname and fail.
* Handle redirect/auth status returned from proxy and retry.
* ReplicatorTest should set up proxy overrides at init time, not in -remoteEndpointWithName:, because not all the tests call that method.