### PR TITLE
fix: exception in conflict handler

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -261,9 +261,11 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
                 } else {
                     return createError(CBLErrorConflict, error);
                 }
-            } @catch(NSError* conflictHandlerError) {
+            } @catch(NSException* ex) {
                 if (error)
-                    *error = conflictHandlerError;
+                    *error = [NSError errorWithDomain: CBLErrorDomain
+                                                 code: CBLErrorConflict
+                                             userInfo: @{NSLocalizedDescriptionKey: ex.description}];
             }
             return NO;
         } else if (!success) { // any other error, we return false with errorInfo

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -582,6 +582,36 @@
     [self cleanDB];
 }
 
+// since objc is not exception safe, this exception throw result in memory issue
+// TODO: handle the expected memory issue in tests. s
+- (void) _testConflictHandlerThrowingException {
+    NSString* docID = @"doc1";
+    CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: docID];
+    [doc setString: @"Tiger" forKey: @"firstName"];
+    [self saveDocument: doc];
+    AssertEqual([self.db documentWithID: docID].generation, 1u);
+    
+    CBLMutableDocument* doc1a = [[self.db documentWithID: docID] toMutable];
+    CBLMutableDocument* doc1b = [[self.db documentWithID: docID] toMutable];
+    
+    [doc1a setString: @"Scotty" forKey: @"nickName"];
+    [self saveDocument: doc1a];
+    AssertEqual([self.db documentWithID: docID].generation, 2u);
+    
+    NSError* error;
+    [doc1b setString: @"Scott" forKey: @"nickName"];
+    BOOL success = [self.db saveDocument: doc1b
+                         conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
+                             [NSException raise: NSInternalInconsistencyException
+                                         format: @"exception inside the conflict handler"];
+                             return YES;
+                         } error: &error];
+    AssertFalse(success);
+    AssertEqualObjects([self.db documentWithID: docID].toDictionary, doc1a.toDictionary);
+    AssertEqual([self.db documentWithID: docID].generation, 2u);
+    AssertEqual(error.code, CBLErrorConflict);
+}
+
 
 #pragma mark - Delete Document
 


### PR DESCRIPTION
* exception in conflict handler was not handling properly before.
* now it handles and returns conflict error, with save error.
* returns NO, and conflict error.
* test case added but disabled due to memory issue when exception thrown from the block.

ref: #2430