### PR TITLE
Fix HTTP redirect not working when using client proxy

### DIFF
--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -155,7 +155,6 @@ static void doDispose(C4Socket* s) {
         request.HTTPShouldHandleCookies = NO;
         _logic = [[CBLHTTPLogic alloc] initWithURLRequest: request];
         _logic.handleRedirects = YES;
-        _logic.useProxyCONNECT = YES;
 
         slice proxy = _options["HTTPProxy"_sl].asString();      //TODO: Add to c4Replicator.h
         if (proxy) {
@@ -283,6 +282,7 @@ static void doDispose(C4Socket* s) {
     if (_connectingToProxy) {
         CBLLog(WebSocket, @"%@ connecting to HTTP proxy %@:%d...",
                self, _logic.directHost, _logic.directPort);
+        _logic.useProxyCONNECT = YES;
         [self writeData: _logic.HTTPRequestData completionHandler: nil];
     } else {
         CBLLog(WebSocket, @"%@ connecting to %@:%d...", self, _logic.URL.host, _logic.port);


### PR DESCRIPTION
* When HTTP redirect happens, if using proxy, need to send a CONNECT request to the redirected host as well.

* The _logic.useProxyCONNECT is reset to NO after the CONNECT response is received. When sending the second CONNECT request for the redirected HOST, need to ensure that _logic.useProxyCONNECT is set to YES, otherwise the CONNECT request will not be sent.

* Moved `_logic.useProxyCONNECT = YES` from -initWithURL:c4socket:options:  to -_connect method where the CONNECT request will be sent.

#2179