### PR TITLE
unit: non-blocking resolver

### DIFF
--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -519,7 +519,7 @@
     [self makeConflictFor: @"doc2" withLocal: localData withRemote: remoteData];
     
     TestConflictResolver* resolver;
-    CBLReplicatorConfiguration* pullConfig = [self pullConfig];
+    CBLReplicatorConfiguration* pullConfig = [self config: kCBLReplicatorTypePull];
     
     NSMutableArray* order = [NSMutableArray array];
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
@@ -528,10 +528,11 @@
         }
         if (order.count == 1) {
             [NSThread sleepForTimeInterval: 0.5];
-            [ex fulfill];
         }
-        @synchronized (order) {
-            [order addObject: con.localDocument.id];
+        [order addObject: con.localDocument.id];
+        
+        if (order.count == 4) {
+            [ex fulfill];
         }
         return con.remoteDocument;
     }];

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -263,7 +263,7 @@
     [self waitForExpectationsWithTimeout: 5 handler: nil];
     
     // make sure, first doc starts resolution but finishes last.
-    // in between another thread starts and finishes second doc.
+    // in between second doc starts and finishes it. 
     AssertEqualObjects(order.firstObject, order.lastObject);
     AssertEqualObjects(order[1], order[2]);
 }

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -245,12 +245,16 @@
     
     NSMutableArray* order = [NSMutableArray array];
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
-        [order addObject: con.localDocument.id];
-        if ([con.localDocument.id isEqualToString: order.firstObject]) {
+        @synchronized (order) {
+            [order addObject: con.localDocument.id];
+        }
+        if (order.count == 1) {
             [NSThread sleepForTimeInterval: 0.5];
             [ex fulfill];
         }
-        [order addObject: con.localDocument.id];
+        @synchronized (order) {
+            [order addObject: con.localDocument.id];
+        }
         return con.remoteDocument;
     }];
     pullConfig.conflictResolver = resolver;


### PR DESCRIPTION
* validate the non blocking by making the first document to sleep.
* then second document should resolve in between.
* order should be doc1(whichever is resolved first) will start, doc2(whichever resolves second) will start, doc2 ends, doc1 ends.

ref:  #2428