### PR TITLE
fix: database alias issue

### DIFF
--- a/Objective-C/CBLQuerySelectResult.m
+++ b/Objective-C/CBLQuerySelectResult.m
@@ -58,7 +58,7 @@
 
 + (instancetype) allFrom: (nullable NSString*)alias {
     CBLQueryExpression* expr = [CBLQueryExpression allFrom: alias];
-    return [[self alloc] initWithExpression: expr as: alias];
+    return [[self alloc] initWithExpression: expr as: nil];
 }
 
 

--- a/Objective-C/Tests/QueryTest+Main.m
+++ b/Objective-C/Tests/QueryTest+Main.m
@@ -412,23 +412,6 @@
     AssertEqual(numRows, 100u);
 }
 
-- (void) testSelectAllWithDatabaseAlias {
-    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] init];
-    [doc1 setString: @"doc1" forKey: @"someKey"];
-    [self saveDocument: doc1];
-    
-    CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult allFrom: @"databaseAliasName"]]
-                                     from: [CBLQueryDataSource database: self.db as: @"databaseAliasName"]];
-    Assert(q);
-    
-    uint64_t numRows = [self verifyQuery: q randomAccess: NO test: ^(uint64_t n, CBLQueryResult* r)
-                        {
-                            AssertEqualObjects([r dictionaryAtIndex: 0],
-                                               [r dictionaryForKey: @"databaseAliasName"]);
-                        }];
-    AssertEqual(numRows, 1u);
-}
-
 - (void) testDatabaseAliasWithMultipleSources {
     [self loadNumbers: 100];
     

--- a/Swift/SelectResult.swift
+++ b/Swift/SelectResult.swift
@@ -111,7 +111,7 @@ public final class SelectResult {
 /* Internal */ class QuerySelectResultFrom: QuerySelectResult, SelectResultFrom {
     
     public func from(_ alias: String?) -> SelectResultProtocol {
-        return QuerySelectResult(expression: Expression.all().from(alias), alias: alias)
+        return QuerySelectResult(expression: Expression.all().from(alias), alias: nil)
     }
     
 }

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1031,22 +1031,6 @@ class QueryTest: CBLTestCase {
     }
     
     
-    func testSelectAllWithDatabaseAlias() throws {
-        let doc = MutableDocument()
-        doc.setString("doc1", forKey: "someKey")
-        try db.saveDocument(doc)
-        
-        let q = QueryBuilder
-            .select(SelectResult.all().from("databaseAliasName"))
-            .from(DataSource.database(db).as("databaseAliasName"))
-        
-        let numRows = try verifyQuery(q) { (n, r) in
-            XCTAssertEqual(r.dictionary(at: 0), r.dictionary(forKey: "databaseAliasName"));
-        }
-        XCTAssertEqual(numRows, 1)
-    }
-    
-    
     func testSelectAllWithDatabaseAliasWithMultipleSources() throws {
         try loadNumbers(100)
         


### PR DESCRIPTION
* alias was using twice, after the SelectAll(withAlias), we were again passing in the alias. which duplicated the alias.
* removed the redundant test
* updated the lite-core to latest.