### PR TITLE
fix: issue with newly created doc without database

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1053,6 +1053,11 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
             
             resolvedDoc = [conflictResolver resolve: conflict];
             
+            if (!resolvedDoc.database) {
+                // when resolved doc is a newly created doc, without a database
+                resolvedDoc.database = localDoc.database;
+            }
+            
             if (resolvedDoc && resolvedDoc.id != docID) {
                 [NSException raise: NSInternalInconsistencyException
                             format: @"Resolved docID '%@' is not matching with docID '%@'",

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -218,21 +218,47 @@
     TestConflictResolver* resolver;
     CBLReplicatorConfiguration* pullConfig = [self pullConfig];
     
+    // EDIT LOCAL DOCUMENT
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
         CBLMutableDocument* mDoc = con.localDocument.toMutable;
         [mDoc setString: @"local" forKey: @"edit"];
         return mDoc;
     }];
     pullConfig.conflictResolver = resolver;
-    
     [self run: pullConfig errorCode: 0 errorDomain: nil];
     
-    // Check that it was resolved:
-    AssertEqual(self.db.count, 1u);
-    CBLDocument* savedDoc = [self.db documentWithID: @"doc"];
-    
+    CBLDocument* savedDoc = [self.db documentWithID: docId];
     NSMutableDictionary* exp = [NSMutableDictionary dictionaryWithDictionary: localData];
     [exp setValue: @"local" forKey: @"edit"];
+    AssertEqualObjects(savedDoc.toDictionary, exp);
+    
+    // EDIT REMOTE DOCUMENT
+    [self makeConflictFor: docId withLocal: localData withRemote: remoteData];
+    resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
+        CBLMutableDocument* mDoc = con.remoteDocument.toMutable;
+        [mDoc setString: @"remote" forKey: @"edit"];
+        return mDoc;
+    }];
+    pullConfig.conflictResolver = resolver;
+    [self run: pullConfig errorCode: 0 errorDomain: nil];
+    
+    savedDoc = [self.db documentWithID: docId];
+    exp = [NSMutableDictionary dictionaryWithDictionary: remoteData];
+    [exp setValue: @"remote" forKey: @"edit"];
+    AssertEqualObjects(savedDoc.toDictionary, exp);
+    
+    // CREATE NEW DOCUMENT
+    [self makeConflictFor: docId withLocal: localData withRemote: remoteData];
+    resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
+        CBLMutableDocument* mDoc = [[CBLMutableDocument alloc] initWithID: con.localDocument.id];
+        [mDoc setString: @"new-with-same-ID" forKey: @"docType"];
+        return mDoc;
+    }];
+    pullConfig.conflictResolver = resolver;
+    [self run: pullConfig errorCode: 0 errorDomain: nil];
+    
+    savedDoc = [self.db documentWithID: docId];
+    exp = [NSMutableDictionary dictionaryWithObject: @"new-with-same-ID" forKey: @"docType"];
     AssertEqualObjects(savedDoc.toDictionary, exp);
 }
 


### PR DESCRIPTION
* when newly created document was returned from the resolve, it will lack the database, handled that scenario by assigning the local-doc.database.
* add merge document conditions to handle, local, remote and newly document returns from the resolve method.

Ref: #2428