### PR TITLE
fix: Make default file logging binary

### DIFF
--- a/Objective-C/CBLFileLogger.mm
+++ b/Objective-C/CBLFileLogger.mm
@@ -36,7 +36,7 @@
     if (self) {
         _level = kCBLLogLevelInfo;
         _directory = [self defaultDirectory];
-        _usePlainText = YES;
+        _usePlainText = FALSE;
         _maxSize = kCBLFileLoggerDefaultMaxSize;
         _maxRotateCount = 1;
         [self apply];

--- a/Objective-C/CBLFileLogger.mm
+++ b/Objective-C/CBLFileLogger.mm
@@ -36,7 +36,7 @@
     if (self) {
         _level = kCBLLogLevelInfo;
         _directory = [self defaultDirectory];
-        _usePlainText = FALSE;
+        _usePlainText = NO;
         _maxSize = kCBLFileLoggerDefaultMaxSize;
         _maxRotateCount = 1;
         [self apply];


### PR DESCRIPTION
* made the default logging as binary in ObjectiveC
* swift is already in binary format.