### PR TITLE
refact: more readable

### DIFF
--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -823,7 +823,7 @@
     CBLQueryJoin* join = [CBLQueryJoin join: [CBLQueryDataSource database: self.db as: @"secondary"]
                                          on: [propNum1 equalTo: propTheOne]];
     CBLQueryJoin* innerJoin;
-    innerJoin = [CBLQueryJoin join: [CBLQueryDataSource database: self.db as: @"secondary"]
+    innerJoin = [CBLQueryJoin innerJoin: [CBLQueryDataSource database: self.db as: @"secondary"]
                                 on: [propNum1 equalTo: propTheOne]];
     
     // select from join: this should return 2 similar rows with same value.

--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -822,6 +822,9 @@
     
     CBLQueryJoin* join = [CBLQueryJoin join: [CBLQueryDataSource database: self.db as: @"secondary"]
                                          on: [propNum1 equalTo: propTheOne]];
+    
+    // there is no particular reason for using inner-join and join. Just for the sake of using
+    // two different statement with same result only.
     CBLQueryJoin* innerJoin;
     innerJoin = [CBLQueryJoin innerJoin: [CBLQueryDataSource database: self.db as: @"secondary"]
                                 on: [propNum1 equalTo: propTheOne]];


### PR DESCRIPTION
* more readable and clear statements.
* include inner join and join. check for number2 as well as number1.
* add comments to the select statements, to distinguish between select and selectDistinct.

Ref: #2376 