### PR TITLE
unit: swift unit tests for replication events

### DIFF
--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -305,6 +305,47 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         XCTAssert(["docType": "new-with-same-ID"] == db.document(withID: docID)!.toDictionary())
     }
     
+    func testDocumentReplicationEventForConflictedDocs() throws {
+        var resolver: TestConflictResolver!
+        
+        // when resolution is skipped: here wrong doc-id throws an exception & skips it
+        resolver = TestConflictResolver() { (conflict) -> Document? in
+            return MutableDocument(id: "wrongDocID")
+        }
+        try validateDocumentReplicationEventForConflictedDocs(resolver)
+        
+        // when resolution is successfull.
+        resolver = TestConflictResolver() { (conflict) -> Document? in
+            return conflict.remoteDocument
+        }
+        try validateDocumentReplicationEventForConflictedDocs(resolver)
+    }
+    
+    func validateDocumentReplicationEventForConflictedDocs(_ resolver: TestConflictResolver) throws {
+        let docID = "doc"
+        let localData = ["key1": "value1"]
+        let remoteData = ["key2": "value2"]
+        let config = getConfig(.pull)
+        config.conflictResolver = resolver
+        
+        try makeConflict(forID: docID, withLocal: localData, withRemote: remoteData)
+        
+        var token: ListenerToken!
+        var replicator: Replicator!
+        var docIds = [String]()
+        run(config: config, reset: false, expectedError: nil, onReplicatorReady: { (r) in
+            replicator = r
+            token = r.addDocumentReplicationListener({ (docRepl) in
+                for doc in docRepl.documents {
+                    docIds.append(doc.id)
+                }
+            })
+        })
+        XCTAssertEqual(docIds.count, 1)
+        XCTAssertEqual(docIds.first!, docID)
+        replicator.removeChangeListener(withToken: token)
+    }
+    
     #endif
 }
 

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -356,6 +356,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
     }
     
     
+    // TODO: enable as a separate PR
     func _testConflictResolverWrongDocID() throws {
         let docID = "doc"
         let localData = ["key1": "value1"]

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -341,6 +341,8 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
                 }
             })
         })
+        
+        // make sure only single listener event is fired when conflict occured.
         XCTAssertEqual(docIds.count, 1)
         XCTAssertEqual(docIds.first!, docID)
         replicator.removeChangeListener(withToken: token)


### PR DESCRIPTION
* validated whether there is only single events are fired when document replication custom conflict resolution happens, and when CCR exception is thrown(skips the ccr).