### PR TITLE
ci: reformat the output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ env:
 before_install:
   - brew update
   - brew install doxygen
-  - gem install xcpretty-travis-formatter
-script: xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=macOS" | xcpretty -f `xcpretty-travis-formatter`
+script: xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=macOS" | xcpretty -c


### PR DESCRIPTION
* code folding removed, as that doesn't give advantages. and needs to unfold for every build, analyze.
* if all build, analyse is grouped to form one build and one analyze, this was helpful. but in our case, this is not helping.
* going back to the old format.