### PR TITLE
fix: error caught and update ReplicatedDocument.error

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1114,7 +1114,6 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
                 @try {
                     // Unless the remote revision is being used as-is, we need a new revision:
                     mergedBody = [resolvedDoc encode: outError];
-
                 } @catch (NSException *ex) {
                     CBLWarn(Sync, @"Exception while encoding the doc '%@' body: %@",
                             resolvedDoc.id, ex.description);
@@ -1123,7 +1122,6 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
                                                 userInfo: @{NSLocalizedDescriptionKey: ex.description}];
                     return false;
                 }
-                
                 if (!mergedBody)
                     return false;
                 isDeleted = resolvedDoc.isDeleted;

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1111,8 +1111,19 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration* config) {
         if (resolvedDoc != remoteDoc) {
             BOOL isDeleted = YES;
             if (resolvedDoc) {
-                // Unless the remote revision is being used as-is, we need a new revision:
-                mergedBody = [resolvedDoc encode: outError];
+                @try {
+                    // Unless the remote revision is being used as-is, we need a new revision:
+                    mergedBody = [resolvedDoc encode: outError];
+
+                } @catch (NSException *ex) {
+                    CBLWarn(Sync, @"Exception while encoding the doc '%@' body: %@",
+                            resolvedDoc.id, ex.description);
+                    *outError = [NSError errorWithDomain: CBLErrorDomain
+                                                    code: CBLErrorUnexpectedError
+                                                userInfo: @{NSLocalizedDescriptionKey: ex.description}];
+                    return false;
+                }
+                
                 if (!mergedBody)
                     return false;
                 isDeleted = resolvedDoc.isDeleted;

--- a/Objective-C/CBLDocumentReplication.mm
+++ b/Objective-C/CBLDocumentReplication.mm
@@ -80,5 +80,4 @@
     _error = error;
 }
 
-
 @end

--- a/Objective-C/CBLDocumentReplication.mm
+++ b/Objective-C/CBLDocumentReplication.mm
@@ -45,7 +45,7 @@
 
 @implementation CBLReplicatedDocument
 
-@synthesize id=_id, flags=_flags, c4Error=_c4Error, isTransientError=_isTransientError;
+@synthesize id=_id, flags=_flags, c4Error=_c4Error, isTransientError=_isTransientError, error=_error;
 
 - (instancetype) initWithC4DocumentEnded: (const C4DocumentEnded*)docEnded {
     self = [super init];
@@ -59,6 +59,11 @@
             _flags |= kCBLDocumentFlagsAccessRemoved;
         
         _c4Error = docEnded->error;
+        if (_c4Error.code) {
+            NSError* error;
+            convertError(_c4Error, &error);
+            _error = error;
+        }
         
         _isTransientError = docEnded->errorIsTransient;
     }
@@ -67,17 +72,13 @@
 
 
 - (void) resetError {
-    _c4Error = {};
+    _error = nil;
 }
 
 
-- (NSError*) error {
-    if (_c4Error.code) {
-        NSError* error;
-        convertError(_c4Error, &error);
-        return error;
-    }
-    return nil;
+- (void) updateError: (NSError*)error {
+    _error = error;
 }
+
 
 @end

--- a/Objective-C/CBLDocumentReplication.mm
+++ b/Objective-C/CBLDocumentReplication.mm
@@ -72,6 +72,7 @@
 
 
 - (void) resetError {
+    _c4Error = {};
     _error = nil;
 }
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -566,6 +566,7 @@ static void onDocsEnded(C4Replicator *repl,
             } else {
                 CBLWarn(Sync, @"%@: Conflict resolution of '%@' failed: %@",
                         self, doc.id, error);
+                [doc updateError: error];
             }
         }
         

--- a/Objective-C/Internal/Replicator/CBLDocumentReplication+Internal.h
+++ b/Objective-C/Internal/Replicator/CBLDocumentReplication+Internal.h
@@ -41,6 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) resetError;
 
+- (void) updateError: (NSError*)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -2011,6 +2011,7 @@
     [replicatedDoc resetError];
     AssertEqual(replicatedDoc.c4Error.code, 0);
     AssertEqual(replicatedDoc.c4Error.domain, 0);
+    AssertNil(replicatedDoc.error);
 }
 
 @end

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -43,8 +43,8 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
     }
     
     func makeConflict(forID docID: String,
-                      withLocal localData: [String: String],
-                      withRemote remoteData: [String: String]) throws {
+                      withLocal localData: [String: Any],
+                      withRemote remoteData: [String: Any]) throws {
         // create doc
         let doc = createDocument(docID)
         try saveDocument(doc)
@@ -464,6 +464,54 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         config.conflictResolver = resolver
         run(config: config, expectedError: nil)
         XCTAssert(db.document(withID: docID)!.toDictionary() == remoteData)
+    }
+    
+    func testConflictResolverReturningBlobFromDifferentDB() throws {
+        let docID = "doc"
+        let content = "I am a blob".data(using: .utf8)!
+        let blob = Blob(contentType: "text/plain", data: content)
+        let localData: [String: Any] = ["key1": "value1"]
+        let remoteData: [String: Any] = ["key2": "value2", "blob": blob]
+        let config = getConfig(.pull)
+        var resolver: TestConflictResolver!
+        
+        // using remote document blob is okay to use!
+        try makeConflict(forID: docID, withLocal: localData, withRemote: remoteData)
+        resolver = TestConflictResolver() { (conflict) -> Document? in
+            let mDoc = conflict.localDocument?.toMutable()
+            mDoc?.setBlob(conflict.remoteDocument?.blob(forKey: "blob"), forKey: "blob")
+            return mDoc
+        }
+        config.conflictResolver = resolver
+        var token: ListenerToken!
+        var replicator: Replicator!
+        run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
+            replicator = repl
+            token = repl.addDocumentReplicationListener({ (docRepl) in
+                XCTAssertNil(docRepl.documents.first?.error)
+            })
+        })
+        replicator.removeChangeListener(withToken: token)
+        
+        // using blob from remote document of user's- which is a different database
+        let otherDBDoc = otherDB.document(withID: docID)!
+        try makeConflict(forID: docID, withLocal: localData, withRemote: remoteData)
+        resolver = TestConflictResolver() { (conflict) -> Document? in
+            let mDoc = conflict.localDocument?.toMutable()
+            mDoc?.setBlob(otherDBDoc.blob(forKey: "blob"), forKey: "blob")
+            return mDoc
+        }
+        config.conflictResolver = resolver
+        run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
+            replicator = repl
+            token = repl.addDocumentReplicationListener({ (docRepl) in
+                if let err = docRepl.documents.first?.error as NSError? {
+                    XCTAssertEqual(err.code, CBLErrorUnexpectedError)
+                }
+            })
+        })
+        
+        replicator.removeChangeListener(withToken: token)
     }
     
     #endif


### PR DESCRIPTION
* previously, if the error happened during the conflict was not updating the existing c4Error. Now updated.
* add test to verify if the blob which is from a different database saved, returns error which traverse back to document-replication-listener.