### PR TITLE
Feat: Implement Purge document by ID

### DIFF
--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -207,9 +207,7 @@ typedef NS_ENUM(uint32_t, CBLConcurrencyControl) {
 /**
  Purges the document for the given documentID from the database.
  This is more drastic than deletion: it removes all traces of the document.
- The purge will NOT be replicated to other databases. Calling this method is
- the same as calling the -purgeDocument:error: method but without invalidating
- the document reference passing to this method.
+ The purge will NOT be replicated to other databases.
  
  @param documentID The ID of the document to be purged.
  @param error On return, the error if any.

--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -204,6 +204,20 @@ typedef NS_ENUM(uint32_t, CBLConcurrencyControl) {
 - (BOOL) purgeDocument: (CBLDocument*)document error: (NSError**)error;
 
 
+/**
+ Purges the document for the given documentID from the database.
+ This is more drastic than deletion: it removes all traces of the document.
+ The purge will NOT be replicated to other databases. Calling this method is
+ the same as calling the -purgeDocument:error: method but without invalidating
+ the document reference passing to this method.
+ 
+ @param documentID The ID of the document to be purged.
+ @param error On return, the error if any.
+ @return True on success, false on failure.
+ */
+- (BOOL) purgeDocumentWithID: (NSString*)documentID error: (NSError**)error;
+
+
 #pragma mark - Batch Operation
 
 

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -214,14 +214,12 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     CBLAssertNotNil(document);
     
     CBL_LOCK(self) {
-        if (![self prepareDocument: document error: error]) {
+        if (![self prepareDocument: document error: error])
             return NO;
-        }
         
-        if (!document.revID) {
+        if (!document.revID)
             return createError(CBLErrorNotFound,
                                @"Document doesn't exist in the database.", error);
-        }
         
         if ([self purgeDocumentWithID:document.id error:error]) {
             [document replaceC4Doc: nil];

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -627,10 +627,6 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
         
         CBLDocument* doc = document != nil ? document : [self documentWithID: documentID];
         
-        if (!doc) {
-            return createError(CBLErrorNotFound, @"Document doesn't exist in the database.", error);
-        }
-        
         if (![self prepareDocument: doc error: error]) {
             return NO;
         }

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -952,6 +952,24 @@
     }];
 }
 
+- (void) testPurgeDocumentOnADeletedDocument {
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+    
+    // Delete doc
+    NSError* errorWhileDeletion;
+    Assert([self.db deleteDocument: document error: &errorWhileDeletion]);
+    AssertNil(errorWhileDeletion);
+    
+    // Purge doc on the deleted document
+    NSError* errorWhilePurging;
+    Assert([self.db purgeDocument: document error: &errorWhilePurging]);
+    AssertNil(errorWhilePurging);
+    AssertEqual(self.db.count, 0u);
+    AssertNil([self.db documentWithID: documentID]);
+}
+
 #pragma mark - Purge Document WithID
 
 
@@ -1147,6 +1165,25 @@
     AssertEqual(self.db.count, 0u);
     
     anotherDBReturnedDocument = nil;
+}
+
+
+- (void) testPurgeDocumentWithIDOnADeletedDocument {
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+    
+    // Delete document
+    NSError* errorWhileDeletion;
+    Assert([self.db deleteDocument: document error: &errorWhileDeletion]);
+    AssertNil(errorWhileDeletion);
+    
+    // Purge the deleted document
+    NSError* errorWhilePurging;
+    Assert([self.db purgeDocumentWithID: documentID error: &errorWhilePurging]);
+    AssertNil(errorWhilePurging);
+    AssertEqual(self.db.count, 0u);
+    AssertNil([self.db documentWithID: documentID]);
 }
 
 

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -19,6 +19,7 @@
 
 #import "CBLTestCase.h"
 #import "CBLDatabase+Internal.h"
+#import "CBLDocument+Internal.h"
 
 
 @interface DatabaseTest : CBLTestCase
@@ -961,11 +962,22 @@
     NSError* errorWhileDeletion;
     Assert([self.db deleteDocument: document error: &errorWhileDeletion]);
     AssertNil(errorWhileDeletion);
+    NSError* documentReadError;
+    CBLDocument* savedDocument = [[CBLDocument alloc] initWithDatabase: self.db
+                                                            documentID: documentID
+                                                        includeDeleted: YES
+                                                                 error: &documentReadError];
+    AssertNotNil(savedDocument);
     
     // Purge doc on the deleted document
     NSError* errorWhilePurging;
     Assert([self.db purgeDocument: document error: &errorWhilePurging]);
     AssertNil(errorWhilePurging);
+    savedDocument = [[CBLDocument alloc] initWithDatabase: self.db
+                                               documentID: documentID
+                                           includeDeleted: YES
+                                                    error: &documentReadError];
+    AssertNil(savedDocument);
     AssertEqual(self.db.count, 0u);
     AssertNil([self.db documentWithID: documentID]);
 }
@@ -1178,10 +1190,24 @@
     Assert([self.db deleteDocument: document error: &errorWhileDeletion]);
     AssertNil(errorWhileDeletion);
     
+    NSError* documentReadError;
+    CBLDocument* savedDocument = [[CBLDocument alloc] initWithDatabase: self.db
+                                                            documentID: documentID
+                                                        includeDeleted: YES
+                                                                 error: &documentReadError];
+    
+    AssertNotNil(savedDocument);
+    
     // Purge the deleted document
     NSError* errorWhilePurging;
     Assert([self.db purgeDocumentWithID: documentID error: &errorWhilePurging]);
     AssertNil(errorWhilePurging);
+    
+    savedDocument = [[CBLDocument alloc] initWithDatabase: self.db
+                                               documentID: documentID
+                                           includeDeleted: YES
+                                                    error: &documentReadError];
+    AssertNil(savedDocument);
     AssertEqual(self.db.count, 0u);
     AssertNil([self.db documentWithID: documentID]);
 }

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -952,6 +952,203 @@
     }];
 }
 
+#pragma mark - Purge Document WithID
+
+
+- (void) testPurgeDocumentWithIDPreSave {
+    AssertEqual(0, (long)self.db.count);
+    
+    // create a doc & not save
+    NSTimeInterval timestamp = [[NSDate date] timeIntervalSince1970];
+    NSString* documentID = [NSString stringWithFormat:@"%0.0f", timestamp];
+    CBLMutableDocument* doc = [self createDocument: documentID];
+    
+    // not found
+    [self expectError: CBLErrorDomain
+                 code: CBLErrorNotFound
+                   in: ^BOOL(NSError** errorWhilePurging) {
+                       return [self.db purgeDocumentWithID: documentID error: errorWhilePurging];
+                   }];
+    
+    documentID = nil;
+    doc = nil;
+    AssertEqual(0, (long)self.db.count);
+}
+
+
+- (void) testPurgeDocumentWithID {
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+    
+    NSError* errorWhilePurging;
+    [self.db purgeDocumentWithID: documentID error: &errorWhilePurging];
+    AssertNil(errorWhilePurging);
+    
+    AssertNil([self.db documentWithID: documentID]);
+    AssertEqual(self.db.count, 0u);
+}
+
+
+- (void) testPurgeDocumentWithIDInDifferentDBInstance {
+    // store doc
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+    
+    // create db instance with same name
+    NSError* errorWhileOpeningDB;
+    CBLDatabase* otherDB = [self openDBNamed: self.db.name error: &errorWhileOpeningDB];
+    AssertNil(errorWhileOpeningDB);
+    AssertNotNil(otherDB);
+    Assert(otherDB != self.db);
+    AssertNotNil([otherDB documentWithID: documentID]);
+    AssertEqual(1, (long)otherDB.count);
+    
+    // purge document from other db instance
+    NSError* errorWhilePurging;
+    [otherDB purgeDocumentWithID: documentID error: &errorWhilePurging];
+    
+    // should remove doc from both DB instances
+    AssertNil(errorWhilePurging);
+    AssertNil([self.db documentWithID: documentID]);
+    AssertNil([otherDB documentWithID: documentID]);
+    AssertEqual(0, (long)otherDB.count);
+    AssertEqual(0, (long)self.db.count);
+    
+    // close otherDB
+    [self closeDatabase: otherDB];
+}
+
+
+- (void) testPurgeDocumentWithIDFromUnknownDB {
+    // store doc
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+    
+    // create db with different name
+    NSError* errorWhileOpeningDB;
+    CBLDatabase* otherDB =  [self openDBNamed: @"otherDB" error: &errorWhileOpeningDB];
+    AssertNil(errorWhileOpeningDB);
+    
+    // validate the otherDB
+    AssertNotNil(otherDB);
+    Assert(otherDB != self.db);
+    AssertNil([otherDB documentWithID: documentID]);
+    AssertEqual(0, (long)otherDB.count);
+    
+    // purge document from other db - where no document exists
+    [self expectError: CBLErrorDomain
+                 code: CBLErrorNotFound
+                   in: ^BOOL(NSError** errorWhilePurging) {
+                       return [otherDB purgeDocumentWithID: documentID error: errorWhilePurging];
+    }];
+    
+    AssertEqual(0, (long)otherDB.count);
+    AssertEqual(1, (long)self.db.count);
+    
+    [self deleteDatabase: otherDB];
+}
+
+
+- (void) testCallPurgeDocumentWithIDTwice {
+    // store doc
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+
+    // Purge Doc first time
+    NSError* errorWhilePurging;
+    [self.db purgeDocumentWithID: documentID error: &errorWhilePurging];
+    AssertNil(errorWhilePurging);
+    AssertEqual(0, (long)self.db.count);
+
+    // Purge Doc second time
+    [self expectError: CBLErrorDomain code: CBLErrorNotFound in: ^BOOL(NSError** error) {
+        return [self.db purgeDocumentWithID: documentID error: error];
+    }];
+}
+
+
+- (void) testPurgeDocumentWithIDInBatch {
+    int totalDocumentsCount = 10;
+    [self createDocs: totalDocumentsCount];
+
+    NSError* error;
+    BOOL success = [self.db inBatch: &error usingBlock: ^{
+        for(int i = 0; i < totalDocumentsCount; i++) {
+            NSString* documentID = [[NSString alloc] initWithFormat: @"doc_%03d", i];
+            NSError* errorWhilePurging;
+            [self.db purgeDocumentWithID: documentID error: &errorWhilePurging];
+            AssertNil(errorWhilePurging);
+            AssertEqual((totalDocumentsCount - 1) - i, (long)self.db.count);
+        }
+    }];
+    Assert(success);
+    AssertNil(error);
+    AssertEqual(0, (long)self.db.count);
+}
+
+
+- (void) testPurgeDocumentWithIDOnClosedDB {
+    // store doc
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+
+    // close db
+    [self closeDatabase: self.db];
+
+    // purge doc
+    [self expectException: @"NSInternalInconsistencyException" in: ^{
+        [self.db purgeDocumentWithID: documentID error: nil];
+    }];
+}
+
+
+- (void) testPurgeDocumentWithIDOnDeletedDB {
+    // store doc
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+
+    // delete db
+    [self deleteDatabase: self.db];
+
+    // purge doc
+    [self expectException: @"NSInternalInconsistencyException" in: ^{
+        [self.db purgeDocumentWithID: documentID error: nil];
+    }];
+}
+
+- (void) testDeletePurgedDocumentWithID {
+    CBLDocument* document = [self generateDocumentWithID: nil];
+    NSString* documentID = document.id;
+    AssertNotNil(documentID);
+    
+    CBLDocument* anotherDBReturnedDocument = [self.db documentWithID: documentID];
+    
+    // Purge doc
+    NSError* errorWhilePurging;
+    Assert([self.db purgeDocumentWithID: documentID error: &errorWhilePurging]);
+    AssertNil(errorWhilePurging);
+    AssertEqual(self.db.count, 0u);
+    AssertNil([self.db documentWithID: documentID]);
+    
+    // Delete doc no-ops:
+    NSError* errorWhileDeletion;
+    Assert([self.db deleteDocument: document error: &errorWhileDeletion]);
+    AssertNil(errorWhileDeletion);
+    
+    // Delete another DB returned document, no-ops:
+    Assert([self.db deleteDocument: anotherDBReturnedDocument error: &errorWhileDeletion]);
+    AssertNil(errorWhileDeletion);
+    AssertEqual(self.db.count, 0u);
+    
+    anotherDBReturnedDocument = nil;
+}
+
 
 #pragma mark - Close Database
 

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -188,6 +188,19 @@ public final class Database {
     }
     
     
+    /// Purges the document for the given documentID from the database.
+    /// This is more drastic than deletion: it removes all traces of the document.
+    /// The purge will NOT be replicated to other databases.
+    /// Calling this method is the same as calling the -purgeDocument:error: method
+    /// but without invalidating the document reference passing to this method.
+    ///
+    /// - Parameter documentID: The document.
+    /// - Throws: An error on a failure.
+    public func purgeDocument(withID documentID: String) throws {
+        try _impl.purgeDocument(withID: documentID)
+    }
+    
+    
     /// Runs a group of database operations in a batch. Use this when performing bulk write 
     /// operations like multiple inserts/updates; it saves the overhead of multiple database 
     /// commits, greatly improving performance.

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -191,8 +191,6 @@ public final class Database {
     /// Purges the document for the given documentID from the database.
     /// This is more drastic than deletion: it removes all traces of the document.
     /// The purge will NOT be replicated to other databases.
-    /// Calling this method is the same as calling the -purgeDocument:error: method
-    /// but without invalidating the document reference passing to this method.
     ///
     /// - Parameter documentID: The document.
     /// - Throws: An error on a failure.

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -604,6 +604,18 @@ class DatabaseTest: CBLTestCase {
         }
     }
     
+    func testPurgeDocumentOnADeletedDocument() throws {
+        let document = try generateDocument(withID: nil)
+        
+        // Delete document
+        try self.db.deleteDocument(document)
+        
+        // Purge doc
+        try db.purgeDocument(document)
+        XCTAssertEqual(db.count, 0)
+        XCTAssertNil(db.document(withID: document.id))
+    }
+    
     // MARK: Purge Document With ID
     
     func testPreSavePurgeDocumentWithID() throws {
@@ -686,6 +698,19 @@ class DatabaseTest: CBLTestCase {
         try self.db.deleteDocument(document)
         try db.deleteDocument(anotherDocumentReference)
         
+        XCTAssertEqual(db.count, 0)
+        XCTAssertNil(db.document(withID: documentID))
+    }
+    
+    func testPurgeDocumentWithIDOnADeletedDocument() throws {
+        let document = try generateDocument(withID: nil)
+        let documentID = document.id
+        
+        // Delete document
+        try self.db.deleteDocument(document)
+        
+        // Purge doc
+        try db.purgeDocument(withID: documentID)
         XCTAssertEqual(db.count, 0)
         XCTAssertNil(db.document(withID: documentID))
     }


### PR DESCRIPTION
* add ObjC private method for purging the document by documentID
* private method will replace the document reference of the baseDocument pointer if provided
* thread safe private method
* re-used same private implementation in purgeDocument(document)
* copied and re-used all the test cases considered while purgingDocumentByDocument, in both ObjC and Swift.
* handling of the purging of deleted documents. 

Fix: #2231