### PR TITLE
CBL-72: unit: save handler cancel in swift

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -3024,11 +3024,11 @@
 				938195D91EBCD5F70032CC51 /* Replicator */,
 				9388CBE521BF717C005CA66D /* Log */,
 				934F4C931E241FB500F90659 /* Internal */,
+				93BFCD931E0380A300E52F8A /* Tests */,
 				9398D9FD1E03531A00464432 /* CouchbaseLite.h */,
 				275FF6BE1E48081B005F90DD /* CouchbaseLite.exp */,
 				93C65C59203CCC2500384F6E /* CouchbaseLite-EE.exp */,
 				9398D9FE1E03531A00464432 /* Info.plist */,
-				93BFCD931E0380A300E52F8A /* Tests */,
 			);
 			path = "Objective-C";
 			sourceTree = "<group>";

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -374,8 +374,7 @@ class DatabaseTest: CBLTestCase {
     
     // MARK: Save Conflict Resolution Handler
     
-    func testConflictResolution() throws
-    {
+    func testConflictResolution() throws {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
@@ -399,10 +398,10 @@ class DatabaseTest: CBLTestCase {
         doc1b.setString("Lion", forKey: "middleName")
         
         // merge the dictionaries, and keeping the doc1b dictionary values if duplicate comes in.
-        try db.saveDocument(doc1b) { (cur, old) -> Bool in
-            let merged = cur.toDictionary()
+        try db.saveDocument(doc1b) { (doc, old) -> Bool in
+            let merged = doc.toDictionary()
                 .merging(old!.toDictionary(), uniquingKeysWith: { (first, _) in first })
-            cur.setData(merged)
+            doc.setData(merged)
             return true
         }
         let savedDoc = db.document(withID: doc1b.id)!
@@ -410,6 +409,44 @@ class DatabaseTest: CBLTestCase {
                                                   "nickName": "Scotty", // merged
                                                   "lastName": "Tiger",  // NA
                                                   "middleName": "Lion"]) // conflicting update
+    }
+    
+    func testCancelConflictHandler() throws {
+        let doc = createDocument("doc1")
+        doc.setString("Daniel", forKey: "firstName")
+        doc.setString("Tiger", forKey: "lastName")
+        try db.saveDocument(doc)
+        
+        // create conflict and return false
+        var doc1a = db.document(withID: doc.id)!.toMutable()
+        var doc1b = db.document(withID: doc.id)!.toMutable()
+        doc1a.setString("Scott", forKey: "firstName")
+        try db.saveDocument(doc1a)
+        doc1b.setString("Lion", forKey: "middleName")
+        XCTAssertFalse(try db.saveDocument(doc1b) { (doc, old) -> Bool in
+            XCTAssert(doc1b == doc)
+            XCTAssertEqual(doc1a, old)
+            return false
+            })
+        
+        // check it is same as old doc, and didn't updated the doc
+        XCTAssertEqual(db.document(withID: doc1b.id)!, doc1a)
+        
+        // Updates to Current Mutable Document, should not save contents.
+        // create conflict, update the mutable doc, and return false
+        doc1a = db.document(withID: doc.id)!.toMutable()
+        doc1b = db.document(withID: doc.id)!.toMutable()
+        doc1a.setString("Sccotty", forKey: "nickname")
+        try db.saveDocument(doc1a)
+        doc1b.setString("Scotty", forKey: "nickname")
+        XCTAssertFalse(try db.saveDocument(doc1b) { (doc, old) -> Bool in
+            XCTAssert(doc1b == doc)
+            XCTAssertEqual(doc1a, old)
+            doc.setString("Scott", forKey: "nickname")
+            return false
+            })
+        // check whether it is same old doc, and no update happened.
+        XCTAssertEqual(db.document(withID: doc1b.id)!, doc1a)
     }
     
     


### PR DESCRIPTION
* check when save handler return false, in swift .
* Tests folder kept near the folders, and files below the folder for objc.
* rename the cur to use doc for save handler test method.
* minor open bracket kept same line and not next line.

#2430 
