### PR TITLE
Test: document expiry on deleted docs

### DIFF
--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -1967,7 +1967,7 @@
     AssertNil([self.db getDocumentExpirationWithID: docID]);
     
     // set expiry
-    NSTimeInterval expiryTime = 4;
+    NSTimeInterval expiryTime = 1;
     NSTimeInterval bufferTime = 2;
     NSDate* expiryDate = [[NSDate date] dateByAddingTimeInterval: expiryTime];
     NSError* err;
@@ -1997,7 +1997,7 @@
     AssertNil([self.db getDocumentExpirationWithID: docID]);
     
     // set expiry
-    NSTimeInterval expiryTime = 4;
+    NSTimeInterval expiryTime = 2;
     NSTimeInterval bufferTime = 1;
     NSDate* expiryDate = [[NSDate date] dateByAddingTimeInterval: expiryTime];
     NSError* err;
@@ -2027,7 +2027,7 @@
     AssertNil([self.db getDocumentExpirationWithID: docID]);
     
     // set expiry
-    NSTimeInterval expiryTime = 3;
+    NSTimeInterval expiryTime = 1;
     NSTimeInterval bufferTime = 2;
     NSDate* expiryDate = [[NSDate date] dateByAddingTimeInterval: expiryTime];
     NSError* err;
@@ -2036,7 +2036,7 @@
     
     [self closeDatabase:self.db];
     
-    // validate its not crashing due during the expiry timer!!
+    // validate its not crashing due to the expiry timer!!
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
                                  (int64_t)((expiryTime + bufferTime) * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
@@ -2059,7 +2059,7 @@
     AssertNil([self.db getDocumentExpirationWithID: docID]);
     
     // set expiry
-    NSTimeInterval expiryTime = 5;
+    NSTimeInterval expiryTime = 1;
     NSTimeInterval bufferTime = 2;
     NSDate* expiryDate = [[NSDate date] dateByAddingTimeInterval: expiryTime];
     NSError* err;
@@ -2067,15 +2067,8 @@
     AssertNil(err);
     AssertNotNil([self.db documentWithID: docID]);
     
-    [self closeDatabase:self.db];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
-                                 (int64_t)(bufferTime * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{
-                       [self reopenDB];
-                       AssertNotNil([self.db documentWithID: docID]);
-                   });
-    
+    [self reopenDB];
+    AssertNotNil([self.db documentWithID: docID]);
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
                                  (int64_t)((expiryTime + bufferTime) * NSEC_PER_SEC)),
@@ -2100,7 +2093,7 @@
     AssertNil([self.db getDocumentExpirationWithID: docID]);
     
     // set expiry
-    NSTimeInterval expiryTime = 5;
+    NSTimeInterval expiryTime = 1;
     NSTimeInterval bufferTime = 2;
     NSDate* expiryDate = [[NSDate date] dateByAddingTimeInterval: expiryTime];
     NSError* err;
@@ -2148,7 +2141,7 @@
     AssertNil([self.db getDocumentExpirationWithID: docID]);
     
     // set expiry
-    NSTimeInterval expiryTime = 4;
+    NSTimeInterval expiryTime = 3;
     NSTimeInterval bufferTime = 2;
     NSDate* expiryDate = [[NSDate date] dateByAddingTimeInterval: expiryTime];
     NSError* err;
@@ -2191,7 +2184,7 @@
     AssertNil([self.db getDocumentExpirationWithID: docID]);
     
     // set expiry
-    NSTimeInterval expiryTime = 10;
+    NSTimeInterval expiryTime = 2;
     NSTimeInterval bufferTime = 2;
     NSDate* expiryDate = [[NSDate date] dateByAddingTimeInterval: expiryTime];
     NSError* err;
@@ -2226,7 +2219,7 @@
     AssertEqual(self.db.count, 1u);
     
     // set expiry
-    NSTimeInterval expiryTime = 5;
+    NSTimeInterval expiryTime = 1;
     NSTimeInterval bufferTime = 2;
     NSDate* expiryDate = [NSDate dateWithTimeIntervalSinceNow: expiryTime];
     NSError* err;
@@ -2244,6 +2237,56 @@
                    dispatch_get_main_queue(), ^{
                        // should not be removed
                        AssertNotNil([self.db documentWithID: docID]);
+                       [expectation fulfill];
+                   });
+    
+    [self waitForExpectationsWithTimeout: expiryTime + (2 * bufferTime)
+                                 handler: ^(NSError *error) {
+                                     AssertNil(error);
+                                 }];
+}
+
+
+- (void) testExpirationAfterDeletion {
+    XCTestExpectation* expectation = [self expectationWithDescription: @"Document expiry test"];
+    
+    // create doc
+    CBLDocument* doc = [self generateDocumentWithID: nil];
+    NSString* docID = doc.id;
+    AssertEqual(self.db.count, 1u);
+    
+    // set expiry
+    NSTimeInterval expiryTime = 1;
+    NSTimeInterval bufferTime = 2;
+    NSDate* expiryDate = [NSDate dateWithTimeIntervalSinceNow: expiryTime];
+    NSError* err;
+    Assert([self.db setDocumentExpirationWithID: docID expiration: expiryDate error: &err]);
+    AssertNil(err);
+    
+    // delete doc
+    Assert([self.db deleteDocument: doc error: &err]);
+    AssertNil(err);
+    AssertNil([self.db documentWithID: docID]);
+    AssertEqual(self.db.count, 0u);
+    
+    CBLDocument* deletedDoc = [[CBLDocument alloc] initWithDatabase: self.db
+                                                         documentID: docID
+                                                     includeDeleted: TRUE
+                                                              error: &err];
+    AssertNotNil(deletedDoc);
+    
+    // validate
+    __weak DatabaseTest *weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)((expiryTime + bufferTime) * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+                       // should be removed
+                       NSError* errorWhileFetchingDoc;
+                       CBLDocument* fetchDoc = [[CBLDocument alloc] initWithDatabase: weakSelf.db
+                                                                            documentID: docID
+                                                                        includeDeleted: TRUE
+                                                                                 error: &errorWhileFetchingDoc];
+                       AssertNil(fetchDoc);
                        [expectation fulfill];
                    });
     


### PR DESCRIPTION
* tests to check whether the deleted docs are able to set expiration and whether they are working.
* test case limited to execute within 4 seconds. 

Fix: #2227