### PR TITLE
doc: update with custom instance set info

### DIFF
--- a/Objective-C/CBLLog.h
+++ b/Objective-C/CBLLog.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** File logger writing log messages to files. */
 @property (readonly, nonatomic) CBLFileLogger* file;
 
-/** For setting a custom logger. */
+/** For setting a custom logger. Set log level for custom instance, before setting this property. */
 @property (nonatomic, nullable) id<CBLLogger> custom;
 
 /** Not available */

--- a/Objective-C/CBLLog.h
+++ b/Objective-C/CBLLog.h
@@ -35,7 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** File logger writing log messages to files. */
 @property (readonly, nonatomic) CBLFileLogger* file;
 
-/** For setting a custom logger. Set log level for custom instance, before setting this property. */
+/** For setting a custom logger. Changing the log level of the assigned custom logger will require
+ the custom logger to be reassigned so that the change can be affected. */
 @property (nonatomic, nullable) id<CBLLogger> custom;
 
 /** Not available */

--- a/Swift/Log.swift
+++ b/Swift/Log.swift
@@ -28,7 +28,8 @@ public class Log {
     /// File logger writing log messages to files.
     public let file = FileLogger()
     
-    /// For setting a custom logger.
+    /// For setting a custom logger. Changing the log level of the assigned custom logger will
+    /// require the custom logger to be reassigned so that the change can be affected.
     public var custom: Logger? {
         didSet {
             if let logger = custom {


### PR DESCRIPTION
* when changing a log level of the custom instance, it should be done before setting the custom instance. 
- as the synchronize call will happen only on setCustom method.