### PR TITLE
ci: exit with same status as xcodebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_install:
   - brew update
   - brew install doxygen
   - gem install slather
-script: xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone XS" -enableCodeCoverage YES | xcpretty -c
+script: set -o pipefail && xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone XS" -enableCodeCoverage YES | xcpretty -c
 after_success:
   - test "$SCHEME" = "CBL ObjC" && slather


### PR DESCRIPTION
* CI systems usually use status codes to determine if the build has failed. When used with xcpretty it always returns zero.

[reference](https://github.com/xcpretty/xcpretty#usage)