### PR TITLE
fix: issue with filename in seconds

### DIFF
--- a/Objective-C/Tests/LogTest.m
+++ b/Objective-C/Tests/LogTest.m
@@ -110,7 +110,6 @@
         CBLWarnError(Database, @"%@", inputString);
     }
     [self writeAllLogs: @"-"]; // 25B : total ~1037Bytes
-    [NSThread sleepForTimeInterval: 1.0];
 }
 
 
@@ -306,22 +305,22 @@
 }
 
 
-- (void) _testFileLoggingMaxSize {
+- (void) testFileLoggingMaxSize {
     CBLLogFileConfiguration* config = [self logFileConfig];
     config.usePlainText = YES;
     config.maxSize = 1024;
     CBLDatabase.log.file.config = config;
-    CBLDatabase.log.file.level = kCBLLogLevelVerbose;
+    CBLDatabase.log.file.level = kCBLLogLevelDebug;
     
     // this should create two files, as the 1KB + extra ~400-500Bytes.
     [self writeOneKiloByteOfLog];
     
-    NSUInteger totalFilesInDirectory = (CBLDatabase.log.file.config.maxRotateCount + 1) * 5;
+    NSUInteger totalFilesShouldBeInDirectory = (CBLDatabase.log.file.config.maxRotateCount + 1) * 5;
 #if !DEBUG
-    totalFilesInDirectory = totalFilesInDirectory - 1;
+    totalFilesShouldBeInDirectory = totalFilesShouldBeInDirectory - 1;
 #endif
     NSArray* files = [self getLogsInDirectory: config.directory properties: nil onlyInfoLogs: NO];
-    AssertEqual(files.count, totalFilesInDirectory);
+    AssertEqual(files.count, totalFilesShouldBeInDirectory);
 }
 
 

--- a/Swift/Tests/LogTest.swift
+++ b/Swift/Tests/LogTest.swift
@@ -255,7 +255,7 @@ class LogTest: CBLTestCase {
         XCTAssertEqual(customLogger.lines.count, 4)
     }
     
-    func _testFileLoggingMaxSize() throws {
+    func testFileLoggingMaxSize() throws {
         let config = self.logFileConfig()
         config.usePlainText = true
         config.maxSize = 1024
@@ -268,14 +268,14 @@ class LogTest: CBLTestCase {
         guard let maxRotateCount = Database.log.file.config?.maxRotateCount else {
             fatalError("Config should be present!!")
         }
-        var totalFilesInDirectory = (maxRotateCount + 1) * 5
+        var totalFilesShouldBeInDirectory = (maxRotateCount + 1) * 5
         
         #if !DEBUG
-        totalFilesInDirectory = totalFilesInDirectory - 1
+        totalFilesShouldBeInDirectory = totalFilesShouldBeInDirectory - 1
         #endif
         
         let totalLogFilesSaved = try getLogsInDirectory(config.directory)
-        XCTAssertEqual(totalLogFilesSaved.count, totalFilesInDirectory)
+        XCTAssertEqual(totalLogFilesSaved.count, totalFilesShouldBeInDirectory)
     }
     
     func testFileLoggingDisableLogging() throws {


### PR DESCRIPTION
* fixed the issue with filename in seconds instead of milliseconds
* enabled both swift and objc

fix: #2302