### PR TITLE
Remove in-transaction check in postDatabaseChanged

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -745,7 +745,7 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
 
 - (void) postDatabaseChanged {
     CBL_LOCK(self) {
-        if (!_dbObs || !_c4db || c4db_isInTransaction(_c4db))
+        if (!_dbObs || !_c4db)
             return;
         
         const uint32_t kMaxChanges = 100u;


### PR DESCRIPTION
We don’t need to check if the database is in transaction before posting the notification as LiteCore will post the change after the transaction is done.

#2291