### PR TITLE
unit: cancel conflict handler

### DIFF
--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -599,9 +599,9 @@
     NSError* error;
     [doc1b setString: @"Scott" forKey: @"nickName"];
     AssertFalse([self.db saveDocument: doc1b
-                      conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
-                          AssertEqualObjects(doc1b.toDictionary, cur.toDictionary);
-                          AssertEqualObjects(doc1a.toDictionary, old.toDictionary);
+                      conflictHandler:^BOOL(CBLMutableDocument * savingDoc, CBLDocument * dbDoc) {
+                          AssertEqualObjects(doc1b.toDictionary, savingDoc.toDictionary);
+                          AssertEqualObjects(doc1a.toDictionary, dbDoc.toDictionary);
                           return NO;
                       } error: &error]);
     AssertEqual(error.code, CBLErrorConflict);
@@ -621,9 +621,9 @@
 
     [doc1b setString: @"Scotty" forKey: @"nickName"];
     AssertFalse([self.db saveDocument: doc1b
-                      conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
+                      conflictHandler:^BOOL(CBLMutableDocument * savingDoc, CBLDocument * dbDoc) {
                           // with some updates to the existing doc also shouldn't cause any issues
-                          [cur setString: @"Scott" forKey: @"nickName"];
+                          [savingDoc setString: @"Scott" forKey: @"nickName"];
                           return NO;
                       } error: &error]);
     AssertEqual(error.code, CBLErrorConflict);

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -598,12 +598,12 @@
     
     NSError* error;
     [doc1b setString: @"Scott" forKey: @"nickName"];
-    [self.db saveDocument: doc1b
-          conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
-              AssertEqualObjects(doc1b.toDictionary, cur.toDictionary);
-              AssertEqualObjects(doc1a.toDictionary, old.toDictionary);
-              return NO;
-          } error: &error];
+    AssertFalse([self.db saveDocument: doc1b
+                      conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
+                          AssertEqualObjects(doc1b.toDictionary, cur.toDictionary);
+                          AssertEqualObjects(doc1a.toDictionary, old.toDictionary);
+                          return NO;
+                      } error: &error]);
     AssertNil(error);
     AssertEqualObjects([self.db documentWithID: docID].toDictionary, doc1a.toDictionary);
     
@@ -620,12 +620,12 @@
     AssertEqual([self.db documentWithID: docID].generation, 3u);
 
     [doc1b setString: @"Scotty" forKey: @"nickName"];
-    [self.db saveDocument: doc1b
-          conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
-              // with some updates to the existing doc also shouldn't cause any issues
-              [cur setString: @"Scott" forKey: @"nickName"];
-              return NO;
-          } error: &error];
+    AssertFalse([self.db saveDocument: doc1b
+                      conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
+                          // with some updates to the existing doc also shouldn't cause any issues
+                          [cur setString: @"Scott" forKey: @"nickName"];
+                          return NO;
+                      } error: &error]);
     AssertNil(error);
     AssertEqualObjects([self.db documentWithID: docID].toDictionary, doc1a.toDictionary);
     

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -735,7 +735,6 @@
     AssertEqualObjects([self.db documentWithID: docID].toDictionary, doc1a.toDictionary);
     AssertEqual([self.db documentWithID: docID].generation, 2u);
     AssertEqual(error.code, CBLErrorConflict);
->>>>>>> 81009e8c2cd700c3fa7c2a9b4d7f46f232ef801a
 }
 
 #pragma mark - Delete Document

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -652,9 +652,9 @@
     NSError* error;
     [doc1b setString: @"Scott" forKey: @"nickName"];
     AssertFalse([self.db saveDocument: doc1b
-                      conflictHandler:^BOOL(CBLMutableDocument * savingDoc, CBLDocument * dbDoc) {
-                          AssertEqualObjects(doc1b.toDictionary, savingDoc.toDictionary);
-                          AssertEqualObjects(doc1a.toDictionary, dbDoc.toDictionary);
+                      conflictHandler:^BOOL(CBLMutableDocument * document, CBLDocument * old) {
+                          AssertEqualObjects(doc1b.toDictionary, document.toDictionary);
+                          AssertEqualObjects(doc1a.toDictionary, old.toDictionary);
                           return NO;
                       } error: &error]);
     AssertEqual(error.code, CBLErrorConflict);
@@ -674,9 +674,9 @@
     
     [doc1b setString: @"Scotty" forKey: @"nickName"];
     AssertFalse([self.db saveDocument: doc1b
-                      conflictHandler:^BOOL(CBLMutableDocument * savingDoc, CBLDocument * dbDoc) {
+                      conflictHandler:^BOOL(CBLMutableDocument * document, CBLDocument * old) {
                           // with some updates to the existing doc also shouldn't cause any issues
-                          [savingDoc setString: @"Scott" forKey: @"nickName"];
+                          [document setString: @"Scott" forKey: @"nickName"];
                           return NO;
                       } error: &error]);
     AssertEqual(error.code, CBLErrorConflict);

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -604,7 +604,7 @@
                           AssertEqualObjects(doc1a.toDictionary, old.toDictionary);
                           return NO;
                       } error: &error]);
-    AssertNil(error);
+    AssertEqual(error.code, CBLErrorConflict);
     AssertEqualObjects([self.db documentWithID: docID].toDictionary, doc1a.toDictionary);
     
     // make sure no update to revision and generation
@@ -626,7 +626,7 @@
                           [cur setString: @"Scott" forKey: @"nickName"];
                           return NO;
                       } error: &error]);
-    AssertNil(error);
+    AssertEqual(error.code, CBLErrorConflict);
     AssertEqualObjects([self.db documentWithID: docID].toDictionary, doc1a.toDictionary);
     
     // make sure no update to revision and generation


### PR DESCRIPTION
* check with/without update to the current document if we return false from the conflict handler, how the save behaves.

ref: #2430