### PR TITLE
Fix: PurgeExpiredDocs from Serial Queue

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1040,7 +1040,7 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
 
 
 - (void) purgeExpiredDocuments {
-    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(_dispatchQueue, ^{
         CBL_LOCK(self) {
             if (!_c4db)
                 return;

--- a/Swift/Tests/DocumentExpirationTest.swift
+++ b/Swift/Tests/DocumentExpirationTest.swift
@@ -442,4 +442,30 @@ class DocumentExpirationTest: CBLTestCase {
         // Remove listener
         db.removeChangeListener(withToken: token);
     }
+    
+    func testWhetherDatabaseEventTrigged() throws {
+        let promise = expectation(description: "document expiry expectation")
+        
+        // Create doc
+        let doc = try generateDocument(withID: nil)
+        
+        // Setup document change notification
+        let token = db.addChangeListener { (change) in
+            XCTAssertEqual(change.documentIDs.count, 1)
+            let docID = change.documentIDs.first
+            XCTAssertNotNil(docID)
+            XCTAssertEqual(doc.id, docID)
+            if change.database.document(withID: doc.id) == nil {
+                promise.fulfill()
+            }
+        }
+        
+        try db.setDocumentExpiration(withID: doc.id, expiration: Date(timeIntervalSinceNow: 1))
+        
+        // Wait for result
+        waitForExpectations(timeout: 5.0)
+        
+        // Remove listener
+        db.removeChangeListener(withToken: token);
+    }
 }


### PR DESCRIPTION
* purging of docs are done from the serial queue instead of the global background queue.
* test cases to check for the db.change event is added. 

link: #2266