### PR TITLE
unit: correct wrong doc id test swift

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		1AA6744B227924120018CC6D /* QueryTest+Join.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF6382226A8DBF0016754C /* QueryTest+Join.m */; };
 		1AA6744C227924130018CC6D /* QueryTest+Meta.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF6371226A8B060016754C /* QueryTest+Meta.m */; };
 		1AA6744D227924130018CC6D /* QueryTest+Join.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF6382226A8DBF0016754C /* QueryTest+Join.m */; };
+		1AA91DC622B0356000BF0BDE /* CustomLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA91DC522B0356000BF0BDE /* CustomLogger.swift */; };
+		1AA91DC722B0356000BF0BDE /* CustomLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA91DC522B0356000BF0BDE /* CustomLogger.swift */; };
 		1AAB273922737A9A0037A880 /* CBLConflictResolution.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AAB273722737A9A0037A880 /* CBLConflictResolution.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AAB273D22739EBB0037A880 /* CBLConflict.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AAB273B22739EBB0037A880 /* CBLConflict.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AAB273E22739EBB0037A880 /* CBLConflict.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAB273C22739EBB0037A880 /* CBLConflict.m */; };
@@ -1652,6 +1654,7 @@
 		1AA3D77122AB06E10098E16B /* CustomLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomLogger.h; sourceTree = "<group>"; };
 		1AA3D77222AB06E10098E16B /* CustomLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomLogger.m; sourceTree = "<group>"; };
 		1AA6744E227925D20018CC6D /* QueryTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QueryTest.h; sourceTree = "<group>"; };
+		1AA91DC522B0356000BF0BDE /* CustomLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLogger.swift; sourceTree = "<group>"; };
 		1AAB2736227373EB0037A880 /* CBLConflictResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLConflictResolver.h; sourceTree = "<group>"; };
 		1AAB273722737A9A0037A880 /* CBLConflictResolution.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLConflictResolution.h; sourceTree = "<group>"; };
 		1AAB273822737A9A0037A880 /* CBLConflictResolution.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLConflictResolution.m; sourceTree = "<group>"; };
@@ -2360,6 +2363,7 @@
 				93AE16E2221DC92E00539C05 /* PredictiveQueryTest+CoreML.swift */,
 				93DB80021ED8FE5100C4F845 /* ReplicatorTest.swift */,
 				1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */,
+				1AA91DC522B0356000BF0BDE /* CustomLogger.swift */,
 				939B79241E679017009A70EF /* Info.plist */,
 			);
 			path = Tests;
@@ -4801,6 +4805,7 @@
 				93C3985F1EC66A89005A7A96 /* DictionaryTest.swift in Sources */,
 				93C50EA021BDFB7C00C7E980 /* DocumentExpirationTest.swift in Sources */,
 				27BE3B4B1E4E46120012B74A /* CBLTestCase.swift in Sources */,
+				1AA91DC622B0356000BF0BDE /* CustomLogger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5230,6 +5235,7 @@
 				9343F191207D636300F19A89 /* NotificationTest.swift in Sources */,
 				9343F192207D636300F19A89 /* DatabaseTest.swift in Sources */,
 				9343F193207D636300F19A89 /* CBLTestHelper.m in Sources */,
+				1AA91DC722B0356000BF0BDE /* CustomLogger.swift in Sources */,
 				9343F194207D636300F19A89 /* FragmentTest.swift in Sources */,
 				9343F195207D636300F19A89 /* QueryTest.swift in Sources */,
 				1AA3D6C222A1A41F0098E16B /* ReplicatorTest+CustomConflict.swift in Sources */,

--- a/Swift/Tests/CustomLogger.swift
+++ b/Swift/Tests/CustomLogger.swift
@@ -1,0 +1,37 @@
+//
+//  CustomLogger.swift
+//  CouchbaseLite
+//
+//  Copyright (c) 2018 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import CouchbaseLiteSwift
+
+class CustomLogger: Logger {
+    
+    var lines: [String] = []
+    
+    var level: LogLevel = .none
+    
+    func reset() {
+        lines.removeAll()
+    }
+    
+    func log(level: LogLevel, domain: LogDomain, message: String) {
+        lines.append(message)
+    }
+    
+}

--- a/Swift/Tests/LogTest.swift
+++ b/Swift/Tests/LogTest.swift
@@ -117,7 +117,7 @@ class LogTest: CBLTestCase {
     
     func testCustomLoggingLevels() throws {
         Log.log(domain: .database, level: .info, message: "IGNORE")
-        let customLogger = LogTestLogger()
+        let customLogger = CustomLogger()
         Database.log.custom = customLogger
         
         for i in (1...5).reversed() {
@@ -255,7 +255,7 @@ class LogTest: CBLTestCase {
     
     func testEnableAndDisableCustomLogging() throws {
         Log.log(domain: .database, level: .info, message: "IGNORE")
-        let customLogger = LogTestLogger()
+        let customLogger = CustomLogger()
         Database.log.custom = customLogger
         
         customLogger.level = .none
@@ -354,7 +354,7 @@ class LogTest: CBLTestCase {
     }
     
     func testNonASCII() throws {
-        let customLogger = LogTestLogger()
+        let customLogger = CustomLogger()
         customLogger.level = .verbose
         Database.log.custom = customLogger
         Database.log.console.domains = .all
@@ -382,7 +382,7 @@ class LogTest: CBLTestCase {
     }
     
     func testPercentEscape() throws {
-        let customLogger = LogTestLogger()
+        let customLogger = CustomLogger()
         customLogger.level = .info
         Database.log.custom = customLogger
         Database.log.console.domains = .all
@@ -396,22 +396,6 @@ class LogTest: CBLTestCase {
         }
         XCTAssert(found)
     }
-}
-
-class LogTestLogger: Logger {
-    
-    var lines: [String] = []
-    
-    var level: LogLevel = .none
-    
-    func reset() {
-        lines.removeAll()
-    }
-    
-    func log(level: LogLevel, domain: LogDomain, message: String) {
-        lines.append(message)
-    }
-    
 }
 
 struct FileLoggerBackup {

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -356,8 +356,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
     }
     
     
-    // TODO: enable as a separate PR
-    func _testConflictResolverWrongDocID() throws {
+    func testConflictResolverWrongDocID() throws {
         let docID = "doc"
         let localData = ["key1": "value1"]
         let remoteData = ["key2": "value2"]
@@ -366,31 +365,33 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         
         try makeConflict(forID: docID, withLocal: localData, withRemote: remoteData)
         resolver = TestConflictResolver() { (conflict) -> Document? in
-            return MutableDocument(id: "wrong-doc-id")
+            let mDoc = MutableDocument(id: "wrong-doc-id")
+            mDoc.setString("update", forKey: "edit")
+            return mDoc
         }
         config.conflictResolver = resolver
         var token: ListenerToken!
         var replicator: Replicator!
-        var error: NSError?
+        var docIds = Set<String>()
         run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
             replicator = repl
             token = repl.addDocumentReplicationListener()  { (docRepl) in
-                if let err = docRepl.documents.first?.error as NSError? {
-                    error = err
-                    XCTAssertEqual(err.code, CBLErrorConflict)
-                    XCTAssertEqual(err.domain, CBLErrorDomain)
+                if docRepl.documents.count != 0 {
+                    XCTAssertEqual(docRepl.documents.count, 1)
+                    docIds.insert(docRepl.documents.first!.id)
                 }
+                
+                // shouldn't report an error from replicator
+                XCTAssertNil(docRepl.documents.first?.error)
             }
         })
         
-        XCTAssertNotNil(error)
+        // validate wrong doc-id is resolved successfully
+        XCTAssertEqual(db.count, 1)
+        XCTAssert(docIds.contains(docID))
+        XCTAssert(db.document(withID: docID)!.toDictionary() == ["edit": "update"])
+        
         replicator.removeChangeListener(withToken: token)
-        resolver = TestConflictResolver() { (conflict) -> Document? in
-            return conflict.remoteDocument
-        }
-        config.conflictResolver = resolver
-        run(config: config, expectedError: nil)
-        XCTAssert(db.document(withID: docID)!.toDictionary() == remoteData)
     }
     
     func testConflictResolverDifferentDBDoc() throws {


### PR DESCRIPTION
* corrected the wrong doc id test case, to incorporate the update. 
* extracted CustomLogger from LogTest and kept separate, so we can validate any log messages
* validated the warning log when there is a wrong doc-id is passed and resolves