### PR TITLE
Feature/date time function

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1A8DD7DA21C9876E00741C47 /* DateTimeQueryFunctionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */; };
 		1AC83BC821C026D100792098 /* DateTimeQueryFunctionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC83BC721C026D100792098 /* DateTimeQueryFunctionTest.m */; };
 		270AB2BC2073EF57009A4596 /* CBLChangeNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 270AB2BA2073EF57009A4596 /* CBLChangeNotifier.h */; };
 		270AB2BD2073EF57009A4596 /* CBLChangeNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 270AB2BA2073EF57009A4596 /* CBLChangeNotifier.h */; };
@@ -1458,6 +1459,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeQueryFunctionTest.swift; sourceTree = "<group>"; };
 		1AC83BC721C026D100792098 /* DateTimeQueryFunctionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DateTimeQueryFunctionTest.m; sourceTree = "<group>"; };
 		270AB2BA2073EF57009A4596 /* CBLChangeNotifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLChangeNotifier.h; sourceTree = "<group>"; };
 		270AB2BB2073EF57009A4596 /* CBLChangeNotifier.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLChangeNotifier.m; sourceTree = "<group>"; };
@@ -2064,6 +2066,7 @@
 				27BE3B4A1E4E46120012B74A /* CBLTestCase.swift */,
 				27BE3B4C1E4E51C80012B74A /* DatabaseTest.swift */,
 				9369A6B6207DEB5F009B5B83 /* DatabaseEncryptionTest.swift */,
+				1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */,
 				93C3985E1EC66A89005A7A96 /* DictionaryTest.swift */,
 				27BE3B4E1E4E65EB0012B74A /* DocumentTest.swift */,
 				93C50E9F21BDFB7C00C7E980 /* DocumentExpirationTest.swift */,
@@ -4279,6 +4282,7 @@
 				27BE3B4D1E4E51C80012B74A /* DatabaseTest.swift in Sources */,
 				934C2CDE1F4FC0D20010316F /* CBLTestHelper.m in Sources */,
 				93F74A9B1EC554D5001289F8 /* FragmentTest.swift in Sources */,
+				1A8DD7DA21C9876E00741C47 /* DateTimeQueryFunctionTest.swift in Sources */,
 				93A91C6C1E81CE4D003D01A2 /* QueryTest.swift in Sources */,
 				93C3985F1EC66A89005A7A96 /* DictionaryTest.swift in Sources */,
 				93C50EA021BDFB7C00C7E980 /* DocumentExpirationTest.swift in Sources */,

--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1AC83BC821C026D100792098 /* DateTimeQueryFunctionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC83BC721C026D100792098 /* DateTimeQueryFunctionTest.m */; };
 		270AB2BC2073EF57009A4596 /* CBLChangeNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 270AB2BA2073EF57009A4596 /* CBLChangeNotifier.h */; };
 		270AB2BD2073EF57009A4596 /* CBLChangeNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 270AB2BA2073EF57009A4596 /* CBLChangeNotifier.h */; };
 		270AB2BE2073EF57009A4596 /* CBLChangeNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 270AB2BB2073EF57009A4596 /* CBLChangeNotifier.m */; };
@@ -1457,6 +1458,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1AC83BC721C026D100792098 /* DateTimeQueryFunctionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DateTimeQueryFunctionTest.m; sourceTree = "<group>"; };
 		270AB2BA2073EF57009A4596 /* CBLChangeNotifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLChangeNotifier.h; sourceTree = "<group>"; };
 		270AB2BB2073EF57009A4596 /* CBLChangeNotifier.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLChangeNotifier.m; sourceTree = "<group>"; };
 		2728509C1E99CA4D009CA22F /* CBLReplicator+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "CBLReplicator+Internal.h"; path = "../CBLReplicator+Internal.h"; sourceTree = "<group>"; };
@@ -2728,6 +2730,7 @@
 				9385F3021FC645AE00032037 /* ConcurrentTest.m */,
 				9378C5901E25B3F0001BB196 /* DatabaseTest.m */,
 				9369A6AC207DD0ED009B5B83 /* DatabaseEncryptionTest.m */,
+				1AC83BC721C026D100792098 /* DateTimeQueryFunctionTest.m */,
 				9352945E1E51708E005CE4E8 /* DictionaryTest.m */,
 				9378C59D1E269F14001BB196 /* DocumentTest.m */,
 				9388CBAA21BD916F005CA66D /* DocumentExpirationTest.m */,
@@ -4812,6 +4815,7 @@
 				9388CBAB21BD916F005CA66D /* DocumentExpirationTest.m in Sources */,
 				9378C5971E25B473001BB196 /* CBLTestCase.m in Sources */,
 				9378C5911E25B3F0001BB196 /* DatabaseTest.m in Sources */,
+				1AC83BC821C026D100792098 /* DateTimeQueryFunctionTest.m in Sources */,
 				938B3702200D7D1D004485D8 /* MigrationTest.m in Sources */,
 				9378C59E1E269F14001BB196 /* DocumentTest.m in Sources */,
 				9352945F1E51708E005CE4E8 /* DictionaryTest.m in Sources */,

--- a/Objective-C/CBLQueryFunction.h
+++ b/Objective-C/CBLQueryFunction.h
@@ -349,6 +349,72 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (CBLQueryExpression*) upper:(CBLQueryExpression*)expression;
 
+#pragma mark - Date-Time
+
+/**
+ Creates a STR_TO_MILLIS(expr) function that returns the number of milliseconds since the unix epoch
+ of the given ISO 8601 date time string expression.
+ 
+ @param expression The validly formatted ISO 8601 date time string expression.
+ @return The corresponding function that converts the date time string to timestamp.
+ @note Valid date strings must start with a date in the form YYYY-MM-DD (time only strings are
+ not supported).
+ 
+ Times can be of the form HH:MM, HH:MM:SS, or HH:MM:SS.FFF. Leading zero is not
+ optional (i.e. 02 is ok, 2 is not). Hours are in 24-hour format. FFF represents milliseconds,
+ and *trailing* zeros are optional (i.e. 5 == 500).
+ 
+ Time zones can be in one of three forms:
+ (+/-)HH:MM
+ (+/-)HHMM
+ Z (which represents UTC)
+ 
+ No time zone present will default to the device local time zone.
+ */
++ (CBLQueryExpression*) stringToMillis: (CBLQueryExpression*)expression;
+
+/**
+ Creates a STR_TO_UTC(expr) function that returns the ISO 8601 UTC datetime string of the
+ given ISO 8601 date time string expression.
+ 
+ @param expression The validly formatted ISO 8601 date time string expression.
+ @return The corresponding function that converts the string to UTC string.
+ @note Valid date strings must start with a date in the form YYYY-MM-DD (time only strings are
+ not supported).
+ 
+ Times can be of the form HH:MM, HH:MM:SS, or HH:MM:SS.FFF. Leading zero is not
+ optional (i.e. 02 is ok, 2 is not). Hours are in 24-hour format. FFF represents milliseconds,
+ and *trailing* zeros are optional (i.e. 5 == 500).
+ 
+ Time zones can be in one of three forms:
+ (+/-)HH:MM
+ (+/-)HHMM
+ Z (which represents UTC)
+ 
+ No time zone present will default to the device local time zone.
+ */
++ (CBLQueryExpression*) stringToUTC:(CBLQueryExpression *)expression;
+
+/**
+ Creates a MILLIS_TO_STR(expr) function that returns a ISO 8601 date time string in device
+ local timezone of the given number of milliseconds since the unix epoch expression.
+ 
+ @param expression The numeric value representing milliseconds since the unix epoch.
+ @return The corresponding function that converts the timestamp to the ISO 8601 date string.
+ @note If the input expression is not numeric, then the result will be null.
+ */
++ (CBLQueryExpression*) millisToString:(CBLQueryExpression *)expression;
+
+/**
+ Creates a MILLIS_TO_UTC(expr) function that returns the UTC ISO 8601 date time string
+ of the given number of milliseconds since the unix epoch expression.
+ 
+ @param expression The numeric value representing milliseconds since the unix epoch.
+ @return The corresponding function that converts the timestamp into the UTC ISO 8601 string.
+ @note If the input expression is not numeric, then the result will be null.
+ */
++ (CBLQueryExpression*) millisToUTC:(CBLQueryExpression *)expression;
+
 /** Not available */
 - (instancetype) init NS_UNAVAILABLE;
 

--- a/Objective-C/CBLQueryFunction.m
+++ b/Objective-C/CBLQueryFunction.m
@@ -322,4 +322,38 @@
 }
 
 
+# pragma mark - Date Time
+
+
++ (CBLQueryExpression*) stringToMillis:(CBLQueryExpression *)expression {
+    CBLAssertNotNil(expression);
+    
+    return [[CBLFunctionExpression alloc] initWithFunction: @"STR_TO_MILLIS()"
+                                                    params: @[expression]];
+}
+
+
++ (CBLQueryExpression*) stringToUTC:(CBLQueryExpression *)expression {
+    CBLAssertNotNil(expression);
+    
+    return [[CBLFunctionExpression alloc] initWithFunction: @"STR_TO_UTC()"
+                                                    params: @[expression]];
+}
+
+
++ (CBLQueryExpression*) millisToString:(CBLQueryExpression *)expression {
+    CBLAssertNotNil(expression);
+    
+    return [[CBLFunctionExpression alloc] initWithFunction: @"MILLIS_TO_STR()"
+                                                    params: @[expression]];
+}
+
+
++ (CBLQueryExpression*) millisToUTC:(CBLQueryExpression *)expression {
+    CBLAssertNotNil(expression);
+    
+    return [[CBLFunctionExpression alloc] initWithFunction: @"MILLIS_TO_UTC()"
+                                                    params: @[expression]];
+}
+
 @end

--- a/Objective-C/Tests/DateTimeQueryFunctionTest.m
+++ b/Objective-C/Tests/DateTimeQueryFunctionTest.m
@@ -28,126 +28,105 @@
 
 @implementation DateTimeQueryFunctionTest
 
+
 #pragma mark - Tests
 
-- (void) testWrongDateFormatStringToMillis {
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getLongStyleDateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
+
+- (void) testStringToMillis {
+    [self validateStringToMillis: @""
+                          result: nil];
     
-    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
+    [self validateStringToMillis: @"2018-12-32T01:01:01Z"
+                          result: nil];
     
-    // should be nil
-    AssertNil([result valueAtIndex: 0]);
+    [self validateStringToMillis: @"1970-01-01T00:00:00Z"
+                          result: [NSNumber numberWithDouble: 0]];
+    
+    [self validateStringToMillis: @"1970-01-01T00:00:00.123+0000"
+                          result: [NSNumber numberWithDouble: 123]];
+    
+    [self validateStringToMillis: @"2018-10-23T11:33:01-0700"
+                          result: [NSNumber numberWithDouble: 1540319581000]];
+    
+    [self validateStringToMillis: @"2018-10-23T18:33:01Z"
+                          result: [NSNumber numberWithDouble: 1540319581000]];
+    
+    [self validateStringToMillis: @"2018-10-23T18:33:01.123Z"
+                          result: [NSNumber numberWithDouble: 1540319581123]];
+    
+    // leap year
+    [self validateStringToMillis: @"2020-02-29T23:59:59.000000+0000"
+                          result: [NSNumber numberWithDouble: 1583020799000]];
 }
 
-- (void) testWrongDateFormatForStringToUTC {
-    NSError* error;
-    NSString* prefix = @"invalid";
-    CBLMutableDocument* doc = [self createDocument];
-    NSUInteger total = [self addInvalidDateStrings: doc prefix: prefix];
-    [self saveDocument: doc];
-    AssertNil(error);
+
+- (void) testStringToUTC {
+    [self validateStringToUTC: nil result: nil];
+    [self validateStringToUTC: @"x" result: nil];
     
-    NSArray* selectQueries = [self getSelectQueryForStringToUTCWithPrefix: prefix
-                                                          totalProperties: total];
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    CBLQueryResultSet* rs = [q execute: &error];
-    AssertNil(error);
+    [self validateStringToUTC: @"2018-10-23T18:33:01Z"
+                       result: @"2018-10-23T18:33:01Z"];
     
-    // should be NIL for all the wrong formats
-    [self validateAllResultSet: rs withDate: nil propertyCount: total prefix: prefix];
+    [self validateStringToUTC: @"2018-10-23T11:33:01-0700"
+                       result: @"2018-10-23T18:33:01Z"];
     
+    [self validateStringToUTC: @"2018-10-23T11:33:01+03:30"
+                       result: @"2018-10-23T08:03:01Z"];
+    
+    [self validateStringToUTC: @"2018-10-23T18:33:01.123Z"
+                       result: @"2018-10-23T18:33:01.123Z"];
+    
+    [self validateStringToUTC: @"2018-10-23T11:33:01.123-0700"
+                       result: @"2018-10-23T18:33:01.123Z"];
+    
+    [self validateStringToUTC: @"1970-01-01T00:00:00.000000+0000"
+                       result: @"1970-01-01T00:00:00Z"];
 }
 
-- (void) testDateWithMilliSeconds {
-    NSString* input = @"1970-01-01T02:46:40.123000+0000";
-    [self validateBasicStringToMillis: input];
-    [self validateStringToMillisWithDifferentTimeZones: input];
-    [self validateStringToMillisWithDifferentTimeformat: input];
+
+- (void) testMillisToString {
+    int mSec = 1000;
+    double seconds = 0.0;
+    [self validateMillisToString: [NSNumber numberWithDouble: seconds * mSec]
+                          result: [NSDate dateWithTimeIntervalSince1970: seconds]];
     
-    [self validateBasicStringToUTC: input];
-    [self validateStringToUTCWithDifferentTimeZones: input];
-    [self validateStringToUTCWithDifferentTimeformat: input];
+    seconds = 0.123;
+    [self validateMillisToString: [NSNumber numberWithDouble: seconds * mSec]
+                          result: [NSDate dateWithTimeIntervalSince1970: seconds]];
+    
+    seconds = 1000.123;
+    [self validateMillisToString: [NSNumber numberWithDouble: seconds * mSec]
+                          result: [NSDate dateWithTimeIntervalSince1970: seconds]];
+    
+    seconds = 65789245.123;
+    [self validateMillisToString: [NSNumber numberWithDouble: seconds * mSec]
+                          result: [NSDate dateWithTimeIntervalSince1970: seconds]];
 }
 
-- (void) testDateTillSeconds {
-    NSString* input = @"1970-01-01T02:46:40.000000+0000";
-    [self validateBasicStringToMillis: input];
-    [self validateStringToMillisWithDifferentTimeZones: input];
-    [self validateStringToMillisWithDifferentTimeformat: input];
+
+- (void) testMillisToUTC {
+    [self validateMillisToUTC: [NSNumber numberWithDouble: 0]
+                       result: @"1970-01-01T00:00:00Z"];
     
-    [self validateBasicStringToUTC: input];
-    [self validateStringToUTCWithDifferentTimeZones: input];
-    [self validateStringToUTCWithDifferentTimeformat: input];
+    [self validateMillisToUTC: [NSNumber numberWithDouble: 1540319581000]
+                       result: @"2018-10-23T18:33:01Z"];
+    
+    [self validateMillisToUTC: [NSNumber numberWithDouble: 1540319581123]
+                       result: @"2018-10-23T18:33:01.123Z"];
+    
+    [self validateMillisToUTC: [NSNumber numberWithDouble: 1540319581999]
+                       result: @"2018-10-23T18:33:01.999Z"];
 }
 
-- (void) testDateTillMinutes {
-    NSString* input = @"1970-01-01T02:46:00.000000+0000";
-    [self validateBasicStringToMillis: input];
-    [self validateStringToMillisWithDifferentTimeZones: input];
-    [self validateStringToMillisWithDifferentTimeformat: input];
-    
-    [self validateBasicStringToUTC: input];
-    [self validateStringToUTCWithDifferentTimeZones: input];
-    [self validateStringToUTCWithDifferentTimeformat: input];
-}
 
-- (void) testDateWithMidnight {
-    NSString* input = @"1970-01-01T00:00:00.000000+0000";
-    [self validateBasicStringToMillis: input];
-    [self validateStringToMillisWithDifferentTimeZones: input];
-    [self validateStringToMillisWithDifferentTimeformat: input];
-    
-    [self validateBasicStringToUTC: input];
-    [self validateStringToUTCWithDifferentTimeZones: input];
-    [self validateStringToUTCWithDifferentTimeformat: input];
-}
+#pragma mark - Helper Methods
 
-- (void) testDateWithJustBeforeMidnight {
-    NSString* input = @"1969-12-31T11:59:59.000000+0000";
-    [self validateBasicStringToMillis: input];
-    [self validateStringToMillisWithDifferentTimeZones: input];
-    [self validateStringToMillisWithDifferentTimeformat: input];
-    
-    [self validateBasicStringToUTC: input];
-    [self validateStringToUTCWithDifferentTimeZones: input];
-    [self validateStringToUTCWithDifferentTimeformat: input];
-}
 
-- (void) testDateWithLeapYearAndFeb29 {
-    NSString* input = @"1920-02-29T11:59:59.000000+0000";
-    [self validateBasicStringToMillis: input];
-    [self validateStringToMillisWithDifferentTimeZones: input];
-    [self validateStringToMillisWithDifferentTimeformat: input];
-    
-    [self validateBasicStringToUTC: input];
-    [self validateStringToUTCWithDifferentTimeZones: input];
-    [self validateStringToUTCWithDifferentTimeformat: input];
-}
-
-#pragma mark - StringToMillis Helper methods
-
-- (void) validateBasicStringToMillis: (NSString*)input {
-    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
-    AssertNotNil(date);
-    
-    // save
+- (void) validateStringToMillis: (NSString*)input result: (nullable NSNumber*)millis {
     NSError* error;
     NSString* key = @"dateString";
     CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getISO8601DateStringFromDate: date] forKey: key];
+    [doc setValue: input forKey: key];
     [self saveDocument: doc];
     AssertNil(error);
     
@@ -161,112 +140,48 @@
     AssertNotNil(result);
     
     // validate
-    long double dateInMillis = roundl([date timeIntervalSince1970] * 1000);
-    AssertEqual([result longLongAtIndex: 0], dateInMillis);
+    AssertEqual([result longLongAtIndex: 0], [millis doubleValue]);
     
     Assert([self.db purgeDocumentWithID: doc.id error: &error]);
     AssertNil(error);
 }
 
-- (void) validateStringToMillisWithDifferentTimeZones: (NSString*)input {
-    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
-    AssertNotNil(date);
-    
-    NSString* timezonePrefix = @"tz";
-    CBLMutableDocument* doc = [self createDocument];
-    [self addDifferentTimezoneDateStringTo: doc forDate: date withPrefix: timezonePrefix];
-    [self saveDocument: doc];
-    
-    NSArray* selectQueries = [self getSelectQueryForStringToMillisWithPrefix: timezonePrefix
-                                                             totalProperties: [self timezones].count];
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
-    AssertNil(error);
-    
-    [self validateResultSet: rs
-                 withMillis: round([date timeIntervalSince1970] * 1000)
-              propertyCount: [self timezones].count
-                     prefix: timezonePrefix];
-    
-    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
-    AssertNil(error);
-}
 
-- (void) validateStringToMillisWithDifferentTimeformat: (NSString*)input {
-    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
-    AssertNotNil(date);
-    
-    NSUInteger total = [self dateFormats].count;
-    NSString* prefix = @"dateFormat";
-    CBLMutableDocument* doc = [self createDocument];
-    NSArray* expectedResults = [self addDifferentDateTimeFormatsTo: doc
-                                                           forDate: date
-                                                        withPrefix: prefix];
-    [self saveDocument: doc];
-    
-    // convert
-    NSArray* selectQueries = [self getSelectQueryForStringToMillisWithPrefix: prefix
-                                                             totalProperties: total];
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs);
-    AssertNil(error);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    
-    // validate
-    for (NSUInteger i = 0; i < expectedResults.count; i++) {
-        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, i];
-        double dateInMillis = [[expectedResults objectAtIndex: i] timeIntervalSince1970] * 1000;
-        AssertEqual([result longLongForKey: propertyKey], round(dateInMillis));
-    }
-    
-    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
-    AssertNil(error);
-}
-
-/**
- This method will return the Timezone Query Select results for the StringToMillis
- 
- @param propertyPrefix prefix to be added with the propertyKey and the index of the timezone.
- For example, if the prefix is `timezone`, then each properties in the doc will be `timezone-0`,
- `timezone-1`, `timezone-2` etc.
- total total no of properties present, with the prefix.
- @return list of select queries for each timezone date-string.
- */
-- (NSArray*) getSelectQueryForStringToMillisWithPrefix: (NSString*)propertyPrefix
-                                       totalProperties: (NSUInteger)total {
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < total; i++) {
-        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", propertyPrefix, i];
-        CBLQueryExpression* expr = [CBLQueryFunction
-                                    stringToMillis: [CBLQueryExpression property: propertyKey]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expr as: propertyKey]];
-    }
-    return [NSArray arrayWithArray: selectQueries];
-}
-
-#pragma mark - StringToUTC Helper methods
-
-- (void) validateBasicStringToUTC: (NSString*)input {
-    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
-    AssertNotNil(date);
-    
-    // save
+- (void) validateStringToUTC: (nullable NSString*)input result: (nullable NSString*)date {
     NSError* error;
     NSString* key = @"dateString";
     CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getISO8601DateStringFromDate: date] forKey: key];
+    [doc setValue: input forKey: key];
     [self saveDocument: doc];
     AssertNil(error);
     
     // convert
     CBLQueryExpression* query = [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    AssertEqualObjects([result stringAtIndex: 0], date);
+    
+    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
+    AssertNil(error);
+}
+
+
+- (void) validateMillisToString: (NSNumber*)input result: (NSDate*)date {
+    NSError* error;
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setDouble: [input doubleValue] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    // convert
+    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
     CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
                                      from: [CBLQueryDataSource database: self.db]];
     CBLQueryResultSet* rs = [q execute: &error];
@@ -281,306 +196,30 @@
     AssertNil(error);
 }
 
-- (void) validateStringToUTCWithDifferentTimeZones: (NSString*)input {
-    NSString* timezonePrefix = @"tz";
-    NSUInteger total = [[self timezones] count];
-    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
-    CBLMutableDocument* doc = [self createDocument];
-    [self addDifferentTimezoneDateStringTo: doc forDate: date withPrefix: timezonePrefix];
-    [self saveDocument: doc];
-    
-    // convert & fetch
-    CBLQuery* q = [CBLQueryBuilder select: [self getSelectQueryForStringToUTCWithPrefix: timezonePrefix
-                                                                        totalProperties: total]
-                                     from: [CBLQueryDataSource database: self.db]];
+
+- (void) validateMillisToUTC: (NSNumber*)input result: (NSString*)utcString {
     NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setDouble: [input doubleValue] forKey: key];
+    [self saveDocument: doc];
     AssertNil(error);
     
-    [self validateAllResultSet: rs withDate: date propertyCount: total prefix: timezonePrefix];
+    // convert
+    CBLQueryExpression* query = [CBLQueryFunction millisToUTC: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    AssertEqualObjects([result stringAtIndex: 0], utcString);
     
     Assert([self.db purgeDocumentWithID: doc.id error: &error]);
     AssertNil(error);
 }
 
-- (void) validateStringToUTCWithDifferentTimeformat: (NSString*)input {
-    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
-    AssertNotNil(date);
-    
-    // save
-    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
-    NSString* prefix = @"dateformat";
-    CBLMutableDocument* doc = [self createDocument];
-    [self addDifferentDateTimeFormatsTo: doc forDate: date withPrefix: prefix];
-    [self saveDocument: doc];
-    
-    // convert & fetch
-    CBLQuery* q = [CBLQueryBuilder select: [self getSelectQueryForStringToUTCWithPrefix: prefix
-                                                                        totalProperties: [[self dateFormats]
-                                                                                          count]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
-    AssertNil(error);
-    
-    [self validateResultSet: rs expectedResults: expectedResults prefix: prefix];
-    
-    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
-    AssertNil(error);
-}
-
-/**
- This method will return the Timezone Query Select results for the StringToUTC
- 
- @param propertyPrefix prefix to be added with the propertyKey and the index of the timezone.
- For example, if the prefix is `timezone`, then each properties in the doc will be `timezone-0`,
- `timezone-1`, `timezone-2` etc.
- total total no of properties present, with the prefix.
- @return list of select queries for each timezone date-string.
- */
-- (NSArray*) getSelectQueryForStringToUTCWithPrefix: (NSString*)propertyPrefix
-                                    totalProperties: (NSUInteger)total
-{
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < total; i++) {
-        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", propertyPrefix, i];
-        CBLQueryExpression* expression = [CBLQueryFunction
-                                          stringToUTC: [CBLQueryExpression property: propertyKey]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: propertyKey]];
-    }
-    return [NSArray arrayWithArray: selectQueries];
-}
-
-#pragma mark - Common
-
-#pragma mark Populate Document Methods
-
-/**
- The method will adds invalid date strings to the given document.
- 
- @param doc The document where we add the invalid date fields, as properties.
- prefix The prefix of the property key, which will be appended with the index will make the property
- key.
- @return no of invalid properties are added to the docs.
- */
-- (NSUInteger) addInvalidDateStrings: (CBLMutableDocument*)doc
-                              prefix: (NSString*)prefix
-{
-    NSDate* now = [NSDate date];
-    NSUInteger totalInvalidCases = 0;
-    [doc setString: [self getLongStyleDateString: now]
-            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
-    [doc setString: @""
-            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
-    [doc setInteger: 9998108
-             forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
-    [doc setString: @"someRandomString"
-            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
-    // Feb 30th, leap
-    [doc setString: @"2020-02-30T01:01:01.000000+0000"
-            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
-    // Feb 29th, non-leap
-    [doc setString: @"2019-02-29T01:01:01.000000+0000"
-            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
-    return totalInvalidCases;
-}
-
-/**
- This method will add date-string for every timezone from [self timezones].
- 
- @param
- doc The mutable document where we add all the date strings to.
- date The date whcih needs to be converted to all timezones and added to the document.
- propertyPrefix prefix to be added with the propertyKey and the index of the timezone.
- For example, if the prefix is `timezone`, then each properties in the doc will be `timezone-0`,
- `timezone-1`, `timezone-2` etc.
- 
- */
-- (void) addDifferentTimezoneDateStringTo: (CBLMutableDocument*)doc
-                                  forDate: (NSDate*)date
-                               withPrefix: (NSString*)prefix
-{
-    for (NSUInteger i = 0; i < [self timezones].count; i++) {
-        NSTimeZone* tz = [NSTimeZone timeZoneWithAbbreviation: [[self timezones] objectAtIndex: i]];
-        NSString* dateString = [self getISO8601DateStringFromDate: date timezone: tz];
-        [doc setString: dateString forKey: [NSString stringWithFormat: @"%@-%lu", prefix, i]];
-    }
-}
-
-
-/**
- This will add different date time formats as properties of the document supplied.
- 
- @param doc The document where we add the new properties.
- date The date which will be converted to different formats.
- prefix The prefix of the property key. It will be appended with the index of the dateFormat array
- will make a property key.
- @return The expected results(NSArray<NSDate>)
- */
-- (NSArray<NSDate*>*) addDifferentDateTimeFormatsTo: (CBLMutableDocument*)doc
-                                            forDate: (NSDate*)date
-                                         withPrefix: (NSString*)prefix
-{
-    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        NSString* format = [[self dateFormats] objectAtIndex: i];
-        NSString* dateString = [self getLocalDateStringFromDate: date format: format];
-        AssertNotNil(dateString);
-        [doc setString: dateString
-                forKey: [NSString stringWithFormat: @"%@-%lu", prefix, (unsigned long)i]];
-        
-        // prepare the expected output date from this
-        NSDate* expectedDate = [self getDateFromString: dateString format: format];
-        AssertNotNil(expectedDate);
-        [expectedResults addObject: expectedDate];
-    }
-    
-    return [NSArray arrayWithArray: expectedResults];
-}
-
-#pragma mark Validate Result Set
-
-
-/**
- The method will validate the result set with the expected results.
- 
- @param rs The result set
- expectedResults The expected results to be compared with
- prefix The prefix of the property key, which will be appended with the index will make the property
- key.
- */
-- (void) validateResultSet: (CBLQueryResultSet*)rs
-           expectedResults: (NSArray*)expectedResults
-                    prefix: (NSString*)prefix
-{
-    Assert(rs);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    
-    for (NSUInteger i = 0; i < expectedResults.count; i++) {
-        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, (unsigned long)i];
-        AssertEqualObjects([result dateForKey: propertyKey], [expectedResults objectAtIndex: i]);
-    }
-}
-
-/**
- This method will validate the Query result set with the given date. It will iterate and
- compare
- 
- @param rs The result set
- expectedDate The expected result Date to be returned in the result.
- prefix The prefix of the property-key.
- */
-- (void) validateAllResultSet: (CBLQueryResultSet*)rs
-                     withDate: (nullable NSDate*)expectedDate
-                propertyCount: (NSUInteger)count
-                       prefix: (NSString*)prefix
-{
-    Assert(rs);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    
-    // validate
-    for (NSUInteger i = 0; i < count; i++) {
-        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, i];
-        AssertEqualObjects(expectedDate, [result dateForKey: propertyKey]);
-    }
-}
-
-/**
- This method will validate the Query result set with the given timestamp. It will iterate and
- compare
- 
- @param rs The result set
- timestamp The expected result in milliseconds.
- prefix The prefix of the property-key.
- */
-- (void) validateResultSet: (CBLQueryResultSet*)rs
-                withMillis: (double)timestamp
-             propertyCount: (NSUInteger)count
-                    prefix: (NSString*)prefix
-{
-    Assert(rs);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    
-    // validate
-    for (NSUInteger i = 0; i < count; i++) {
-        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, i];
-        AssertEqual(timestamp, [result longLongForKey: propertyKey]);
-    }
-}
-
-#pragma mark Date Conversion methods
-
-- (NSString*) getISO8601DateStringFromDate: (NSDate*)date {
-    return [self getISO8601DateStringFromDate: date timezone: [NSTimeZone localTimeZone]];
-}
-
-- (NSString*) getISO8601DateStringFromDate: (NSDate*)date timezone: (NSTimeZone*)tz {
-    return [self getDateStringFromDate: date
-                                format: kISO8601DateFormat
-                              timezone: tz];
-}
-
-- (NSString*) getLocalDateStringFromDate: (NSDate*)date format: (NSString*)format {
-    return [self getDateStringFromDate: date
-                                format: format
-                              timezone: [NSTimeZone localTimeZone]];
-}
-
-- (NSString*) getDateStringFromDate: (NSDate*)date
-                             format: (NSString*)format
-                           timezone: (NSTimeZone*)tz
-{
-    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setTimeZone: tz];
-    [dateFormatter setDateFormat: format];
-    return [dateFormatter stringFromDate: date];
-}
-
-- (NSString*) getLongStyleDateString: (NSDate*)date {
-    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateStyle: NSDateFormatterLongStyle];
-    return [dateFormatter stringFromDate: date];
-}
-
-- (NSDate*) getDateFromString: (NSString*)dateString format: (NSString*)format {
-    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat: format];
-    return [dateFormatter dateFromString: dateString];
-}
-
-#pragma mark - test-constants
-
-- (NSArray*) dateFormats {
-    return @[ @"yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ",
-              @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
-              @"yyyy-MM-dd'T'HH:mm:ss.SZZZZZ",
-              @"yyyy-MM-dd'T'HH:mm:ssZZZZZ",
-              @"yyyy-MM-dd'T'HH:mmZZZZZ"];
-}
-
-- (NSArray*) timezones {
-    return @[ @"BIT", // -12
-              @"AKST", // -9
-              @"CDT", // -6
-              @"IST", // -5:30
-              @"EDT", // -4
-              @"UYT", // -3
-              @"EGT", // -1
-              @"UTC", // +00
-              @"BST", // +1
-              @"CAT", // +2
-              @"MSK", // +3
-              @"MUT", // +4
-              @"MST", // +5
-              @"PST", // +8
-              @"JST", // +9
-              @"ACDT"]; // +10:30
-}
 
 @end

--- a/Objective-C/Tests/DateTimeQueryFunctionTest.m
+++ b/Objective-C/Tests/DateTimeQueryFunctionTest.m
@@ -20,11 +20,295 @@
 
 #import "CBLTestCase.h"
 
+#define kISO8601DateFormat @"yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ"
+#define kStringToUTCDateFormat @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+#define kMillisToStringFormat @"yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+
 @interface DateTimeQueryFunctionTest : CBLTestCase
 
 @end
 
 @implementation DateTimeQueryFunctionTest
+
+#pragma mark - StringToMillis
+
+- (void) testStringToMillis {
+    // save
+    NSError* error;
+    NSDate* now = [NSDate date];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getISO8601DateString: now] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    // convert
+    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
+    AssertEqual([result longLongAtIndex: 0], nowInMillis);
+}
+
+- (void) testWrongDateFormat {
+    NSError* error;
+    NSDate* now = [NSDate date];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getLongStyleDateString: now] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // should be nil
+    AssertNil([result valueAtIndex: 0]);
+}
+
+- (void) testStringToMillisWithDifferentTimeZones {
+    // save
+    NSDate* now = [NSDate date];
+    CBLMutableDocument* doc = [self createDocument];
+    for (NSString* abbr in [self timezones]) {
+        NSString* dateString =
+            [self getISO8601DateString: now timezone: [NSTimeZone timeZoneWithAbbreviation:abbr]];
+        [doc setString: dateString forKey: abbr];
+    }
+    [self saveDocument: doc];
+    
+    // convert
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSString* abbr in [self timezones]) {
+        CBLQueryExpression* expression =
+            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: abbr]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: abbr]];
+    }
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs);
+    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
+    for (NSString* abbr in [self timezones]) {
+        AssertEqual(nowInMillis, [result longLongForKey: abbr]);
+    }
+}
+
+- (void) testStringToMillisWithDifferentTimeformat {
+    NSDate* now = [NSDate date];
+    CBLMutableDocument* doc = [self createDocument];
+    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        // save
+        NSString* format = [[self dateFormats] objectAtIndex: i];
+        NSString* dateString = [self getLocalDateString: now format: format];
+        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
+        
+        // create expected outputs from the input
+        NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat: format];
+        NSDate* date = [dateFormatter dateFromString: dateString];
+        [expectedResults addObject: [NSNumber numberWithDouble: [date timeIntervalSince1970]]];
+    }
+    [self saveDocument: doc];
+    
+    // convert
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        CBLQueryExpression* expression =
+            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: key]];
+    }
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs);
+    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    for (NSUInteger i = 0; i < expectedResults.count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        double expectedResult = [[expectedResults objectAtIndex: i] doubleValue] * 1000;
+        AssertEqual([result longLongForKey: key], expectedResult);
+    }
+}
+
+#pragma mark - StringToUTC
+
+- (void) testWrongDateFormatWithStringToUTC {
+    NSError* error;
+    NSDate* now = [NSDate date];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getLongStyleDateString: now] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // should be NIL
+    AssertNil([result valueAtIndex: 0]);
+}
+
+- (void) testStringToUTCWithDifferentTimeZones {
+    NSDate* now = [NSDate date];
+    CBLMutableDocument* doc = [self createDocument];
+    for (NSString* abbr in [self timezones]) {
+        NSString* dateString = [self getISO8601DateString: now
+                                                 timezone: [NSTimeZone
+                                                            timeZoneWithAbbreviation: abbr]];
+        [doc setString: dateString forKey: abbr];
+    }
+    [self saveDocument: doc];
+    
+    // convert & fetch
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSString* abbr in [self timezones]) {
+        CBLQueryExpression* expression =
+        [CBLQueryFunction stringToUTC: [CBLQueryExpression property: abbr]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: abbr]];
+    }
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs);
+    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    NSString* expectedOutput = [self getUTCDateString: now format: kStringToUTCDateFormat];
+    for (NSString* abbr in [self timezones]) {
+        AssertEqualObjects(expectedOutput, [result stringForKey: abbr]);
+    }
+}
+
+- (void) testStringToUTCWithDifferentTimeformat {
+    NSString* input = @"1970-01-01T02:46:40.123000Z";
+    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat: kStringToUTCDateFormat];
+    NSDate* date = [dateFormatter dateFromString: input];
+    
+    // save
+    CBLMutableDocument* doc = [self createDocument];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        NSString* format = [[self dateFormats] objectAtIndex: i];
+        NSString* dateString = [self getLocalDateString: date format: format];
+        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
+    }
+    [self saveDocument: doc];
+    
+    // convert & fetch
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        CBLQueryExpression* expression =
+        [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: key]];
+    }
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs);
+    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    NSArray* expectedResults = [[NSArray alloc] initWithObjects:
+                                @"1970-01-01T02:46:40.123Z",
+                                @"1970-01-01T02:46:40.123Z",
+                                @"1970-01-01T02:46:40.100Z",
+                                @"1970-01-01T02:46:40Z",
+                                @"1970-01-01T02:46:00Z", nil];
+    for (NSUInteger i = 0; i < expectedResults.count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        AssertEqualObjects([result stringForKey: key], [expectedResults objectAtIndex: i]);
+    }
+}
+
+#pragma mark - MillisToString
+
+- (void) testWrongDataWithMillisToString {
+    // save
+    NSError* error;
+    NSDate* now = [NSDate date];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getISO8601DateString: now] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    // convert & fetch
+    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // should be NIL
+    AssertNil([result valueAtIndex: 0]);
+}
+
+- (void) testMillisToString {
+    NSError* error;
+    NSString* key = @"dateString";
+    NSDate* date = [NSDate dateWithTimeIntervalSince1970: 10000.123456];
+    NSTimeInterval dateInMillis = [date timeIntervalSince1970] * 1000;
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setDouble: dateInMillis forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    // convert & fetch
+    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    NSString* dateString = [self getLocalDateString: date format: kMillisToStringFormat];
+    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
+}
+
+#pragma mark - Helper Methods
 
 - (NSString*) getISO8601DateString: (NSDate*)date {
     return [self getISO8601DateString: date
@@ -33,7 +317,7 @@
 
 - (NSString*) getISO8601DateString: (NSDate*)date timezone: (NSTimeZone*)tz {
     return [self getDateString: date
-                        format: @"yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ"
+                        format: kISO8601DateFormat
                       timezone: tz];
 }
 
@@ -41,6 +325,12 @@
     return [self getDateString: date
                         format: format
                       timezone: [NSTimeZone localTimeZone]];
+}
+
+- (NSString*) getUTCDateString: (NSDate*)date format: (NSString*)format {
+    return [self getDateString: date
+                        format: format
+                      timezone: [NSTimeZone timeZoneWithName: @"UTC"]];
 }
 
 - (NSString*) getDateString: (NSDate*)date format: (NSString*)format timezone: (NSTimeZone*)tz {
@@ -81,315 +371,6 @@
               @"yyyy-MM-dd'T'HH:mm:ss.SZZZZZ",
               @"yyyy-MM-dd'T'HH:mm:ssZZZZZ",
               @"yyyy-MM-dd'T'HH:mmZZZZZ"];
-}
-
-#pragma mark - StringToMillis
-
-- (void) testStringToMillis {
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getISO8601DateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
-    AssertEqual([result longLongAtIndex: 0], nowInMillis);
-}
-
-- (void) testWrongDateFormat {
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getLongStyleDateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    AssertNil([result valueAtIndex: 0]);
-}
-
-- (void) testStringToMillisWithDifferentTimeZones {
-    NSDate* now = [NSDate date];
-    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
-    
-    CBLMutableDocument* doc = [self createDocument];
-    for (NSString* abbr in [self timezones]) {
-        NSString* dateString =
-            [self getISO8601DateString: now timezone: [NSTimeZone timeZoneWithAbbreviation:abbr]];
-        [doc setString: dateString forKey: abbr];
-    }
-    [self saveDocument: doc];
-    
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSString* abbr in [self timezones]) {
-        CBLQueryExpression* expression =
-            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: abbr]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: abbr]];
-    }
-    
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs);
-    AssertNil(error);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    for (NSString* abbr in [self timezones]) {
-        AssertEqual(nowInMillis, [result longLongForKey: abbr]);
-    }
-}
-
-- (void) testStringToMillisWithDifferentTimeformat {
-    NSDate* now = [NSDate date];
-    
-    CBLMutableDocument* doc = [self createDocument];
-    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        NSString* format = [[self dateFormats] objectAtIndex: i];
-        NSString* dateString = [self getLocalDateString: now format: format];
-        
-        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat: format];
-        NSDate *date = [dateFormatter dateFromString: dateString];
-        [expectedResults addObject: [NSNumber numberWithDouble: [date timeIntervalSince1970]]];
-        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
-    }
-    [self saveDocument: doc];
-    
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        CBLQueryExpression* expression =
-            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: key]];
-    }
-    
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs);
-    AssertNil(error);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    for (NSUInteger i = 0; i < expectedResults.count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        double expectedResult = [[expectedResults objectAtIndex: i] doubleValue] * 1000;
-        AssertEqual([result longLongForKey: key], expectedResult);
-    }
-}
-
-#pragma mark - StringToUTC
-
-- (void) testWrongDateFormatWithStringToUTC {
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getLongStyleDateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    AssertNil([result valueAtIndex: 0]);
-}
-
-- (void) testStringToUTCWithDifferentTimeZones {
-    NSDate* now = [NSDate date];
-    NSString* utcString = [self getDateString: now
-                                       format: @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-                                     timezone: [NSTimeZone timeZoneWithName: @"UTC"]];
-    
-    CBLMutableDocument* doc = [self createDocument];
-    for (NSString* abbr in [self timezones]) {
-        NSString* dateString =
-        [self getISO8601DateString: now timezone: [NSTimeZone timeZoneWithAbbreviation:abbr]];
-        [doc setString: dateString forKey: abbr];
-    }
-    [self saveDocument: doc];
-    
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSString* abbr in [self timezones]) {
-        CBLQueryExpression* expression =
-        [CBLQueryFunction stringToUTC: [CBLQueryExpression property: abbr]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: abbr]];
-    }
-    
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs);
-    AssertNil(error);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    for (NSString* abbr in [self timezones]) {
-        AssertEqualObjects(utcString, [result stringForKey: abbr]);
-    }
-}
-
-- (void) testStringToUTCWithDifferentTimeformat {
-    // 1970-01-01T02:46:40.123000Z in UTC
-    NSDate* date = [NSDate dateWithTimeIntervalSince1970: 10000.123456];
-    CBLMutableDocument* doc = [self createDocument];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        NSString* format = [[self dateFormats] objectAtIndex: i];
-        NSString* dateString = [self getLocalDateString: date format: format];
-        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
-    }
-    [self saveDocument: doc];
-    
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        CBLQueryExpression* expression =
-        [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: key]];
-    }
-    
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs);
-    AssertNil(error);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
-    NSArray* expectedResults = [[NSArray alloc] initWithObjects:
-                                @"1970-01-01T02:46:40.123Z",
-                                @"1970-01-01T02:46:40.123Z",
-                                @"1970-01-01T02:46:40.100Z",
-                                @"1970-01-01T02:46:40Z",
-                                @"1970-01-01T02:46:00Z", nil];
-    for (NSUInteger i = 0; i < expectedResults.count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        AssertEqualObjects([result stringForKey: key], [expectedResults objectAtIndex: i]);
-    }
-}
-
-#pragma mark - MillisToString
-
-- (void) testWrongDataWithMillisToString {
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getISO8601DateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    AssertNil([result valueAtIndex: 0]);
-}
-
-- (void) testMillisToString {
-    NSDate* date = [NSDate dateWithTimeIntervalSince1970: 10000.123456];
-    NSString* dateString = [self getLocalDateString: date format: @"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-    NSTimeInterval dateInMillis = [date timeIntervalSince1970] * 1000;
-    NSError* error;
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setDouble: dateInMillis forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
-}
-
-- (void) testMillisToStringFromNoSeconds {
-    // zero seconds and no fraction, so format will not include the FFF.
-    NSString* format = @"yyyy-MM-dd'T'HH:mm:ssZ";
-    double seconds = 0;
-    NSDate* date = [NSDate dateWithTimeIntervalSince1970: seconds];
-    NSString* dateString = [self getLocalDateString: date format: format];
-    NSError* error;
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setDouble: seconds forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
-}
-
-- (void) testMillisToStringFromFractionOfSeconds {
-    NSString* format = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
-    double seconds = 0.123;
-    NSDate* date = [NSDate dateWithTimeIntervalSince1970: seconds];
-    NSString* dateString = [self getLocalDateString: date format: format];
-    NSError* error;
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setDouble: seconds * 1000 forKey: key]; // secs to milliseconds
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
 }
 
 @end

--- a/Objective-C/Tests/DateTimeQueryFunctionTest.m
+++ b/Objective-C/Tests/DateTimeQueryFunctionTest.m
@@ -21,8 +21,6 @@
 #import "CBLTestCase.h"
 
 #define kISO8601DateFormat @"yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ"
-#define kStringToUTCDateFormat @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-#define kMillisToStringFormat @"yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 
 @interface DateTimeQueryFunctionTest : CBLTestCase
 
@@ -30,33 +28,9 @@
 
 @implementation DateTimeQueryFunctionTest
 
-#pragma mark - StringToMillis
+#pragma mark - Tests
 
-- (void) testStringToMillis {
-    // save
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getISO8601DateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    // convert
-    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    
-    // validate
-    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
-    AssertEqual([result longLongAtIndex: 0], nowInMillis);
-}
-
-- (void) testWrongDateFormat {
+- (void) testWrongDateFormatStringToMillis {
     NSError* error;
     NSDate* now = [NSDate date];
     NSString* key = @"dateString";
@@ -77,67 +51,164 @@
     AssertNil([result valueAtIndex: 0]);
 }
 
-- (void) testStringToMillisWithDifferentTimeZones {
-    // save
-    NSDate* now = [NSDate date];
+- (void) testWrongDateFormatForStringToUTC {
+    NSError* error;
+    NSString* prefix = @"invalid";
     CBLMutableDocument* doc = [self createDocument];
-    for (NSString* abbr in [self timezones]) {
-        NSString* dateString =
-            [self getISO8601DateString: now timezone: [NSTimeZone timeZoneWithAbbreviation:abbr]];
-        [doc setString: dateString forKey: abbr];
-    }
+    NSUInteger total = [self addInvalidDateStrings: doc prefix: prefix];
     [self saveDocument: doc];
+    AssertNil(error);
+    
+    NSArray* selectQueries = [self getSelectQueryForStringToUTCWithPrefix: prefix
+                                                          totalProperties: total];
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    AssertNil(error);
+    
+    // should be NIL for all the wrong formats
+    [self validateAllResultSet: rs withDate: nil propertyCount: total prefix: prefix];
+    
+}
+
+- (void) testDateWithMilliSeconds {
+    NSString* input = @"1970-01-01T02:46:40.123000+0000";
+    [self validateBasicStringToMillis: input];
+    [self validateStringToMillisWithDifferentTimeZones: input];
+    [self validateStringToMillisWithDifferentTimeformat: input];
+    
+    [self validateBasicStringToUTC: input];
+    [self validateStringToUTCWithDifferentTimeZones: input];
+    [self validateStringToUTCWithDifferentTimeformat: input];
+}
+
+- (void) testDateTillSeconds {
+    NSString* input = @"1970-01-01T02:46:40.000000+0000";
+    [self validateBasicStringToMillis: input];
+    [self validateStringToMillisWithDifferentTimeZones: input];
+    [self validateStringToMillisWithDifferentTimeformat: input];
+    
+    [self validateBasicStringToUTC: input];
+    [self validateStringToUTCWithDifferentTimeZones: input];
+    [self validateStringToUTCWithDifferentTimeformat: input];
+}
+
+- (void) testDateTillMinutes {
+    NSString* input = @"1970-01-01T02:46:00.000000+0000";
+    [self validateBasicStringToMillis: input];
+    [self validateStringToMillisWithDifferentTimeZones: input];
+    [self validateStringToMillisWithDifferentTimeformat: input];
+    
+    [self validateBasicStringToUTC: input];
+    [self validateStringToUTCWithDifferentTimeZones: input];
+    [self validateStringToUTCWithDifferentTimeformat: input];
+}
+
+- (void) testDateWithMidnight {
+    NSString* input = @"1970-01-01T00:00:00.000000+0000";
+    [self validateBasicStringToMillis: input];
+    [self validateStringToMillisWithDifferentTimeZones: input];
+    [self validateStringToMillisWithDifferentTimeformat: input];
+    
+    [self validateBasicStringToUTC: input];
+    [self validateStringToUTCWithDifferentTimeZones: input];
+    [self validateStringToUTCWithDifferentTimeformat: input];
+}
+
+- (void) testDateWithJustBeforeMidnight {
+    NSString* input = @"1969-12-31T11:59:59.000000+0000";
+    [self validateBasicStringToMillis: input];
+    [self validateStringToMillisWithDifferentTimeZones: input];
+    [self validateStringToMillisWithDifferentTimeformat: input];
+    
+    [self validateBasicStringToUTC: input];
+    [self validateStringToUTCWithDifferentTimeZones: input];
+    [self validateStringToUTCWithDifferentTimeformat: input];
+}
+
+- (void) testDateWithLeapYearAndFeb29 {
+    NSString* input = @"1920-02-29T11:59:59.000000+0000";
+    [self validateBasicStringToMillis: input];
+    [self validateStringToMillisWithDifferentTimeZones: input];
+    [self validateStringToMillisWithDifferentTimeformat: input];
+    
+    [self validateBasicStringToUTC: input];
+    [self validateStringToUTCWithDifferentTimeZones: input];
+    [self validateStringToUTCWithDifferentTimeformat: input];
+}
+
+#pragma mark - StringToMillis Helper methods
+
+- (void) validateBasicStringToMillis: (NSString*)input {
+    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
+    AssertNotNil(date);
+    
+    // save
+    NSError* error;
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getISO8601DateStringFromDate: date] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
     
     // convert
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSString* abbr in [self timezones]) {
-        CBLQueryExpression* expression =
-            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: abbr]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: abbr]];
-    }
+    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    
+    // validate
+    long double dateInMillis = roundl([date timeIntervalSince1970] * 1000);
+    AssertEqual([result longLongAtIndex: 0], dateInMillis);
+    
+    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
+    AssertNil(error);
+}
+
+- (void) validateStringToMillisWithDifferentTimeZones: (NSString*)input {
+    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
+    AssertNotNil(date);
+    
+    NSString* timezonePrefix = @"tz";
+    CBLMutableDocument* doc = [self createDocument];
+    [self addDifferentTimezoneDateStringTo: doc forDate: date withPrefix: timezonePrefix];
+    [self saveDocument: doc];
+    
+    NSArray* selectQueries = [self getSelectQueryForStringToMillisWithPrefix: timezonePrefix
+                                                             totalProperties: [self timezones].count];
     CBLQuery* q = [CBLQueryBuilder select: selectQueries
                                      from: [CBLQueryDataSource database: self.db]];
     NSError* error;
     CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs);
     AssertNil(error);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
     
-    // validate
-    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
-    for (NSString* abbr in [self timezones]) {
-        AssertEqual(nowInMillis, [result longLongForKey: abbr]);
-    }
+    [self validateResultSet: rs
+                 withMillis: round([date timeIntervalSince1970] * 1000)
+              propertyCount: [self timezones].count
+                     prefix: timezonePrefix];
+    
+    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
+    AssertNil(error);
 }
 
-- (void) testStringToMillisWithDifferentTimeformat {
-    NSDate* now = [NSDate date];
+- (void) validateStringToMillisWithDifferentTimeformat: (NSString*)input {
+    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
+    AssertNotNil(date);
+    
+    NSUInteger total = [self dateFormats].count;
+    NSString* prefix = @"dateFormat";
     CBLMutableDocument* doc = [self createDocument];
-    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        // save
-        NSString* format = [[self dateFormats] objectAtIndex: i];
-        NSString* dateString = [self getLocalDateString: now format: format];
-        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
-        
-        // create expected outputs from the input
-        NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat: format];
-        NSDate* date = [dateFormatter dateFromString: dateString];
-        [expectedResults addObject: [NSNumber numberWithDouble: [date timeIntervalSince1970]]];
-    }
+    NSArray* expectedResults = [self addDifferentDateTimeFormatsTo: doc
+                                                           forDate: date
+                                                        withPrefix: prefix];
     [self saveDocument: doc];
     
     // convert
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        CBLQueryExpression* expression =
-            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: key]];
-    }
+    NSArray* selectQueries = [self getSelectQueryForStringToMillisWithPrefix: prefix
+                                                             totalProperties: total];
     CBLQuery* q = [CBLQueryBuilder select: selectQueries
                                      from: [CBLQueryDataSource database: self.db]];
     NSError* error;
@@ -150,23 +221,51 @@
     
     // validate
     for (NSUInteger i = 0; i < expectedResults.count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        double expectedResult = [[expectedResults objectAtIndex: i] doubleValue] * 1000;
-        AssertEqual([result longLongForKey: key], expectedResult);
+        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, i];
+        double dateInMillis = [[expectedResults objectAtIndex: i] timeIntervalSince1970] * 1000;
+        AssertEqual([result longLongForKey: propertyKey], round(dateInMillis));
     }
+    
+    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
+    AssertNil(error);
 }
 
-#pragma mark - StringToUTC
+/**
+ This method will return the Timezone Query Select results for the StringToMillis
+ 
+ @param propertyPrefix prefix to be added with the propertyKey and the index of the timezone.
+ For example, if the prefix is `timezone`, then each properties in the doc will be `timezone-0`,
+ `timezone-1`, `timezone-2` etc.
+ total total no of properties present, with the prefix.
+ @return list of select queries for each timezone date-string.
+ */
+- (NSArray*) getSelectQueryForStringToMillisWithPrefix: (NSString*)propertyPrefix
+                                       totalProperties: (NSUInteger)total {
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < total; i++) {
+        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", propertyPrefix, i];
+        CBLQueryExpression* expr = [CBLQueryFunction
+                                    stringToMillis: [CBLQueryExpression property: propertyKey]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expr as: propertyKey]];
+    }
+    return [NSArray arrayWithArray: selectQueries];
+}
 
-- (void) testWrongDateFormatWithStringToUTC {
+#pragma mark - StringToUTC Helper methods
+
+- (void) validateBasicStringToUTC: (NSString*)input {
+    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
+    AssertNotNil(date);
+    
+    // save
     NSError* error;
-    NSDate* now = [NSDate date];
     NSString* key = @"dateString";
     CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getLongStyleDateString: now] forKey: key];
+    [doc setValue: [self getISO8601DateStringFromDate: date] forKey: key];
     [self saveDocument: doc];
     AssertNil(error);
     
+    // convert
     CBLQueryExpression* query = [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
     CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
                                      from: [CBLQueryDataSource database: self.db]];
@@ -175,165 +274,268 @@
     CBLQueryResult* result = [[rs allObjects] firstObject];
     AssertNotNil(result);
     
-    // should be NIL
-    AssertNil([result valueAtIndex: 0]);
+    // validate
+    AssertEqualObjects([result dateAtIndex: 0], date);
+    
+    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
+    AssertNil(error);
 }
 
-- (void) testStringToUTCWithDifferentTimeZones {
-    NSDate* now = [NSDate date];
+- (void) validateStringToUTCWithDifferentTimeZones: (NSString*)input {
+    NSString* timezonePrefix = @"tz";
+    NSUInteger total = [[self timezones] count];
+    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
     CBLMutableDocument* doc = [self createDocument];
-    for (NSString* abbr in [self timezones]) {
-        NSString* dateString = [self getISO8601DateString: now
-                                                 timezone: [NSTimeZone
-                                                            timeZoneWithAbbreviation: abbr]];
-        [doc setString: dateString forKey: abbr];
-    }
+    [self addDifferentTimezoneDateStringTo: doc forDate: date withPrefix: timezonePrefix];
     [self saveDocument: doc];
     
     // convert & fetch
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSString* abbr in [self timezones]) {
-        CBLQueryExpression* expression =
-        [CBLQueryFunction stringToUTC: [CBLQueryExpression property: abbr]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: abbr]];
-    }
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+    CBLQuery* q = [CBLQueryBuilder select: [self getSelectQueryForStringToUTCWithPrefix: timezonePrefix
+                                                                        totalProperties: total]
                                      from: [CBLQueryDataSource database: self.db]];
     NSError* error;
     CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs);
     AssertNil(error);
-    NSArray* allResults = [rs allObjects];
-    CBLQueryResult* result = [allResults firstObject];
-    AssertNotNil(result);
     
-    // validate
-    NSString* expectedOutput = [self getUTCDateString: now format: kStringToUTCDateFormat];
-    for (NSString* abbr in [self timezones]) {
-        AssertEqualObjects(expectedOutput, [result stringForKey: abbr]);
+    [self validateAllResultSet: rs withDate: date propertyCount: total prefix: timezonePrefix];
+    
+    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
+    AssertNil(error);
+}
+
+- (void) validateStringToUTCWithDifferentTimeformat: (NSString*)input {
+    NSDate* date = [self getDateFromString: input format: kISO8601DateFormat];
+    AssertNotNil(date);
+    
+    // save
+    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
+    NSString* prefix = @"dateformat";
+    CBLMutableDocument* doc = [self createDocument];
+    [self addDifferentDateTimeFormatsTo: doc forDate: date withPrefix: prefix];
+    [self saveDocument: doc];
+    
+    // convert & fetch
+    CBLQuery* q = [CBLQueryBuilder select: [self getSelectQueryForStringToUTCWithPrefix: prefix
+                                                                        totalProperties: [[self dateFormats]
+                                                                                          count]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    AssertNil(error);
+    
+    [self validateResultSet: rs expectedResults: expectedResults prefix: prefix];
+    
+    Assert([self.db purgeDocumentWithID: doc.id error: &error]);
+    AssertNil(error);
+}
+
+/**
+ This method will return the Timezone Query Select results for the StringToUTC
+ 
+ @param propertyPrefix prefix to be added with the propertyKey and the index of the timezone.
+ For example, if the prefix is `timezone`, then each properties in the doc will be `timezone-0`,
+ `timezone-1`, `timezone-2` etc.
+ total total no of properties present, with the prefix.
+ @return list of select queries for each timezone date-string.
+ */
+- (NSArray*) getSelectQueryForStringToUTCWithPrefix: (NSString*)propertyPrefix
+                                    totalProperties: (NSUInteger)total
+{
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < total; i++) {
+        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", propertyPrefix, i];
+        CBLQueryExpression* expression = [CBLQueryFunction
+                                          stringToUTC: [CBLQueryExpression property: propertyKey]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: propertyKey]];
+    }
+    return [NSArray arrayWithArray: selectQueries];
+}
+
+#pragma mark - Common
+
+#pragma mark Populate Document Methods
+
+/**
+ The method will adds invalid date strings to the given document.
+ 
+ @param doc The document where we add the invalid date fields, as properties.
+ prefix The prefix of the property key, which will be appended with the index will make the property
+ key.
+ @return no of invalid properties are added to the docs.
+ */
+- (NSUInteger) addInvalidDateStrings: (CBLMutableDocument*)doc
+                              prefix: (NSString*)prefix
+{
+    NSDate* now = [NSDate date];
+    NSUInteger totalInvalidCases = 0;
+    [doc setString: [self getLongStyleDateString: now]
+            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
+    [doc setString: @""
+            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
+    [doc setInteger: 9998108
+             forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
+    [doc setString: @"someRandomString"
+            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
+    // Feb 30th, leap
+    [doc setString: @"2020-02-30T01:01:01.000000+0000"
+            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
+    // Feb 29th, non-leap
+    [doc setString: @"2019-02-29T01:01:01.000000+0000"
+            forKey: [NSString stringWithFormat: @"%lu", (unsigned long)totalInvalidCases++]];
+    return totalInvalidCases;
+}
+
+/**
+ This method will add date-string for every timezone from [self timezones].
+ 
+ @param
+ doc The mutable document where we add all the date strings to.
+ date The date whcih needs to be converted to all timezones and added to the document.
+ propertyPrefix prefix to be added with the propertyKey and the index of the timezone.
+ For example, if the prefix is `timezone`, then each properties in the doc will be `timezone-0`,
+ `timezone-1`, `timezone-2` etc.
+ 
+ */
+- (void) addDifferentTimezoneDateStringTo: (CBLMutableDocument*)doc
+                                  forDate: (NSDate*)date
+                               withPrefix: (NSString*)prefix
+{
+    for (NSUInteger i = 0; i < [self timezones].count; i++) {
+        NSTimeZone* tz = [NSTimeZone timeZoneWithAbbreviation: [[self timezones] objectAtIndex: i]];
+        NSString* dateString = [self getISO8601DateStringFromDate: date timezone: tz];
+        [doc setString: dateString forKey: [NSString stringWithFormat: @"%@-%lu", prefix, i]];
     }
 }
 
-- (void) testStringToUTCWithDifferentTimeformat {
-    NSString* input = @"1970-01-01T02:46:40.123000Z";
-    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat: kStringToUTCDateFormat];
-    NSDate* date = [dateFormatter dateFromString: input];
-    
-    // save
-    CBLMutableDocument* doc = [self createDocument];
+
+/**
+ This will add different date time formats as properties of the document supplied.
+ 
+ @param doc The document where we add the new properties.
+ date The date which will be converted to different formats.
+ prefix The prefix of the property key. It will be appended with the index of the dateFormat array
+ will make a property key.
+ @return The expected results(NSArray<NSDate>)
+ */
+- (NSArray<NSDate*>*) addDifferentDateTimeFormatsTo: (CBLMutableDocument*)doc
+                                            forDate: (NSDate*)date
+                                         withPrefix: (NSString*)prefix
+{
+    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
     for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
         NSString* format = [[self dateFormats] objectAtIndex: i];
-        NSString* dateString = [self getLocalDateString: date format: format];
-        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
+        NSString* dateString = [self getLocalDateStringFromDate: date format: format];
+        AssertNotNil(dateString);
+        [doc setString: dateString
+                forKey: [NSString stringWithFormat: @"%@-%lu", prefix, (unsigned long)i]];
+        
+        // prepare the expected output date from this
+        NSDate* expectedDate = [self getDateFromString: dateString format: format];
+        AssertNotNil(expectedDate);
+        [expectedResults addObject: expectedDate];
     }
-    [self saveDocument: doc];
     
-    // convert & fetch
-    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
-    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        CBLQueryExpression* expression =
-        [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
-        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: key]];
-    }
-    CBLQuery* q = [CBLQueryBuilder select: selectQueries
-                                     from: [CBLQueryDataSource database: self.db]];
-    NSError* error;
-    CBLQueryResultSet* rs = [q execute: &error];
+    return [NSArray arrayWithArray: expectedResults];
+}
+
+#pragma mark Validate Result Set
+
+
+/**
+ The method will validate the result set with the expected results.
+ 
+ @param rs The result set
+ expectedResults The expected results to be compared with
+ prefix The prefix of the property key, which will be appended with the index will make the property
+ key.
+ */
+- (void) validateResultSet: (CBLQueryResultSet*)rs
+           expectedResults: (NSArray*)expectedResults
+                    prefix: (NSString*)prefix
+{
     Assert(rs);
-    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    
+    for (NSUInteger i = 0; i < expectedResults.count; i++) {
+        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, (unsigned long)i];
+        AssertEqualObjects([result dateForKey: propertyKey], [expectedResults objectAtIndex: i]);
+    }
+}
+
+/**
+ This method will validate the Query result set with the given date. It will iterate and
+ compare
+ 
+ @param rs The result set
+ expectedDate The expected result Date to be returned in the result.
+ prefix The prefix of the property-key.
+ */
+- (void) validateAllResultSet: (CBLQueryResultSet*)rs
+                     withDate: (nullable NSDate*)expectedDate
+                propertyCount: (NSUInteger)count
+                       prefix: (NSString*)prefix
+{
+    Assert(rs);
     NSArray* allResults = [rs allObjects];
     CBLQueryResult* result = [allResults firstObject];
     AssertNotNil(result);
     
     // validate
-    NSArray* expectedResults = [[NSArray alloc] initWithObjects:
-                                @"1970-01-01T02:46:40.123Z",
-                                @"1970-01-01T02:46:40.123Z",
-                                @"1970-01-01T02:46:40.100Z",
-                                @"1970-01-01T02:46:40Z",
-                                @"1970-01-01T02:46:00Z", nil];
-    for (NSUInteger i = 0; i < expectedResults.count; i++) {
-        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
-        AssertEqualObjects([result stringForKey: key], [expectedResults objectAtIndex: i]);
+    for (NSUInteger i = 0; i < count; i++) {
+        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, i];
+        AssertEqualObjects(expectedDate, [result dateForKey: propertyKey]);
     }
 }
 
-#pragma mark - MillisToString
-
-- (void) testWrongDataWithMillisToString {
-    // save
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getISO8601DateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    // convert & fetch
-    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    
-    // should be NIL
-    AssertNil([result valueAtIndex: 0]);
-}
-
-- (void) testMillisToString {
-    NSError* error;
-    NSString* key = @"dateString";
-    NSDate* date = [NSDate dateWithTimeIntervalSince1970: 10000.123456];
-    NSTimeInterval dateInMillis = [date timeIntervalSince1970] * 1000;
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setDouble: dateInMillis forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    // convert & fetch
-    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    CBLQueryResultSet* rs = [q execute: &error];
-    Assert(rs, @"Query failed: %@", error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
+/**
+ This method will validate the Query result set with the given timestamp. It will iterate and
+ compare
+ 
+ @param rs The result set
+ timestamp The expected result in milliseconds.
+ prefix The prefix of the property-key.
+ */
+- (void) validateResultSet: (CBLQueryResultSet*)rs
+                withMillis: (double)timestamp
+             propertyCount: (NSUInteger)count
+                    prefix: (NSString*)prefix
+{
+    Assert(rs);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
     AssertNotNil(result);
     
     // validate
-    NSString* dateString = [self getLocalDateString: date format: kMillisToStringFormat];
-    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
+    for (NSUInteger i = 0; i < count; i++) {
+        NSString* propertyKey = [NSString stringWithFormat: @"%@-%lu", prefix, i];
+        AssertEqual(timestamp, [result longLongForKey: propertyKey]);
+    }
 }
 
-#pragma mark - Helper Methods
+#pragma mark Date Conversion methods
 
-- (NSString*) getISO8601DateString: (NSDate*)date {
-    return [self getISO8601DateString: date
-                             timezone: [NSTimeZone localTimeZone]];
+- (NSString*) getISO8601DateStringFromDate: (NSDate*)date {
+    return [self getISO8601DateStringFromDate: date timezone: [NSTimeZone localTimeZone]];
 }
 
-- (NSString*) getISO8601DateString: (NSDate*)date timezone: (NSTimeZone*)tz {
-    return [self getDateString: date
-                        format: kISO8601DateFormat
-                      timezone: tz];
+- (NSString*) getISO8601DateStringFromDate: (NSDate*)date timezone: (NSTimeZone*)tz {
+    return [self getDateStringFromDate: date
+                                format: kISO8601DateFormat
+                              timezone: tz];
 }
 
-- (NSString*) getLocalDateString: (NSDate*)date format: (NSString*)format {
-    return [self getDateString: date
-                        format: format
-                      timezone: [NSTimeZone localTimeZone]];
+- (NSString*) getLocalDateStringFromDate: (NSDate*)date format: (NSString*)format {
+    return [self getDateStringFromDate: date
+                                format: format
+                              timezone: [NSTimeZone localTimeZone]];
 }
 
-- (NSString*) getUTCDateString: (NSDate*)date format: (NSString*)format {
-    return [self getDateString: date
-                        format: format
-                      timezone: [NSTimeZone timeZoneWithName: @"UTC"]];
-}
-
-- (NSString*) getDateString: (NSDate*)date format: (NSString*)format timezone: (NSTimeZone*)tz {
+- (NSString*) getDateStringFromDate: (NSDate*)date
+                             format: (NSString*)format
+                           timezone: (NSTimeZone*)tz
+{
     NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setTimeZone: tz];
     [dateFormatter setDateFormat: format];
@@ -346,24 +548,13 @@
     return [dateFormatter stringFromDate: date];
 }
 
-- (NSArray*) timezones {
-    return  @[ @"BIT", // -12
-               @"AKST", // -9
-               @"CDT", // -6
-               @"IST", // -5:30
-               @"EDT", // -4
-               @"UYT", // -3
-               @"EGT", // -1
-               @"UTC", // +00
-               @"BST", // +1
-               @"CAT", // +2
-               @"MSK", // +3
-               @"MUT", // +4
-               @"MST", // +5
-               @"PST", // +8
-               @"JST", // +9
-               @"ACDT"]; // +10:30
+- (NSDate*) getDateFromString: (NSString*)dateString format: (NSString*)format {
+    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat: format];
+    return [dateFormatter dateFromString: dateString];
 }
+
+#pragma mark - test-constants
 
 - (NSArray*) dateFormats {
     return @[ @"yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ",
@@ -371,6 +562,25 @@
               @"yyyy-MM-dd'T'HH:mm:ss.SZZZZZ",
               @"yyyy-MM-dd'T'HH:mm:ssZZZZZ",
               @"yyyy-MM-dd'T'HH:mmZZZZZ"];
+}
+
+- (NSArray*) timezones {
+    return @[ @"BIT", // -12
+              @"AKST", // -9
+              @"CDT", // -6
+              @"IST", // -5:30
+              @"EDT", // -4
+              @"UYT", // -3
+              @"EGT", // -1
+              @"UTC", // +00
+              @"BST", // +1
+              @"CAT", // +2
+              @"MSK", // +3
+              @"MUT", // +4
+              @"MST", // +5
+              @"PST", // +8
+              @"JST", // +9
+              @"ACDT"]; // +10:30
 }
 
 @end

--- a/Objective-C/Tests/DateTimeQueryFunctionTest.m
+++ b/Objective-C/Tests/DateTimeQueryFunctionTest.m
@@ -1,0 +1,204 @@
+//
+//  DateTimeQueryFunctionTest.m
+//  CouchbaseLite
+//
+//  Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+#import "CBLTestCase.h"
+
+@interface DateTimeQueryFunctionTest : CBLTestCase
+
+@end
+
+@implementation DateTimeQueryFunctionTest
+
+- (NSString*) getISO8601DateString: (NSDate*)date {
+    return [self getISO8601DateString: date
+                             timezone: [NSTimeZone localTimeZone]];
+}
+
+- (NSString*) getISO8601DateString: (NSDate*)date timezone: (NSTimeZone*)tz {
+    return [self getDateString: date
+                        format: @"yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ"
+                      timezone: tz];
+}
+
+- (NSString*) getLocalDateString: (NSDate*)date format: (NSString*)format {
+    return [self getDateString: date
+                        format: format
+                      timezone: [NSTimeZone localTimeZone]];
+}
+
+- (NSString*) getDateString: (NSDate*)date format: (NSString*)format timezone: (NSTimeZone*)tz {
+    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setTimeZone: tz];
+    [dateFormatter setDateFormat: format];
+    return [dateFormatter stringFromDate: date];
+}
+
+- (NSString*) getLongStyleDateString: (NSDate*)date {
+    NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateStyle: NSDateFormatterLongStyle];
+    return [dateFormatter stringFromDate: date];
+}
+
+- (NSArray*) timezones {
+    return  @[ @"BIT", // -12
+               @"AKST", // -9
+               @"CDT", // -6
+               @"IST", // -5:30
+               @"EDT", // -4
+               @"UYT", // -3
+               @"EGT", // -1
+               @"UTC", // +00
+               @"BST", // +1
+               @"CAT", // +2
+               @"MSK", // +3
+               @"MUT", // +4
+               @"MST", // +5
+               @"PST", // +8
+               @"JST", // +9
+               @"ACDT"]; // +10:30
+}
+
+- (NSArray*) dateFormats {
+    return @[ @"yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ",
+              @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+              @"yyyy-MM-dd'T'HH:mm:ss.SZZZZZ",
+              @"yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+              @"yyyy-MM-dd'T'HH:mmZZZZZ"];
+}
+
+- (void) testStringToMillis {
+    NSError* error;
+    NSDate* now = [NSDate date];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getISO8601DateString: now] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
+    AssertEqual([result longLongAtIndex: 0], nowInMillis);
+}
+
+- (void) testWrongDateFormat {
+    NSError* error;
+    NSDate* now = [NSDate date];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getLongStyleDateString: now] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    AssertNil([result valueAtIndex: 0]);
+}
+
+- (void) testStringToMillisWithDifferentTimeZones {
+    NSDate* now = [NSDate date];
+    long double nowInMillis = roundl([now timeIntervalSince1970] * 1000);
+    
+    CBLMutableDocument* doc = [self createDocument];
+    for (NSString* abbr in [self timezones]) {
+        NSString* dateString =
+            [self getISO8601DateString: now timezone: [NSTimeZone timeZoneWithAbbreviation:abbr]];
+        [doc setString: dateString forKey: abbr];
+    }
+    [self saveDocument: doc];
+    
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSString* abbr in [self timezones]) {
+        CBLQueryExpression* expression =
+            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: abbr]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression  as: abbr]];
+    }
+    
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs);
+    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    for (NSString* abbr in [self timezones]) {
+        AssertEqual(nowInMillis, [result longLongForKey: abbr]);
+    }
+}
+
+- (void) testStringToMillisWithDifferentTimeformat {
+    NSDate* now = [NSDate date];
+    
+    CBLMutableDocument* doc = [self createDocument];
+    NSMutableArray* expectedResults = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        NSString* format = [[self dateFormats] objectAtIndex: i];
+        NSString* dateString = [self getLocalDateString: now format: format];
+        
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat: format];
+        NSDate *date = [dateFormatter dateFromString: dateString];
+        [expectedResults addObject: [NSNumber numberWithDouble: [date timeIntervalSince1970]]];
+        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
+    }
+    [self saveDocument: doc];
+    
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        CBLQueryExpression* expression =
+            [CBLQueryFunction stringToMillis: [CBLQueryExpression property: key]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression  as: key]];
+    }
+    
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs);
+    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    for (NSUInteger i = 0; i < expectedResults.count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        double expectedResult = [[expectedResults objectAtIndex: i] doubleValue] * 1000;
+        AssertEqual([result longLongForKey: key], expectedResult);
+    }
+}
+
+
+@end

--- a/Objective-C/Tests/DateTimeQueryFunctionTest.m
+++ b/Objective-C/Tests/DateTimeQueryFunctionTest.m
@@ -204,31 +204,6 @@
 
 #pragma mark - StringToUTC
 
-- (void) testStringToUTC {
-    NSError* error;
-    NSDate* now = [NSDate date];
-    NSString* key = @"dateString";
-    CBLMutableDocument* doc = [self createDocument];
-    [doc setValue: [self getISO8601DateString: now] forKey: key];
-    [self saveDocument: doc];
-    AssertNil(error);
-    
-    CBLQueryExpression* query = [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
-                                     from: [CBLQueryDataSource database: self.db]];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    AssertNil(error);
-    CBLQueryResult* result = [[rs allObjects] firstObject];
-    AssertNotNil(result);
-    NSLog(@"result: %@", [result toDictionary]);
-    
-    NSString* utcString = [self getDateString: now
-                                       format: @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-                                     timezone: [NSTimeZone timeZoneWithName: @"UTC"]];
-    AssertEqualObjects([result stringAtIndex: 0], utcString);
-}
-
 - (void) testWrongDateFormatWithStringToUTC {
     NSError* error;
     NSDate* now = [NSDate date];
@@ -283,6 +258,138 @@
     for (NSString* abbr in [self timezones]) {
         AssertEqualObjects(utcString, [result stringForKey: abbr]);
     }
+}
+
+- (void) testStringToUTCWithDifferentTimeformat {
+    // 1970-01-01T02:46:40.123000Z in UTC
+    NSDate* date = [NSDate dateWithTimeIntervalSince1970: 10000.123456];
+    CBLMutableDocument* doc = [self createDocument];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        NSString* format = [[self dateFormats] objectAtIndex: i];
+        NSString* dateString = [self getLocalDateString: date format: format];
+        [doc setString: dateString forKey: [NSString stringWithFormat: @"%lu", (unsigned long)i]];
+    }
+    [self saveDocument: doc];
+    
+    NSMutableArray* selectQueries = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < [self dateFormats].count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        CBLQueryExpression* expression =
+        [CBLQueryFunction stringToUTC: [CBLQueryExpression property: key]];
+        [selectQueries addObject: [CBLQuerySelectResult expression: expression as: key]];
+    }
+    
+    CBLQuery* q = [CBLQueryBuilder select: selectQueries
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    NSError* error;
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs);
+    AssertNil(error);
+    NSArray* allResults = [rs allObjects];
+    CBLQueryResult* result = [allResults firstObject];
+    AssertNotNil(result);
+    NSArray* expectedResults = [[NSArray alloc] initWithObjects:
+                                @"1970-01-01T02:46:40.123Z",
+                                @"1970-01-01T02:46:40.123Z",
+                                @"1970-01-01T02:46:40.100Z",
+                                @"1970-01-01T02:46:40Z",
+                                @"1970-01-01T02:46:00Z", nil];
+    for (NSUInteger i = 0; i < expectedResults.count; i++) {
+        NSString* key = [NSString stringWithFormat: @"%lu", (unsigned long)i];
+        AssertEqualObjects([result stringForKey: key], [expectedResults objectAtIndex: i]);
+    }
+}
+
+#pragma mark - MillisToString
+
+- (void) testWrongDataWithMillisToString {
+    NSError* error;
+    NSDate* now = [NSDate date];
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setValue: [self getISO8601DateString: now] forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    AssertNil([result valueAtIndex: 0]);
+}
+
+- (void) testMillisToString {
+    NSDate* date = [NSDate dateWithTimeIntervalSince1970: 10000.123456];
+    NSString* dateString = [self getLocalDateString: date format: @"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+    NSTimeInterval dateInMillis = [date timeIntervalSince1970] * 1000;
+    NSError* error;
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setDouble: dateInMillis forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
+}
+
+- (void) testMillisToStringFromNoSeconds {
+    // zero seconds and no fraction, so format will not include the FFF.
+    NSString* format = @"yyyy-MM-dd'T'HH:mm:ssZ";
+    double seconds = 0;
+    NSDate* date = [NSDate dateWithTimeIntervalSince1970: seconds];
+    NSString* dateString = [self getLocalDateString: date format: format];
+    NSError* error;
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setDouble: seconds forKey: key];
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
+}
+
+- (void) testMillisToStringFromFractionOfSeconds {
+    NSString* format = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    double seconds = 0.123;
+    NSDate* date = [NSDate dateWithTimeIntervalSince1970: seconds];
+    NSString* dateString = [self getLocalDateString: date format: format];
+    NSError* error;
+    NSString* key = @"dateString";
+    CBLMutableDocument* doc = [self createDocument];
+    [doc setDouble: seconds * 1000 forKey: key]; // secs to milliseconds
+    [self saveDocument: doc];
+    AssertNil(error);
+    
+    CBLQueryExpression* query = [CBLQueryFunction millisToString: [CBLQueryExpression property: key]];
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: query]]
+                                     from: [CBLQueryDataSource database: self.db]];
+    
+    CBLQueryResultSet* rs = [q execute: &error];
+    Assert(rs, @"Query failed: %@", error);
+    CBLQueryResult* result = [[rs allObjects] firstObject];
+    AssertNotNil(result);
+    AssertEqualObjects(dateString, [result valueAtIndex: 0]);
 }
 
 @end

--- a/Swift/Function.swift
+++ b/Swift/Function.swift
@@ -388,4 +388,71 @@ public final class Function {
         return QueryExpression(CBLQueryFunction.upper(expression.toImpl()))
     }
     
+    
+    /// Creates a STR_TO_MILLIS(expr) function that returns the number of milliseconds since
+    /// the unix epoch of the given ISO 8601 date string expression.
+    ///
+    /// - Parameter expression: The validly formatted ISO 8601 date time string expression.
+    /// - Returns: The STR_TO_MILLIS(expr) function.
+    /// - Note: Valid date strings must start with a date in the form YYYY-MM-DD (time only strings
+    /// are not supported).
+    ///
+    /// Times can be of the form HH:MM, HH:MM:SS, or HH:MM:SS.FFF. Leading zero is not
+    /// optional (i.e. 02 is ok, 2 is not). Hours are in 24-hour format. FFF represents
+    /// milliseconds, and *trailing* zeros are optional (i.e. 5 == 500).
+    ///
+    /// Time zones can be in one of three forms:
+    /// (+/-)HH:MM
+    /// (+/-)HHMM
+    /// Z (which represents UTC)
+    ///
+    /// No time zone present will default to the device local time zone.
+    public static func string(toMillis expression: ExpressionProtocol) -> ExpressionProtocol {
+        return QueryExpression(CBLQueryFunction.string(toMillis: expression.toImpl()))
+    }
+    
+    
+    /// Creates a STR_TO_UTC(expr) function that returns the ISO 8601 UTC datetime string
+    /// of the given ISO 8601 date string expression.
+    ///
+    /// - Parameter expression: The validly formatted ISO 8601 date time string expression.
+    /// - Returns: The STR_TO_UTC(expr) function.
+    /// - Note: Valid date strings must start with a date in the form YYYY-MM-DD (time only strings
+    /// are not supported).
+    ///
+    /// Times can be of the form HH:MM, HH:MM:SS, or HH:MM:SS.FFF. Leading zero is not
+    /// optional (i.e. 02 is ok, 2 is not). Hours are in 24-hour format. FFF represents
+    /// milliseconds, and *trailing* zeros are optional (i.e. 5 == 500).
+    ///
+    /// Time zones can be in one of three forms:
+    /// (+/-)HH:MM
+    /// (+/-)HHMM
+    /// Z (which represents UTC)
+    ///
+    /// No time zone present will default to the device local time zone.
+    public static func string(toUTC expression: ExpressionProtocol) -> ExpressionProtocol {
+        return QueryExpression(CBLQueryFunction.string(toUTC: expression.toImpl()))
+    }
+    
+    
+    /// Creates a MILLIS_TO_STR(expr) function that returns a ISO 8601 date time string in device
+    /// local timezone of the given number of milliseconds since the unix epoch expression.
+    ///
+    /// - Parameter expression: The numeric value representing milliseconds since the unix epoch.
+    /// - Returns: The MILLIS_TO_STR(expr) function.
+    /// - Note: If the input expression is not numeric, then the result will be null.
+    public static func millis(toString expression: ExpressionProtocol) -> ExpressionProtocol {
+        return QueryExpression(CBLQueryFunction.millis(toString: expression.toImpl()))
+    }
+    
+    
+    /// Creates a MILLIS_TO_UTC(expr) function that returns the UTC ISO 8601 date time string
+    /// of the given number of milliseconds since the unix epoch expression.
+    ///
+    /// - Parameter expression: The numeric value representing milliseconds since the unix epoch.
+    /// - Returns: The MILLIS_TO_UTC(expr) function.
+    /// - Note: If the input expression is not numeric, then the result will be null.
+    public static func millis(toUTC expression: ExpressionProtocol) -> ExpressionProtocol {
+        return QueryExpression(CBLQueryFunction.millis(toUTC: expression.toImpl()))
+    }
 }

--- a/Swift/Tests/DateTimeQueryFunctionTest.swift
+++ b/Swift/Tests/DateTimeQueryFunctionTest.swift
@@ -1,0 +1,166 @@
+//
+//  DateTimeQueryFunctionTest.swift
+//  CBL Swift
+//
+//  Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import CouchbaseLiteSwift
+
+class DateTimeQueryFunctionTest: CBLTestCase {
+    func testStringToMillis() throws {
+        try validateStringToMillis("", millis: 0.0)
+        try validateStringToMillis("2018-12-32T01:01:01Z", millis: 0.0)
+        try validateStringToMillis("1970-01-01T00:00:00Z", millis: 0.0)
+        try validateStringToMillis("1970-01-01T00:00:00.123+0000", millis: 123)
+        try validateStringToMillis("2018-10-23T11:33:01-0700", millis: 1540319581000)
+        try validateStringToMillis("2018-10-23T18:33:01Z", millis: 1540319581000)
+        try validateStringToMillis("2018-10-23T18:33:01.123Z", millis: 1540319581123)
+        try validateStringToMillis("2020-02-29T23:59:59.000000+0000", millis: 1583020799000)
+    }
+    
+    func testStringToUTC() throws {
+        try validateStringToUTC("", utcString: nil)
+        try validateStringToUTC("x", utcString: nil)
+        
+        try validateStringToUTC("2018-10-23T18:33:01Z",
+                                utcString: "2018-10-23T18:33:01Z")
+        try validateStringToUTC("2018-10-23T11:33:01-0700",
+                                utcString: "2018-10-23T18:33:01Z")
+        try validateStringToUTC("2018-10-23T11:33:01+03:30",
+                                utcString: "2018-10-23T08:03:01Z")
+        try validateStringToUTC("2018-10-23T18:33:01.123Z",
+                                utcString: "2018-10-23T18:33:01.123Z")
+        try validateStringToUTC("2018-10-23T11:33:01.123-0700",
+                                utcString: "2018-10-23T18:33:01.123Z")
+        try validateStringToUTC("1970-01-01T00:00:00.000000+0000",
+                                utcString: "1970-01-01T00:00:00Z")
+    }
+    
+    func testMillisToString() throws {
+        let mSec = 1000.0
+        var seconds = 0.0
+        try validateMillisToString(seconds * mSec, date: Date(timeIntervalSince1970: seconds))
+        
+        seconds = 0.123
+        try validateMillisToString(seconds * mSec, date: Date(timeIntervalSince1970: seconds))
+        
+        seconds = 1000.123
+        try validateMillisToString(seconds * mSec, date: Date(timeIntervalSince1970: seconds))
+        
+        seconds = 65789245.123;
+        try validateMillisToString(seconds * mSec, date: Date(timeIntervalSince1970: seconds))
+    }
+    
+    func testMillisToUTC() throws {
+        try validateMillisToUTC(0.0, utcString: "1970-01-01T00:00:00Z")
+        try validateMillisToUTC(1540319581000.0, utcString: "2018-10-23T18:33:01Z")
+        try validateMillisToUTC(1540319581123.0, utcString: "2018-10-23T18:33:01.123Z")
+        try validateMillisToUTC(1540319581999.0, utcString: "2018-10-23T18:33:01.999Z")
+    }
+    
+    // MARK: Helper methods
+    
+    func validateStringToMillis(_ input: String?, millis: Double) throws {
+        let key = "dateString"
+        let doc = createDocument().setString(input, forKey: key)
+        try saveDocument(doc)
+        
+        let select = SelectResult.expression(Function.string(toMillis: Expression.property(key)))
+        let q = QueryBuilder
+            .select([select])
+            .from(DataSource.database(db))
+        let rs = try q.execute()
+        let allResults = rs.allResults()
+        XCTAssertEqual(allResults.count, 1)
+        
+        guard let result = allResults.first else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(result.double(at: 0) , millis)
+        
+        try db.purgeDocument(doc)
+    }
+    
+    func validateStringToUTC(_ input: String?, utcString: String?) throws {
+        let key = "dateString"
+        let doc = createDocument().setString(input, forKey: key)
+        try saveDocument(doc)
+        
+        let select = SelectResult.expression(Function.string(toUTC: Expression.property(key)))
+        let q = QueryBuilder
+            .select([select])
+            .from(DataSource.database(db))
+        let rs = try q.execute()
+        let allResults = rs.allResults()
+        XCTAssertEqual(allResults.count, 1)
+        
+        guard let result = allResults.first else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(result.string(at: 0) , utcString)
+        
+        try db.purgeDocument(doc)
+    }
+    
+    func validateMillisToString(_ input: Double, date: Date) throws {
+        let key = "dateString"
+        let doc = createDocument().setDouble(input, forKey: key)
+        try saveDocument(doc)
+        
+        let select = SelectResult.expression(Function.millis(toString: Expression.property(key)))
+        let q = QueryBuilder
+            .select([select])
+            .from(DataSource.database(db))
+        let rs = try q.execute()
+        let allResults = rs.allResults()
+        XCTAssertEqual(allResults.count, 1)
+        
+        guard let result = allResults.first else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(result.date(at: 0) , date)
+        
+        try db.purgeDocument(doc)
+    }
+    
+    func validateMillisToUTC(_ input: Double, utcString: String?) throws {
+        let key = "dateString"
+        let doc = createDocument().setDouble(input, forKey: key)
+        try saveDocument(doc)
+        
+        let select = SelectResult.expression(Function.millis(toUTC: Expression.property(key)))
+        let q = QueryBuilder
+            .select([select])
+            .from(DataSource.database(db))
+        let rs = try q.execute()
+        let allResults = rs.allResults()
+        XCTAssertEqual(allResults.count, 1)
+        
+        guard let result = allResults.first else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(result.string(at: 0) , utcString)
+        
+        try db.purgeDocument(doc)
+    }
+}


### PR DESCRIPTION
* add ObjC and Swift implementations to create query functions for str_to_millis, str_to_utc, millis_to_str, and millis_to_utc.
* made consistent notes with dotnet.
* Add StringToMillis & StringToUTC Unit Tests for different timezone, different date formats for ObjC.
* helper methods kept in the bottom.
* kept the basic date formatter as macros.

fix: #2242