### PR TITLE
unit: conflict handler called twice

### DIFF
--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -784,6 +784,59 @@
     [self cleanDB];
 }
 
+- (void) testConflictHandlerCalledTwice {
+    NSString* docID = @"doc1";
+    CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: docID];
+    [doc setString: @"Tiger" forKey: @"firstName"];
+    [self saveDocument: doc];
+    AssertEqual([self.db documentWithID: docID].generation, 1u);
+    
+    CBLMutableDocument* doc1a = [[self.db documentWithID: docID] toMutable];
+    CBLMutableDocument* doc1b = [[self.db documentWithID: docID] toMutable];
+    
+    [doc1a setString: @"Scotty" forKey: @"nickName"];
+    [self saveDocument: doc1a];
+    AssertEqual([self.db documentWithID: docID].generation, 2u);
+    
+    NSError* error;
+    [doc1b setString: @"Scott" forKey: @"nickName"];
+    __block int count = 0;
+    Assert([self.db saveDocument: doc1b
+                 conflictHandler:^BOOL(CBLMutableDocument * cur, CBLDocument * old) {
+                     count++;
+                     CBLMutableDocument* doc1c = [[self.db documentWithID: docID] toMutable];
+                     if (![doc1c booleanForKey: @"secondUpdate"]) {
+                         AssertEqual(old.generation, 2u);
+                         AssertEqual(cur.generation, 2u);
+                         [doc1c setBoolean: YES forKey: @"secondUpdate"];
+                         [self saveDocument: doc1c];
+                         AssertEqual([self.db documentWithID: docID].generation, 3u);
+                     }
+                     
+                     // "secondUpdate" is going to be erased, since the cur doesn't have the latest
+                     // doc from DB. We will be merging the old and cur here...
+                     // whether this should be due to variable naming may be!!!!
+                     NSMutableDictionary* dict = [NSMutableDictionary dictionaryWithDictionary: old.toDictionary];
+                     for (NSString* key in cur.toDictionary.allKeys) {
+                         [dict setValue: [cur valueForKey: key] forKey: key];
+                     }
+                     [cur setData: dict];
+                     [cur setValue: @"local" forKey: @"edit"];
+                     return YES;
+                 } error: &error]);
+    
+    // make sure the save handler method called twice due to second conflict
+    AssertEqual(count, 2u);
+    AssertEqual(self.db.count, 1u);
+    
+    NSDictionary* expected = @{@"nickName": @"Scott",
+                               @"firstName": @"Tiger",
+                               @"secondUpdate": @YES,
+                               @"edit": @"local"};
+    AssertEqualObjects([self.db documentWithID: docID].toDictionary, expected);
+    AssertEqual([self.db documentWithID: docID].generation, 4u);
+}
+
 
 #pragma mark - Purge Document
 


### PR DESCRIPTION
* add conflict handler to be called twice test.
* confusion on either naming, may be the old is not old, as Jens suggested. since this test wil confuse. and cur is not cur, but the savedDoc.

ref: #2430