### PR TITLE
Fixed #2306 default log directory

### DIFF
--- a/Objective-C/CBLFileLogger.mm
+++ b/Objective-C/CBLFileLogger.mm
@@ -47,15 +47,19 @@
 
 
 - (NSString*) defaultDirectory {
-    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString* path = paths[0];
 #if !TARGET_OS_IPHONE
     NSString* bundleID = [[NSBundle mainBundle] bundleIdentifier];
-    if (!bundleID)
-        return [NSFileManager.defaultManager currentDirectoryPath]; // last-ditch default for non-apps
-    path = [path stringByAppendingPathComponent: bundleID];
+    if (bundleID) {
+        NSArray* paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+        return [paths[0] stringByAppendingPathComponent:
+                [bundleID stringByAppendingPathComponent: @"/CouchbaseLite"]];
+    } else
+        return [[NSFileManager.defaultManager currentDirectoryPath]
+                stringByAppendingPathComponent: @"/CouchbaseLite/Logs"];
+#else
+    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    return [paths[0] stringByAppendingPathComponent: @"/CouchbaseLite/Logs"];
 #endif
-    return [path stringByAppendingPathComponent: @"CouchbaseLite/Logs"];
 }
 
 

--- a/Objective-C/CBLFileLogger.mm
+++ b/Objective-C/CBLFileLogger.mm
@@ -52,13 +52,13 @@
     if (bundleID) {
         NSArray* paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
         return [paths[0] stringByAppendingPathComponent:
-                [bundleID stringByAppendingPathComponent: @"/CouchbaseLite"]];
+                [NSString stringWithFormat: @"Logs/%@/CouchbaseLite", bundleID]];
     } else
         return [[NSFileManager.defaultManager currentDirectoryPath]
-                stringByAppendingPathComponent: @"/CouchbaseLite/Logs"];
+                stringByAppendingPathComponent: @"CouchbaseLite/Logs"];
 #else
     NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    return [paths[0] stringByAppendingPathComponent: @"/CouchbaseLite/Logs"];
+    return [paths[0] stringByAppendingPathComponent: @"CouchbaseLite/Logs"];
 #endif
 }
 


### PR DESCRIPTION
Fixed the default log directory to the followings:

iOS : <NSCachesDirectory>/CouchbaseLite/Logs
Mac: ~/Library/Logs/<BundleID>/CouchbaseLite

#2306