### PR TITLE
Fix Blob metadata not preserved in predictive query parameters

### DIFF
--- a/Objective-C/CBLBlob.mm
+++ b/Objective-C/CBLBlob.mm
@@ -46,7 +46,6 @@ static NSString* const kDataMetaProperty = @kC4BlobDataProperty;
 static NSString* const kBlobType = @kC4ObjectType_Blob;
 
 
-
 @implementation CBLBlob
 {
     CBLDatabase *_db;                       // nil if blob is new and unsaved

--- a/Objective-C/CBLQueryParameters.mm
+++ b/Objective-C/CBLQueryParameters.mm
@@ -113,7 +113,7 @@ using namespace fleece;
 
 
 - (void) setBlob: (nullable CBLBlob*)value forName:(NSString *)name {
-    [self setValue: value.content forName: name];
+    [self setValue: value forName: name];
 }
 
 

--- a/Objective-C/Internal/CBLData.h
+++ b/Objective-C/Internal/CBLData.h
@@ -56,6 +56,7 @@ namespace cbl {
     NSNumber* asNumber  (__nullable id);
     NSString* asString  (__nullable id);
     NSDate*   asDate    (__nullable id);
+    NSData*   asData    (__nullable id);
 }
 #endif
 

--- a/Objective-C/Internal/CBLData.mm
+++ b/Objective-C/Internal/CBLData.mm
@@ -108,4 +108,5 @@ namespace cbl {
     NSNumber* asNumber  (id object)    {return $castIf(NSNumber, object);}
     NSString* asString  (id object)    {return $castIf(NSString, object);}
     NSDate*   asDate    (id object)    {return [CBLJSON dateWithJSONObject: object];}
+    NSData*   asData    (id object)    {return $castIf(NSData, object);}
 }

--- a/Objective-C/Tests/PredictiveQueryTest.m
+++ b/Objective-C/Tests/PredictiveQueryTest.m
@@ -1090,6 +1090,11 @@
     if (!blob)
         return nil;
     
+    if (![blob.contentType isEqualToString: @"text/plain"]) {
+        NSLog(@"WARN: Invalid blob content type; not text/plain.");
+        return nil;
+    }
+    
     NSString* text = [[NSString alloc] initWithData: blob.content
                                            encoding: NSUTF8StringEncoding];
     

--- a/Swift/Parameters.swift
+++ b/Swift/Parameters.swift
@@ -62,7 +62,7 @@ public class Parameters {
     ///   - name: The parameter name.
     /// - Returns: The self object.
     @discardableResult public func setBlob(_ value: Blob, forName name: String) -> Parameters {
-        return setValue(value.content, forName: name)
+        return setValue(value, forName: name)
     }
     
     /// Set a boolean value to the query parameter referenced by the given name. A query parameter

--- a/Swift/Tests/PredictiveQueryTest.swift
+++ b/Swift/Tests/PredictiveQueryTest.swift
@@ -1044,6 +1044,11 @@ class TextModel: TestPredictiveModel {
             return nil
         }
         
+        guard let contentType = blob.contentType, contentType == "text/plain" else {
+            NSLog("WARN: Invalid blob content type; not text/plain.")
+            return nil
+        }
+        
         let text =  String(bytes: blob.content!, encoding: .utf8)! as NSString
         
         var wc = 0


### PR DESCRIPTION
* Encoded blob in parameters as blob properties + content instead of content only.

* Updated TextModel in unit tests to check the content type of blob.

#2320