### PR TITLE
debug: add logs in push filter

### DIFF
--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -2079,6 +2079,10 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady
 
 
 - (void) testStopAndRestartPushReplicationWithFilter {
+    // TODO: #2420 for debugging https://github.com/couchbase/couchbase-lite-ios/issues/2420
+    CBLDatabase.log.console.domains = kCBLLogDomainAll;
+    CBLDatabase.log.console.level = kCBLLogLevelVerbose;
+    
     // Create documents
     NSError* error;
     CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
@@ -2126,6 +2130,9 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady
     AssertNil([otherDB documentWithID: @"doc3"]);
     AssertEqual(self.db.count, 3u);
     AssertEqual(otherDB.count, 2u);
+    
+    // TODO: #2420 for debugging https://github.com/couchbase/couchbase-lite-ios/issues/2420
+    CBLDatabase.log.console.level = kCBLLogLevelNone;
 }
 
 

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -2132,7 +2132,7 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady
     AssertEqual(otherDB.count, 2u);
     
     // TODO: #2420 for debugging https://github.com/couchbase/couchbase-lite-ios/issues/2420
-    CBLDatabase.log.console.level = kCBLLogLevelNone;
+    CBLDatabase.log.console.level = kCBLLogLevelWarning;
 }
 
 

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -741,6 +741,10 @@ class ReplicatorTest: CBLTestCase {
     // MARK: stop and restart replication with filter
     
     func testStopAndRestartPushReplicationWithFilter() throws {
+        // TODO: #2420 for debugging https://github.com/couchbase/couchbase-lite-ios/issues/2420
+        Database.log.console.domains = .all
+        Database.log.console.level = .verbose
+        
         // Create documents:
         let doc1 = MutableDocument(id: "doc1")
         doc1.setString("pass", forKey: "name")
@@ -787,6 +791,9 @@ class ReplicatorTest: CBLTestCase {
         XCTAssertNil(otherDB.document(withID: "doc3"))
         XCTAssertEqual(db.count, 3)
         XCTAssertEqual(otherDB.count, 2)
+        
+        // TODO: #2420 for debugging https://github.com/couchbase/couchbase-lite-ios/issues/2420
+        Database.log.console.level = .none
     }
     
     func testStopAndRestartPullReplicationWithFilter() throws {

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -793,7 +793,7 @@ class ReplicatorTest: CBLTestCase {
         XCTAssertEqual(otherDB.count, 2)
         
         // TODO: #2420 for debugging https://github.com/couchbase/couchbase-lite-ios/issues/2420
-        Database.log.console.level = .none
+        Database.log.console.level = .warning
     }
     
     func testStopAndRestartPullReplicationWithFilter() throws {


### PR DESCRIPTION
* add logs to unit tests so that we can identify next time issue happens.
* if need to remove the logs, search for `// TODO: #2420`

ref: #2420

