### PR TITLE
Allow creating Query from JSON, and getting JSON [API CHANGE]

### DIFF
--- a/Objective-C/CBLQuery.h
+++ b/Objective-C/CBLQuery.h
@@ -18,6 +18,7 @@
 //
 
 #import <Foundation/Foundation.h>
+@class CBLDatabase;
 @class CBLQueryParameters;
 @class CBLQueryResultSet;
 @class CBLQueryChange;
@@ -99,6 +100,23 @@ NS_ASSUME_NONNULL_BEGIN
  @param token The listener token.
  */
 - (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token;
+
+
+/**
+ Encoded representation of the query. Can be used to re-create the query by calling
+ -initWithDatabase:JSONRepresentation:.
+ */
+@property (nonatomic, readonly) NSData* JSONRepresentation;
+
+
+/**
+ Creates a query, given a previously-encoded JSON representation, as from the
+ JSONRepresentation property.
+ @param database  The database to query.
+ @param json  JSON data representing an encoded query description.
+ */
+- (instancetype) initWithDatabase: (CBLDatabase*)database
+               JSONRepresentation: (NSData*)json NS_DESIGNATED_INITIALIZER;
 
 
 /** Not available */

--- a/Objective-C/CBLQuerySelectResult.m
+++ b/Objective-C/CBLQuerySelectResult.m
@@ -90,7 +90,10 @@
 
 
 - (id) asJSON {
-    return [_expression asJSON];
+    id json = [_expression asJSON];
+    if (_alias)
+        json = @[@"AS", json, _alias];
+    return json;
 }
 
 

--- a/Objective-C/Internal/CBLQuery+Internal.h
+++ b/Objective-C/Internal/CBLQuery+Internal.h
@@ -39,25 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) CBLDatabase* database;
 
-@property (nonatomic, readonly) NSArray<CBLQuerySelectResult*>* select;
-
-@property (nonatomic, readonly) CBLQueryDataSource* from;
-
-@property (nonatomic, readonly, nullable) NSArray<CBLQueryJoin*>* join;
-
-@property (nonatomic, readonly, nullable) CBLQueryExpression* where;
-
-@property (nonatomic, readonly, nullable) NSArray<CBLQueryExpression*>* groupBy;
-
-@property (nonatomic, readonly, nullable) CBLQueryExpression* having;
-
-@property (nonatomic, readonly, nullable) NSArray<CBLQueryOrdering*>* orderings;
-
-@property (nonatomic, readonly, nullable) CBLQueryLimit* limit;
-
-@property (nonatomic, readonly) BOOL distinct;
-
-/** Initializer. */
 - (instancetype) initWithSelect: (NSArray<CBLQuerySelectResult*>*)select
                        distinct: (BOOL)distinct
                            from: (CBLQueryDataSource*)from
@@ -67,8 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
                          having: (nullable CBLQueryExpression*)having
                         orderBy: (nullable NSArray<CBLQueryOrdering*>*)orderings
                           limit: (nullable CBLQueryLimit*)limit;
-
-+ (nullable NSData*) encodeExpressions: (NSArray*)expressions error: (NSError**)outError;
 
 @end
 

--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -875,10 +875,10 @@
     uint64_t numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r)
     {
         AssertEqual(r.count, 5u);
-        AssertEqual([r doubleForKey: @"$1"], [r doubleAtIndex: 0]);
-        AssertEqual([r integerForKey: @"$2"], [r integerAtIndex: 1]);
+        AssertEqual([r doubleForKey: @"AVG()"], [r doubleAtIndex: 0]);
+        AssertEqual([r integerForKey: @"COUNT()"], [r integerAtIndex: 1]);
         AssertEqual([r integerForKey: @"min"], [r integerAtIndex: 2]);
-        AssertEqual([r integerForKey: @"$3"], [r integerAtIndex: 3]);
+        AssertEqual([r integerForKey: @"MAX()"], [r integerAtIndex: 3]);
         AssertEqual([r integerForKey: @"sum"], [r integerAtIndex: 4]);
     }];
     AssertEqual(numRows, 1u);
@@ -1726,5 +1726,36 @@
     AssertEqual(i, 2);
 }
 
+
+- (void) testJSONEncoding {
+    NSError* error;
+    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] init];
+    [doc1 setValue: @"string" forKey: @"string"];
+    Assert([_db saveDocument: doc1 error: &error], @"Error when creating a document: %@", error);
+
+    NSData* json;
+    {
+        CBLQuery* q = [CBLQueryBuilder select: @[kDOCID]
+                                         from: [CBLQueryDataSource database: self.db]
+                                        where: [[CBLQueryExpression property: @"string"] is: [CBLQueryExpression string: @"string"]]];
+        json = q.JSONRepresentation;
+        Assert(json);
+    }
+
+    // Reconstitute query from JSON data:
+    CBLQuery* q = [[CBLQuery alloc] initWithDatabase: _db JSONRepresentation: json];
+    Assert(q);
+    AssertEqualObjects(q.JSONRepresentation, json);
+
+    // Now test the reconstituted query:
+    uint64_t numRows = [self verifyQuery: q randomAccess: YES
+                                    test: ^(uint64_t n, CBLQueryResult* r)
+                        {
+                            CBLDocument* doc = [self.db documentWithID: [r valueAtIndex: 0]];
+                            AssertEqualObjects(doc.id, doc1.id);
+                            AssertEqualObjects([doc valueForKey: @"string"], @"string");
+                        }];
+    AssertEqual(numRows, 1u);
+}
 
 @end

--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -141,6 +141,22 @@ public class Query {
         lock.unlock()
     }
 
+    /// Encoded JSON representation of the query.
+    /// Can be used later to reconstruct an identical query.
+    public var JSONRepresentation : Data {
+        prepareQuery()
+        return queryImpl!.jsonRepresentation
+    }
+
+    /// Initialize a Query given a JSON-encoded representation.
+    /// - Parameters:
+    ///   - database: The database to query.
+    ///   - json: JSON data encoding the query. This can be obtained from a Query object's
+    //            JSONRepresentation property.
+    public init(database: Database, JSONRepresentation json: Data) {
+        queryImpl = CBLQuery(database: database._impl, jsonRepresentation: json)
+    }
+
     // MARK: Internal
     
     var params: Parameters?

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -679,10 +679,10 @@ class QueryTest: CBLTestCase {
         
         let numRow = try verifyQuery(q, block: { (n, r) in
             XCTAssertEqual(r.count, 5)
-            XCTAssertEqual(r.double(forKey: "$1"), r.double(at: 0))
-            XCTAssertEqual(r.int(forKey: "$2"), r.int(at: 1))
+            XCTAssertEqual(r.double(forKey: "AVG()"), r.double(at: 0))
+            XCTAssertEqual(r.int(forKey: "COUNT()"), r.int(at: 1))
             XCTAssertEqual(r.int(forKey: "min"), r.int(at: 2))
-            XCTAssertEqual(r.int(forKey: "$3"), r.int(at: 3))
+            XCTAssertEqual(r.int(forKey: "MAX()"), r.int(at: 3))
             XCTAssertEqual(r.int(forKey: "sum"), r.int(at: 4))
         })
         XCTAssertEqual(numRow, 1)
@@ -1296,5 +1296,24 @@ class QueryTest: CBLTestCase {
         XCTAssertEqual(dict.count, 2)
         XCTAssertEqual(dict["name"] as! String, "Scott")
         XCTAssertEqual(dict["address"] as! NSNull, NSNull())
+    }
+
+    func testJSONRepresentation() throws {
+        let doc1 = MutableDocument()
+        doc1.setValue("string", forKey: "string")
+        try saveDocument(doc1)
+
+        let q1 = QueryBuilder.select(kDOCID).from(DataSource.database(db)).where(
+            Expression.property("string").is(Expression.string("string")))
+        let json = q1.JSONRepresentation
+
+        let q = Query(database: db, JSONRepresentation: json)
+
+        var numRows = try verifyQuery(q) { (n, r) in
+            let doc = db.document(withID: r.string(at: 0)!)!
+            XCTAssertEqual(doc.id, doc1.id);
+            XCTAssertEqual(doc.string(forKey: "string")!, "string");
+        }
+        XCTAssertEqual(numRows, 1);
     }
 }


### PR DESCRIPTION
Added to CBLQuery:
```
  - initWithDatabase:JSONRepresentation:
  @property (nonatomic, readonly) NSData* JSONRepresentation;
```
(API is provisional. In particular, should there be a factory method
on CBLDatabase, instead of an initializer?)

Restructured the implementation to avoid dependencies on the
query-builder objects (CBLQuerySelectResult, etc.) Instead, the
existing initializer translates to JSON immediately and only stores
JSON. The column names are obtained from a new LiteCore function
(c4query_columnTitle) instead of the builder objects.

Removed some unused code: the properties for the builder objects,
and the -encodeExpressions: method.

couchbaselabs/couchbase-lite-apiv2#212