### PR TITLE
unit: add misc cpp tests

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1A4FE76A225ED344009D5F43 /* MiscCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A4FE769225ED344009D5F43 /* MiscCppTest.mm */; };
 		1A8DD7DA21C9876E00741C47 /* DateTimeQueryFunctionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */; };
 		1AC83BC821C026D100792098 /* DateTimeQueryFunctionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC83BC721C026D100792098 /* DateTimeQueryFunctionTest.m */; };
 		1ACEB9672256B74A00DED54C /* TrustCheckTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ACEB9662256B74A00DED54C /* TrustCheckTest.m */; };
@@ -1586,6 +1587,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A4FE769225ED344009D5F43 /* MiscCppTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MiscCppTest.mm; sourceTree = "<group>"; };
 		1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeQueryFunctionTest.swift; sourceTree = "<group>"; };
 		1AC83BC721C026D100792098 /* DateTimeQueryFunctionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DateTimeQueryFunctionTest.m; sourceTree = "<group>"; };
 		1ACEB9662256B74A00DED54C /* TrustCheckTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TrustCheckTest.m; sourceTree = "<group>"; };
@@ -2973,6 +2975,7 @@
 				939260B020A0FF0C00E5748C /* MessageEndpointTest.m */,
 				938B3701200D7D1D004485D8 /* MigrationTest.m */,
 				93384F8B1EB151C100976B41 /* MiscTest.m */,
+				1A4FE769225ED344009D5F43 /* MiscCppTest.mm */,
 				72A87A0E1E32E858008466FF /* NotificationTest.m */,
 				27EF6A931E298E26004748DF /* PredicateQueryTest.m */,
 				93EB25CB21CDD12A0006FB88 /* PredictiveQueryTest.m */,
@@ -5251,6 +5254,7 @@
 				1ACEB9672256B74A00DED54C /* TrustCheckTest.m in Sources */,
 				9378C5971E25B473001BB196 /* CBLTestCase.m in Sources */,
 				9378C5911E25B3F0001BB196 /* DatabaseTest.m in Sources */,
+				1A4FE76A225ED344009D5F43 /* MiscCppTest.mm in Sources */,
 				1AC83BC821C026D100792098 /* DateTimeQueryFunctionTest.m in Sources */,
 				938B3702200D7D1D004485D8 /* MigrationTest.m in Sources */,
 				9378C59E1E269F14001BB196 /* DocumentTest.m in Sources */,

--- a/Objective-C/Tests/MiscCppTest.mm
+++ b/Objective-C/Tests/MiscCppTest.mm
@@ -1,0 +1,88 @@
+//
+//  MiscCppTest.mm
+//  CBL ObjC Tests
+//
+//  Created by Jayahari Vavachan on 4/10/19.
+//  Copyright © 2019 Couchbase. All rights reserved.
+//
+
+#import "CBLTestCase.h"
+#import "CBLStatus.h"
+
+@interface MiscCppTest : CBLTestCase
+
+@end
+
+@implementation MiscCppTest
+
+#pragma mark - CBLStatus
+
+- (void) testConvertErrorNSErrorToC4ErrorNSURLError {
+    NSError* error = [NSError errorWithDomain: NSURLErrorDomain
+                                         code: kCFHostErrorHostNotFound
+                                     userInfo: nil];
+    C4Error c4err;
+    convertError(error, &c4err);
+    AssertEqual(c4err.domain, NetworkDomain);
+    AssertEqual(c4err.code, kC4NetErrUnknownHost);
+    
+    error = [NSError errorWithDomain: NSURLErrorDomain
+                                code: kCFErrorHTTPConnectionLost
+                            userInfo: nil];
+    convertError(error, &c4err);
+    AssertEqual(c4err.domain, POSIXDomain);
+    AssertEqual(c4err.code, ECONNRESET);
+}
+
+- (void) testConvertErrorNSErrorToC4ErrorOSStatusError {
+    C4Error c4err;
+    NSError* error = [NSError errorWithDomain: NSOSStatusErrorDomain
+                                         code: errSSLCertExpired
+                                     userInfo: nil];
+    convertError(error, &c4err);
+    AssertEqual(c4err.domain, NetworkDomain);
+    AssertEqual(c4err.code, kC4NetErrTLSCertExpired);
+    
+    // error code between -9899 & -9800
+    error = [NSError errorWithDomain: NSOSStatusErrorDomain
+                                code: errSSLPeerInternalError
+                            userInfo: nil];
+    convertError(error, &c4err);
+    AssertEqual(c4err.domain, NetworkDomain);
+    AssertEqual(c4err.code, kC4NetErrTLSHandshakeFailed);
+}
+
+- (void) testConvertErrorNSErrorToC4ErrorUndefinedError {
+    C4Error c4err;
+    NSError* error = [NSError errorWithDomain: NSOSStatusErrorDomain
+                                         code: errSSLPeerInternalError
+                                     userInfo: nil];
+    convertError(error, &c4err);
+    AssertEqual(c4err.domain, NetworkDomain);
+    AssertEqual(c4err.code, kC4NetErrTLSHandshakeFailed);
+    
+    error = [NSError errorWithDomain: NSURLErrorDomain
+                                code: kCFURLErrorCannotFindHost
+                            userInfo: nil];
+    convertError(error, &c4err);
+    AssertEqual(c4err.domain, LiteCoreDomain);
+    AssertEqual(c4err.code, kC4ErrorRemoteError);
+}
+
+- (void) testConvertErrorFleeceToNSError {
+    NSError* error;
+    AssertFalse(convertError(kFLEncodeError, &error));
+    
+    AssertEqual(error.code, kFLEncodeError);
+    AssertEqualObjects(error.domain, @"CouchbaseLite.Fleece");
+}
+
+- (void)testConvertErrorFleeceToC4Error {
+    C4Error c4Error;
+    AssertFalse(convertError(kFLEncodeError, &c4Error));
+    
+    AssertEqual(c4Error.code, kFLEncodeError);
+    AssertEqual(c4Error.domain, FleeceDomain);
+}
+
+@end

--- a/Objective-C/Tests/MiscCppTest.mm
+++ b/Objective-C/Tests/MiscCppTest.mm
@@ -1,9 +1,20 @@
 //
 //  MiscCppTest.mm
-//  CBL ObjC Tests
+//  CouchbaseLite
 //
-//  Created by Jayahari Vavachan on 4/10/19.
-//  Copyright © 2019 Couchbase. All rights reserved.
+//  Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "CBLTestCase.h"


### PR DESCRIPTION
* there are a few tests in CPP, which needs to be done from cpp test class itself. so kept a common test file with cpp tests in it.
* convertError method was not tested with some valid and invalid test scenarios.

Ref: #2376 