### PR TITLE
fix: purge during save conflict

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -249,7 +249,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
                                                 includeDeleted: YES
                                                          error: error];
                 if (!oldDoc)
-                    return NO;
+                    return createError(CBLErrorConflict, error);
                 
                 if (!transaction.commit())
                     return convertError(transaction.error(), error);

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -249,7 +249,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
                                                 includeDeleted: YES
                                                          error: error];
                 if (!oldDoc)
-                    return createError(CBLErrorConflict, error);
+                    return createError(CBLErrorNotFound, error);
                 
                 if (!transaction.commit())
                     return convertError(transaction.error(), error);

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -599,7 +599,7 @@
                       conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
                           return YES;
                       } error: &error]);
-    AssertEqual(error.code, CBLErrorConflict);
+    AssertEqual(error.code, CBLErrorNotFound);
 }
 
 


### PR DESCRIPTION
* when purge happened during save, we should return NotFound error.
* should also return save false, which is already doing.

ref: #2430