### PR TITLE
Make conflict resolution concurrent and defer stopped until done 

### DIFF
--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -52,9 +52,10 @@ typedef NS_ENUM(uint32_t, CBLCustomWebSocketCloseCode) {
 }
 
 @property (readonly, atomic) BOOL active;
-@property (atomic) BOOL suspended;
 @property (nonatomic) MYBackgroundMonitor* bgMonitor;
 @property (readonly, atomic) dispatch_queue_t dispatchQueue;
+
+- (void) setSuspended: (BOOL)suspended;
 
 @end
 


### PR DESCRIPTION
1. Refactored the replicator to use an enum state to control start, stop, and suspend.
2. Made conflict resolution concurrent and defer stopped until done. 
3. Moved the logic to remove from the active replicator list to the stopped method so that the logic could go along with updating/posting stopped status.