### PR TITLE
feat: Meta.isDeleted for Swift

### DIFF
--- a/Objective-C/CBLQueryMeta.h
+++ b/Objective-C/CBLQueryMeta.h
@@ -53,14 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (CBLQueryExpression*) sequence;
 
 /**
- A metadata expression refering to the deleted boolean flag of the document.
- 
- @return The deleted boolean flag expression.
- */
-+ (CBLQueryExpression*) isDeleted;
-
-
-/**
  Sequence number expression. The sequence number indicates how recently
  the document has been changed. If one document's `sequence` is greater
  than another's, that means it was changed more recently.
@@ -69,6 +61,21 @@ NS_ASSUME_NONNULL_BEGIN
  @return The sequence number expression.
  */
 + (CBLQueryExpression*) sequenceFrom: (nullable NSString*)alias;
+
+/**
+ A metadata expression referring to the deleted boolean flag of the document.
+ 
+ @return The deleted boolean flag expression.
+ */
++ (CBLQueryExpression*) isDeleted;
+
+/**
+ A metadata expression referring to the deleted boolean flag of the document.
+ 
+ @param alias The data source alias name.
+ @return The deleted boolean flag expression.
+ */
++ (CBLQueryExpression*) isDeletedFrom: (nullable NSString*)alias;
 
 /** Not available */
 - (instancetype) init NS_UNAVAILABLE;

--- a/Objective-C/CBLQueryMeta.m
+++ b/Objective-C/CBLQueryMeta.m
@@ -50,16 +50,21 @@
 }
 
 
-+ (CBLQueryExpression*) isDeleted {
-    return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaIsDeletedKeyPath
-                                               columnName: kCBLQueryMetaIsDeletedColumnName
-                                                     from: nil];
-}
-
-
 + (CBLQueryExpression*) sequenceFrom:(nullable NSString *)alias {
     return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaSequenceKeyPath
                                                columnName: kCBLQueryMetaSequenceColumnName
+                                                     from: alias];
+}
+
+
++ (CBLQueryExpression*) isDeleted {
+    return [self isDeletedFrom: nil];
+}
+
+
++ (CBLQueryExpression*) isDeletedFrom: (nullable NSString *)alias {
+    return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaIsDeletedKeyPath
+                                               columnName: kCBLQueryMetaIsDeletedColumnName
                                                      from: alias];
 }
 

--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -28,7 +28,6 @@
 
 #define kDOCID      [CBLQuerySelectResult expression: [CBLQueryMeta id]]
 #define kSEQUENCE   [CBLQuerySelectResult expression: [CBLQueryMeta sequence]]
-#define kISDELETED  [CBLQuerySelectResult expression: [CBLQueryMeta isDeleted]]
 
 @interface QueryTest : CBLTestCase
 

--- a/Swift/Meta.swift
+++ b/Swift/Meta.swift
@@ -44,10 +44,16 @@ public final class Meta {
     public static var sequence: MetaExpressionProtocol {
         return MetaExpression(type: .sequence)
     }
+    
+    
+    /// A metadata expression referring to the deleted boolean flag of the document.
+    public static var isDeleted: MetaExpressionProtocol {
+        return MetaExpression(type: .isDeleted)
+    }
 }
 
 /* internal */ enum MetaType {
-    case id, sequence
+    case id, sequence, isDeleted
 }
 
 /* internal */ class MetaExpression: QueryExpression, MetaExpressionProtocol {
@@ -75,6 +81,8 @@ public final class Meta {
             return CBLQueryMeta.id(from: from)
         case .sequence:
             return CBLQueryMeta.sequence(from: from)
+        case .isDeleted:
+            return CBLQueryMeta.isDeleted(from: from)
         }
     }
     


### PR DESCRIPTION
* add methods to handle the swift isDeleted call.
* refactored and grouped the sequence and isDeleted methods calls.
* removed unused variable from CBLQueryTest
* add 3 test cases with no deleted file, single deleted doc, and multiple deleted document.

Fix: #2232