### PR TITLE
Use weak reference / guard in place of unowned in Query addChangeListener closure.

### DIFF
--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -105,7 +105,8 @@ public class Query {
         
         prepareQuery()
         let token = self.queryImpl!.addChangeListener(with: queue, listener: {
-            [unowned self] (change) in
+            [weak self] (change) in
+            guard let `self` = self else { return }
             let rows: ResultSet?;
             if let rs = change.results {
                 rows = ResultSet(impl: rs)


### PR DESCRIPTION
*Summary:* This small PR prevents a crash where an `unowned`, deinit'd `Query` reference is fatally accessed. It changes the reference to `weak` with a guarded unwrap in the `listener` closure created in `addChangeListener`. 

*Context:* our app uses `Query` change listeners to populate views. These change listeners are tied to the life cycle of view controllers on a navigation stack. When these view controllers appear, they refresh from network and update some Couchbase documents. 

*Problem:* In one particular case, we had two screens (root view controller `A` and pushed view controller `B` for reference) which both added similarly configured change listeners on an identical query, with different instances of `Query` with different `ListenerToken` instances. We encountered a race condition when `B` was popped, `A` triggered a refresh, and modified some documents, queuing up notifications to both change listeners from the database thread. However, before the update gets fired, back on the main thread `B` is deinit'd, removing it's change listener and deinit'ing its `Query`. This results in a crash in `Query`'s `addChangeListener` function when `self` is accessed in the `listener` closure provided to `queryImpl`s `addChangeListener`. The crash reports as follows…

```Fatal error: Attempted to read an unowned reference but object 0x6040002f5800 was already deallocated```

*Solution:* The `addChangeListener` uses an `[unowned self]` to prevent retain cycles, but does nothing to ensure that `self` is still a valid instance. This PR simply changes the `unowned` specifier to `weak` and unwraps the optional at the start of the block, preventing the deinit'd instance from being accessed. I don't have a readymade reproduction case as this is tied in rather tightly with our application lifecycle, but we've tested this approach thoroughly on simulator and device and have been unable to reproduce a crash which was quite common for us before.