### PR TITLE
ci: coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: $COVERALL_REPO_TOKEN

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,0 +1,8 @@
+# .slather.yml
+
+coverage_service: coveralls
+xcodeproj: CouchbaseLite.xcodeproj
+scheme: "CBL ObjC"
+ignore:
+  - vendor/*
+  - Swift/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ env:
 before_install:
   - brew update
   - brew install doxygen
-script: xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=macOS" | xcpretty -c
+  - gem install slather
+script: xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone XS" -enableCodeCoverage YES | xcpretty -c
+after_success:
+  - test "$SCHEME" = "CBL ObjC" && slather


### PR DESCRIPTION
* add coveralls
* enable slather and ignore all swift and vendor files.
* simulator corrected to iPhone XS

$COVERALL_REPO_TOKEN  is added as travis environment variable. 

<img width="469" alt="screen shot 2019-01-26 at 12 26 52 pm" src="https://user-images.githubusercontent.com/10448770/51792438-b397e300-2165-11e9-8f21-e8710a44f862.png">