### PR TITLE
Not reformat the log message in logCallback()

### DIFF
--- a/Objective-C/CBLLog.mm
+++ b/Objective-C/CBLLog.mm
@@ -93,9 +93,8 @@ static CBLLogDomain toCBLLogDomain(C4LogDomain domain) {
 }
 
 static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, va_list args) {
-    // Message:
-    static char formatBuffer[2048];
-    vsnprintf(formatBuffer, sizeof(formatBuffer), fmt, args);
+    // Log message has been preformatted.
+    // c4log_writeToCallback() is called with preformatted=true:
     NSString* message = [NSString stringWithUTF8String: fmt];
     
     // Send to console and custom logger:


### PR DESCRIPTION
The log message has been reformatted so there is no need to reformat (which doesn’t take care of % character).

#2405