### PR TITLE
unit: resolver read from/to config

### DIFF
--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -21,6 +21,19 @@ import XCTest
 import CouchbaseLiteSwift
 
 class ReplicatorTest_CustomConflict: ReplicatorTest {
+    func testConflictResolverConfigProperty() {
+        let target = URLEndpoint(url: URL(string: "wss://foo")!)
+        let pullConfig = config(target: target, type: .pull, continuous: false)
+        
+        let conflictResolver = TestConflictResolver { (con) -> Document? in
+            return con.remoteDocument
+        }
+        pullConfig.conflictResolver = conflictResolver
+        repl = Replicator(config: pullConfig)
+        
+        XCTAssertNotNil(pullConfig.conflictResolver)
+        XCTAssertNotNil(repl.config.conflictResolver)
+    }
     
     #if COUCHBASE_ENTERPRISE
     

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -841,18 +841,4 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertEqual(db.count, 2)
     }
     #endif
-    
-    func testConflictResolverConfigProperty() {
-        let target = URLEndpoint(url: URL(string: "wss://foo")!)
-        let pullConfig = config(target: target, type: .pull, continuous: false)
-        
-        let conflictResolver = TestConflictResolver { (con) -> Document? in
-            return con.remoteDocument
-        }
-        pullConfig.conflictResolver = conflictResolver
-        repl = Replicator(config: pullConfig)
-        
-        XCTAssertNotNil(pullConfig.conflictResolver)
-        XCTAssertNotNil(repl.config.conflictResolver)
-    }
 }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1002,6 +1002,20 @@ class ReplicatorTest: CBLTestCase {
     }
     
     #endif
+    
+    func testConflictResolverConfigProperty() {
+        let target = URLEndpoint(url: URL(string: "wss://foo")!)
+        let pullConfig = config(target: target, type: .pull, continuous: false)
+        
+        let conflictResolver = TestConflictResolver { (con) -> Document? in
+            return con.remoteDocument
+        }
+        pullConfig.conflictResolver = conflictResolver
+        repl = Replicator(config: pullConfig)
+        
+        XCTAssertNotNil(pullConfig.conflictResolver)
+        XCTAssertNotNil(repl.config.conflictResolver)
+    }
 }
 
 class TestConflictResolver: ConflictResolver {


### PR DESCRIPTION
* check whether we can set or get conflict resolver to/from config.
* cannot check whether it is readonly, since setting readonly will result in fatalError. 
* Handling fatalError seems to be more effort, which not sure whether we should be adding or not. 

ref: #2428