### PR TITLE
fix: replicator flag setting corrected

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -599,7 +599,7 @@ static bool pullFilter(C4String docID, C4RevisionFlags flags, FLDict flbody, voi
         docFlags |= kCBLDocumentFlagsDeleted;
     
     if ((flags & kRevPurged) == kRevPurged)
-        docFlags |= kRevPurged;
+        docFlags |= kCBLDocumentFlagsAccessRemoved;
     
     return pushing ? _config.pushFilter(doc, docFlags) : _config.pullFilter(doc, docFlags);
 }

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -1859,12 +1859,12 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady
 #pragma mark Removed Doc with Filter
 
 
-- (void) _testPullRemovedDocWithFilterSingleShot {
+- (void) testPullRemovedDocWithFilterSingleShot {
     [self testPullRemovedDocWithFilter: NO];
 }
 
 
-- (void) _testPullRemovedDocWithFilterContinuous {
+- (void) testPullRemovedDocWithFilterContinuous {
     [self testPullRemovedDocWithFilter: YES];
 }
 


### PR DESCRIPTION
* replicator flag was setting to LiteCore flag value.
* enabled the objc test for Pull only. 
* objc push is also failing, which is still investigating. 
* swift is still failing with push and pul, which is also still investigating. 

link: #2303