### PR TITLE
fix: query column title correction

### DIFF
--- a/Objective-C/Tests/QueryTest.m
+++ b/Objective-C/Tests/QueryTest.m
@@ -578,6 +578,37 @@
     AssertEqual(numRows, 1u);
 }
 
+- (void) testDatabaseAliasWithMultipleSources {
+    [self loadNumbers: 100];
+    
+    CBLMutableDocument* joinme = [[CBLMutableDocument alloc] initWithID: @"joinme"];
+    [joinme setValue: @42 forKey: @"theone"];
+    [self saveDocument: joinme];
+    
+    CBLMutableDocument* joinmeCopy = [[CBLMutableDocument alloc] initWithID: @"joinmeCopy"];
+    [joinmeCopy setValue: @42 forKey: @"theone"];
+    [self saveDocument: joinmeCopy];
+    
+    CBLQueryExpression* propNum1 = [CBLQueryExpression property: @"number1" from: @"main"];
+    CBLQueryExpression* propTheOne = [CBLQueryExpression property: @"theone" from: @"secondary"];
+    
+    CBLQueryJoin* join = [CBLQueryJoin join: [CBLQueryDataSource database: self.db as: @"secondary"]
+                                         on: [propNum1 equalTo: propTheOne]];
+    
+    CBLQuery* q = [CBLQueryBuilder selectDistinct: @[[CBLQuerySelectResult allFrom: @"main"],
+                                                     [CBLQuerySelectResult allFrom: @"secondary"]]
+                                             from: [CBLQueryDataSource database: self.db as: @"main"]
+                                             join: @[join]];
+    Assert(q);
+    uint64_t numRows = 0;
+    numRows = [self verifyQuery: q randomAccess: YES test: ^(uint64_t n, CBLQueryResult* r) {
+        AssertEqualObjects([r dictionaryAtIndex: 0], [r dictionaryForKey: @"main"]);
+        AssertEqualObjects([r dictionaryAtIndex: 1], [r dictionaryForKey: @"secondary"]);
+    }];
+    AssertEqual(numRows, 1u);
+}
+
+
 #pragma mark - OrderBy/GroupBy
 
 - (void) testOrderBy {

--- a/Swift/SelectResult.swift
+++ b/Swift/SelectResult.swift
@@ -111,7 +111,7 @@ public final class SelectResult {
 /* Internal */ class QuerySelectResultFrom: QuerySelectResult, SelectResultFrom {
     
     public func from(_ alias: String?) -> SelectResultProtocol {
-        return QuerySelectResult(expression: Expression.all().from(alias), alias: nil)
+        return QuerySelectResult(expression: Expression.all().from(alias), alias: alias)
     }
     
 }

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1048,8 +1048,6 @@ class QueryTest: CBLTestCase {
     
     
     func testSelectAllWithDatabaseAliasWithMultipleSources() throws {
-        Database.log.console.domains = .all
-        Database.log.console.level = .verbose
         try loadNumbers(100)
         
         let doc = createDocument()


### PR DESCRIPTION
* removed the workaround and added the fix for the query column title issue.
* fixed the issue with selectResult with alias in Swift.