### PR TITLE
refact: remove unused function

### DIFF
--- a/Objective-C/CBLSessionAuthenticator.m
+++ b/Objective-C/CBLSessionAuthenticator.m
@@ -61,17 +61,4 @@
     options[@kC4ReplicatorOptionCookies] = cookieStr;
 }
 
-
-#pragma mark - Private
-
-
-- (nullable NSDate*) convertExpires: (nullable id)expires {
-    if (!expires || [expires isKindOfClass: [NSDate class]])
-        return expires;
-    
-    NSParameterAssert([expires isKindOfClass: [NSString class]]);
-    return [CBLJSON dateWithJSONObject: expires];
-}
-
-
 @end


### PR DESCRIPTION
* removed the function convertExpires from the class. which was used before #2016 and now it is not used.