### PR TITLE
Fix select all with database alias

### DIFF
--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -1189,6 +1189,24 @@
 }
 
 
+- (void) testSelectAllWithDatabaseAlias {
+    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] init];
+    [doc1 setString: @"doc1" forKey: @"someKey"];
+    [self saveDocument: doc1];
+    
+    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult allFrom: @"databaseAliasName"]]
+                                     from: [CBLQueryDataSource database: self.db as: @"databaseAliasName"]];
+    Assert(q);
+    
+    uint64_t numRows = [self verifyQuery: q randomAccess: NO test: ^(uint64_t n, CBLQueryResult* r)
+    {
+        AssertEqualObjects([r dictionaryAtIndex: 0],
+                           [r dictionaryForKey: @"databaseAliasName"]);
+    }];
+    AssertEqual(numRows, 1u);
+}
+
+
 - (void) testGenerateJSONCollation {
     NSArray* collations =
         @[[CBLQueryCollation asciiWithIgnoreCase: NO],

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -986,6 +986,22 @@ class QueryTest: CBLTestCase {
     }
     
     
+    func testSelectAllWithDatabaseAlias() throws {
+        let doc = MutableDocument()
+        doc.setString("doc1", forKey: "someKey")
+        try db.saveDocument(doc)
+        
+        let q = QueryBuilder
+            .select(SelectResult.all().from("databaseAliasName"))
+            .from(DataSource.database(db).as("databaseAliasName"))
+        
+        let numRows = try verifyQuery(q) { (n, r) in
+            XCTAssertEqual(r.dictionary(at: 0), r.dictionary(forKey: "databaseAliasName"));
+        }
+        XCTAssertEqual(numRows, 1)
+    }
+    
+    
     func testUnicodeCollationWithLocale() throws {
         let letters = ["B", "A", "Z", "Å"]
         for letter in letters {


### PR DESCRIPTION
If the title string is `*` or has `* #` as the prefix, fallback to 2.1.x approach by getting the column name from the SelectResult.columnName.