### PR TITLE
fix: Remove Count from Tests

### DIFF
--- a/Objective-C/Tests/DocumentExpirationTest.m
+++ b/Objective-C/Tests/DocumentExpirationTest.m
@@ -77,11 +77,9 @@
     AssertNil([self.db getDocumentExpirationWithID: doc.id]);
     
     // Setup document change notification
-    __block int count = 0;
     id token = [self.db addDocumentChangeListenerWithID: doc.id
                                                listener: ^(CBLDocumentChange *change)
     {
-        count += 1;
         AssertEqualObjects(change.documentID, doc.id);
         if ([change.database documentWithID: change.documentID] == nil) {
             [expectation fulfill];
@@ -97,7 +95,6 @@
     
     // Wait for result
     [self waitForExpectationsWithTimeout: 5.0 handler: nil];
-    AssertEqual(count, 1);
     
     // Remove listener
     [self.db removeChangeListenerWithToken: token];
@@ -112,11 +109,9 @@
     
     // Setup document change notification
     __weak DocumentExpirationTest* weakSelf = self;
-    __block int count = 0;
     id token = [self.db addDocumentChangeListenerWithID: doc.id
                                                listener: ^(CBLDocumentChange *change)
     {
-        count += 1;
         DocumentExpirationTest* strongSelf = weakSelf;
         AssertEqualObjects(change.documentID, doc.id);
         if ([change.database documentWithID: change.documentID] == nil) {
@@ -133,7 +128,6 @@
     
     // Wait for result
     [self waitForExpectationsWithTimeout: 5.0 handler: nil];
-    AssertEqual(count, 1);
     
     // Remove listener
     [self.db removeChangeListenerWithToken: token];
@@ -164,12 +158,10 @@
     CBLDocument* doc = [self generateDocumentWithID: nil];
     AssertNil([self.db getDocumentExpirationWithID: doc.id]);
     
-    __block int count = 0;
     __block NSTimeInterval purgeTime;
     id token = [self.db addDocumentChangeListenerWithID: doc.id
                                                listener: ^(CBLDocumentChange *change)
     {
-        count += 1;
         AssertEqualObjects(change.documentID, doc.id);
         if ([change.database documentWithID: change.documentID] == nil) {
             purgeTime = [[NSDate date] timeIntervalSince1970];
@@ -189,7 +181,6 @@
     
     // Validate
     Assert(purgeTime - begin >= 2.0);
-    AssertEqual(count, 1);
     
     // Remove listener
     [self.db removeChangeListenerWithToken: token];
@@ -239,11 +230,9 @@
     [self reopenDB];
     
     // Setup document change notification
-    __block int count = 0;
     id token = [self.db addDocumentChangeListenerWithID: doc.id
                                                listener: ^(CBLDocumentChange *change)
     {
-        count += 1;
         AssertEqualObjects(change.documentID, doc.id);
         if ([change.database documentWithID: change.documentID] == nil) {
             [expectation fulfill];
@@ -254,7 +243,6 @@
     
     // Wait for result
     [self waitForExpectationsWithTimeout: 5 handler: nil];
-    AssertEqual(count, 1);
     
     // Remove listener
     [self.db removeChangeListenerWithToken: token];
@@ -272,12 +260,10 @@
     Assert(otherDB != self.db);
     
     // Setup document change notification on otherDB
-    __block int count = 0;
     __weak CBLDatabase *weakOtherDB = otherDB;
     id token = [otherDB addDocumentChangeListenerWithID: doc.id
                                                listener: ^(CBLDocumentChange *change)
     {
-        count += 1;
         AssertEqualObjects(change.documentID, doc.id);
         if ([weakOtherDB documentWithID: change.documentID] == nil) {
             [expectation fulfill];
@@ -294,7 +280,6 @@
     
     // Wait for result
     [self waitForExpectationsWithTimeout: 5 handler: nil];
-    AssertEqual(count, 1);
     
     AssertNil([self.db documentWithID: doc.id]);
     AssertNil([otherDB documentWithID: doc.id]);
@@ -314,12 +299,10 @@
     AssertNil([self.db getDocumentExpirationWithID: doc.id]);
     
     // Setup document change notification
-    __block int count = 0;
     __block NSTimeInterval purgeTime;
     id token = [self.db addDocumentChangeListenerWithID: doc.id
                                                listener: ^(CBLDocumentChange *change)
     {
-        count += 1;
         AssertEqualObjects(change.documentID, doc.id);
         if ([change.database documentWithID: change.documentID] == nil) {
             purgeTime = [[NSDate date] timeIntervalSince1970];
@@ -341,7 +324,6 @@
     
     // Wait for result
     [self waitForExpectationsWithTimeout: 5.0 handler: nil];
-    AssertEqual(count, 1);
     
     // Validate
     Assert(purgeTime - begin >= 2.0);
@@ -358,10 +340,8 @@
     AssertNil([self.db getDocumentExpirationWithID: doc.id]);
     
     // Setup document change notification
-    __block int count = 0;
     __block NSTimeInterval purgeTime;
     id token = [self.db addDocumentChangeListenerWithID: doc.id listener: ^(CBLDocumentChange *change) {
-        count += 1;
         AssertEqualObjects(change.documentID, doc.id);
         if ([change.database documentWithID: change.documentID] == nil) {
             [expectation fulfill];
@@ -383,7 +363,6 @@
     
     // Wait for result
     [self waitForExpectationsWithTimeout: 5.0 handler: nil];
-    AssertEqual(count, 1);
     
     // Validate
     Assert(purgeTime - begin < 3.0);
@@ -518,12 +497,10 @@
     AssertNil([self.db getDocumentExpirationWithID: doc.id]);
     
     // Setup document change notification
-    __block int count = 0;
     __block NSDate* purgeTime;
     id token = [self.db addDocumentChangeListenerWithID: doc.id
                                                listener: ^(CBLDocumentChange *change)
     {
-        count += 1;
         AssertEqualObjects(change.documentID, doc.id);
         if ([change.database documentWithID: change.documentID] == nil) {
             purgeTime = [NSDate date];
@@ -539,7 +516,6 @@
     
     // Wait for result
     [self waitForExpectationsWithTimeout: 5.0 handler: nil];
-    AssertEqual(count, 1);
     
     /*
      Validate. Delay inside the KeyStore::now() is in seconds, without milliseconds part.

--- a/Swift/Tests/DocumentExpirationTest.swift
+++ b/Swift/Tests/DocumentExpirationTest.swift
@@ -60,9 +60,7 @@ class DocumentExpirationTest: CBLTestCase {
         let doc = try generateDocument(withID: nil)
         
         // Setup document change notification
-        var count = 0
         let token = db.addDocumentChangeListener(withID: doc.id) { (change) in
-            count += 1
             XCTAssertEqual(doc.id, change.documentID)
             if change.database.document(withID: doc.id) == nil {
                 promise.fulfill()
@@ -75,7 +73,6 @@ class DocumentExpirationTest: CBLTestCase {
         
         // Wait for result
         waitForExpectations(timeout: 5.0)
-        XCTAssertEqual(count, 1)
         
         // Remove listener
         db.removeChangeListener(withToken: token);
@@ -88,9 +85,7 @@ class DocumentExpirationTest: CBLTestCase {
         let doc = try generateDocument(withID: nil)
         
         // Setup document change notification
-        var count = 0
         let token = db.addDocumentChangeListener(withID: doc.id) { [unowned self] (change) in
-            count += 1
             XCTAssertEqual(doc.id, change.documentID)
             if change.database.document(withID: doc.id) == nil {
                 try! self.verifyQueryResultCount(0, deletedDocs: 0)
@@ -104,7 +99,6 @@ class DocumentExpirationTest: CBLTestCase {
         
         // Wait for result
         waitForExpectations(timeout: 5.0)
-        XCTAssertEqual(count, 1)
         
         // Remove listener
         db.removeChangeListener(withToken: token);
@@ -131,10 +125,8 @@ class DocumentExpirationTest: CBLTestCase {
         let doc = try generateDocument(withID: nil)
         
         // Setup document change notification
-        var count = 0
         var purgeTime: TimeInterval = 0.0
         let token = db.addDocumentChangeListener(withID: doc.id) { (change) in
-            count += 1
             XCTAssertEqual(doc.id, change.documentID)
             if change.database.document(withID: doc.id) == nil {
                 purgeTime = Date().timeIntervalSince1970
@@ -152,7 +144,6 @@ class DocumentExpirationTest: CBLTestCase {
         
         // Validate
         XCTAssert(purgeTime - begin >= 2.0)
-        XCTAssertEqual(count, 1)
         
         // Remove listener
         db.removeChangeListener(withToken: token);
@@ -195,9 +186,7 @@ class DocumentExpirationTest: CBLTestCase {
         try self.reopenDB()
         
         // Setup document change notification
-        var count = 0
         let token = db.addDocumentChangeListener(withID: doc.id) { (change) in
-            count += 1
             XCTAssertEqual(doc.id, change.documentID)
             if change.database.document(withID: doc.id) == nil {
                 promise.fulfill()
@@ -208,7 +197,6 @@ class DocumentExpirationTest: CBLTestCase {
         
         // Wait for result
         waitForExpectations(timeout: 5.0)
-        XCTAssertEqual(count, 1)
         
         // Remove listener
         db.removeChangeListener(withToken: token);
@@ -224,9 +212,7 @@ class DocumentExpirationTest: CBLTestCase {
         let otherDB = try self.openDB(name: db.name)
         
         // Setup document change notification on otherDB
-        var count = 0
         let token = otherDB.addDocumentChangeListener(withID: doc.id) { (change) in
-            count += 1
             XCTAssertEqual(doc.id, change.documentID)
             if otherDB.document(withID: doc.id) == nil {
                 promise.fulfill()
@@ -242,7 +228,6 @@ class DocumentExpirationTest: CBLTestCase {
         
         // Wait for result
         waitForExpectations(timeout: 5.0)
-        XCTAssertEqual(count, 1)
         
         XCTAssertNil(self.db.document(withID: doc.id))
         XCTAssertNil(otherDB.document(withID: doc.id))
@@ -261,10 +246,8 @@ class DocumentExpirationTest: CBLTestCase {
         let doc = try generateDocument(withID: nil)
         
         // Setup document change notification
-        var count = 0
         var purgeTime: TimeInterval = 0.0
         let token = db.addDocumentChangeListener(withID: doc.id) { (change) in
-            count += 1
             XCTAssertEqual(doc.id, change.documentID)
             if change.database.document(withID: doc.id) == nil {
                 purgeTime = Date().timeIntervalSince1970
@@ -282,7 +265,6 @@ class DocumentExpirationTest: CBLTestCase {
         
         // Wait for result
         waitForExpectations(timeout: 5.0)
-        XCTAssertEqual(count, 1)
         
         // Validate
         XCTAssert(purgeTime - begin >= 2.0)
@@ -298,10 +280,8 @@ class DocumentExpirationTest: CBLTestCase {
         let doc = try generateDocument(withID: nil)
         
         // Setup document change notification
-        var count = 0
         var purgeTime: TimeInterval = 0.0
         let token = db.addDocumentChangeListener(withID: doc.id) { (change) in
-            count += 1
             XCTAssertEqual(doc.id, change.documentID)
             if change.database.document(withID: doc.id) == nil {
                 purgeTime = Date().timeIntervalSince1970
@@ -319,7 +299,6 @@ class DocumentExpirationTest: CBLTestCase {
         
         // Wait for result
         waitForExpectations(timeout: 5.0)
-        XCTAssertEqual(count, 1)
         
         // Validate
         XCTAssert(purgeTime - begin < 3.0)


### PR DESCRIPTION
* removed the count variable put in to test whether the document listener is fired more than once.
* as the test cases are now working fine, make sure whether the count has any impact on the tests.