### PR TITLE
Fixed #2238 : pinnedServerCertificate memory release issue

### DIFF
--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -133,7 +133,8 @@
         _replicatorType = config.replicatorType;
         _continuous = config.continuous;
         _authenticator = config.authenticator;
-        _pinnedServerCertificate = cfretain(config.pinnedServerCertificate);
+        _pinnedServerCertificate = config.pinnedServerCertificate;
+        cfretain(_pinnedServerCertificate);
         _headers = config.headers;
         _documentIDs = config.documentIDs;
         _channels = config.channels;

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -133,7 +133,7 @@
         _replicatorType = config.replicatorType;
         _continuous = config.continuous;
         _authenticator = config.authenticator;
-        _pinnedServerCertificate = config.pinnedServerCertificate;
+        _pinnedServerCertificate = cfretain(config.pinnedServerCertificate);
         _headers = config.headers;
         _documentIDs = config.documentIDs;
         _channels = config.channels;


### PR DESCRIPTION
* certificate was not retained in the constructor, but was doing in the setter method.
* setter method will be called, when we are setting the configuration object directly.
* But while setting the already allocated object configuration through replicator:init:config: it will again allocate separate config, which in turn was not retaining the certificate object.

* tested by enabling the CBL_TEST_HOST. And now tests are passing.

Fix: #2238