### PR TITLE
Exclude default log directory from backup for iOS

### DIFF
--- a/Objective-C/Tests/LogTest.m
+++ b/Objective-C/Tests/LogTest.m
@@ -79,7 +79,7 @@
                              properties: (nullable NSArray<NSURLResourceKey>*)keys
                            onlyInfoLogs: (BOOL)onlyInfo {
     directory = directory ? directory : CBLDatabase.log.file.directory;
-    NSURL* path = [NSURL URLWithString: directory];
+    NSURL* path = [NSURL fileURLWithPath: directory];
     AssertNotNil(path);
     
     NSError* error;

--- a/Swift/Tests/LogTest.swift
+++ b/Swift/Tests/LogTest.swift
@@ -49,10 +49,7 @@ class LogTest: CBLTestCase {
     func getLogsInDirectory(_ directory: String = Database.log.file.directory,
                             properties: [URLResourceKey] = [],
                             onlyInfoLogs: Bool = false) throws -> [URL] {
-        guard let url = URL(string: directory) else {
-            fatalError("valid directory should be provided")
-        }
-        
+        let url = URL(fileURLWithPath: directory)
         let files = try FileManager.default.contentsOfDirectory(at: url,
                                                                 includingPropertiesForKeys: properties,
                                                                 options: .skipsSubdirectoryDescendants)


### PR DESCRIPTION
* Changed the default log directory for iOS to inside the App Support directory.
* Set the default log directory to exclude from backup.
* Fixed file URL in LogTest.getLogsInDirectory().