### PR TITLE
unit: test join by docID

### DIFF
--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -966,7 +966,7 @@
     CBLQuery* q = [CBLQueryBuilder select: @[mainDocID, secondaryDocID, secondaryTheOne]
                                      from: mainDS
                                      join: @[join]];
-    uint64 numRows = [self verifyQuery: q randomAccess: NO test:^(uint64_t n, CBLQueryResult * _Nonnull result) {
+    uint64_t numRows = [self verifyQuery: q randomAccess: NO test:^(uint64_t n, CBLQueryResult * _Nonnull result) {
         AssertEqual(n, 1u);
         NSString* docID = [result stringForKey: @"mainDocID"];
         CBLDocument* doc = [self.db documentWithID: docID];

--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -933,6 +933,52 @@
     AssertEqual(numRows, 100u);
 }
 
+- (void) testJoinByDocID {
+    [self loadNumbers: 100];
+    
+    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"joinme"];
+    [doc1 setInteger: 42 forKey: @"theone"];
+    [doc1 setString: @"doc1" forKey: @"numberID"];
+    [self saveDocument: doc1];
+    
+    // datasources
+    CBLQueryDataSource* mainDS = [CBLQueryDataSource database: self.db as: @"main"];
+    CBLQueryDataSource* secondaryDS = [CBLQueryDataSource database: self.db as: @"secondary"];
+    
+    // create the join statement
+    CBLQueryExpression* mainPropExpr = [CBLQueryMeta idFrom: @"main"];
+    CBLQueryExpression* secondaryExpr = [CBLQueryExpression property: @"numberID"
+                                                                from: @"secondary"];
+    CBLQueryExpression* joinExpr = [mainPropExpr equalTo: secondaryExpr];
+    CBLQueryJoin* join = [CBLQueryJoin innerJoin: secondaryDS on: joinExpr];
+    
+    // select result statement
+    CBLQuerySelectResult* mainDocID = [CBLQuerySelectResult expression: mainPropExpr
+                                                                    as: @"mainDocID"];
+    CBLQuerySelectResult* secondaryDocID = [CBLQuerySelectResult expression: [CBLQueryMeta
+                                                                              idFrom: @"secondary"]
+                                                                         as: @"secondaryDocID"];
+    CBLQuerySelectResult* secondaryTheOne = [CBLQuerySelectResult
+                                             expression: [CBLQueryExpression property: @"theone"
+                                                                                 from:@"secondary"]];
+    
+    // query
+    CBLQuery* q = [CBLQueryBuilder select: @[mainDocID, secondaryDocID, secondaryTheOne]
+                                     from: mainDS
+                                     join: @[join]];
+    uint64 numRows = [self verifyQuery: q randomAccess: NO test:^(uint64_t n, CBLQueryResult * _Nonnull result) {
+        AssertEqual(n, 1u);
+        NSString* docID = [result stringForKey: @"mainDocID"];
+        CBLDocument* doc = [self.db documentWithID: docID];
+        AssertEqual([doc integerForKey: @"number1"], 1u);
+        AssertEqual([doc integerForKey: @"number2"], 99u);
+        
+        AssertEqualObjects([result stringForKey: @"secondaryDocID"], @"joinme");
+        AssertEqual([result integerForKey: @"theone"], 42u);
+    }];
+    AssertEqual(numRows, 1u);
+}
+
 
 - (void) testGroupBy {
     NSArray* expectedStates  = @[@"AL",    @"CA",    @"CO",    @"FL",    @"IA"];

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1506,8 +1506,8 @@ class QueryTest: CBLTestCase {
         let expiry = Date(timeIntervalSinceNow: 120)
         try db.setDocumentExpiration(withID: doc.id, expiration: expiry)
         
-            let q = QueryBuilder
-                .select(SelectResult.expression(Meta.id))
+        let q = QueryBuilder
+            .select(SelectResult.expression(Meta.id))
             .from(DataSource.database(db))
             .where(Meta.expiration
                 .greaterThan(Expression


### PR DESCRIPTION
* add test which is failing in dot net to validate the failure. but iOS is passing all tests.
* test consists of fetching property with `alias`. 

ref: #2229