### PR TITLE
fix: empty slice as body is crashing when pushing the doc

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1128,7 +1128,7 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
                     return false;
                 isDeleted = resolvedDoc.isDeleted;
             } else
-                mergedBody = alloc_slice(""_sl);
+                mergedBody = [self emptyFLSliceResult];
             
             if (isDeleted)
                 mergedFlags |= kRevDeleted;
@@ -1151,6 +1151,15 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
         
         return t.commit() || convertError(t.error(), outError);
     }
+}
+
+- (FLSliceResult) emptyFLSliceResult {
+    FLEncoder enc = c4db_getSharedFleeceEncoder(_c4db);
+    FLEncoder_BeginDict(enc, 0);
+    FLEncoder_EndDict(enc);
+    auto result = FLEncoder_Finish(enc, nullptr);
+    FLEncoder_Reset(enc);
+    return result;
 }
 
 

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1162,7 +1162,6 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
     return result;
 }
 
-
 # pragma mark DOCUMENT EXPIRATION
 
 


### PR DESCRIPTION
* when doc is pushed back to remote, the crash happened due to fromData(s) == nullptr.
* fixed by handling the [.NET way](https://github.com/couchbase/couchbase-lite-net/blob/master/src/Couchbase.Lite.Shared/API/Database/Database.cs#L1320)