### PR TITLE
Made conflict resolution concurrent and defer stopped until done

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -352,7 +352,7 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
         }
         
         // Post status update:
-        [self updateStatusAndPost: YES];
+        [self updateAndPostStatus];
     }
 }
 
@@ -491,7 +491,7 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
             } else
                 [self stopped];
         } else
-            [self updateStatusAndPost: YES];
+            [self updateAndPostStatus];
         
         if (shouldUnsuspend)
             [self retry: YES];
@@ -539,7 +539,7 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
 }
 
 
-- (void) updateStatusAndPost: (BOOL)post {
+- (void) updateAndPostStatus {
     NSError *error = nil;
     if (_rawStatus.error.code)
         convertError(_rawStatus.error, &error);
@@ -550,8 +550,7 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
                self, kC4ReplicatorActivityLevelNames[_rawStatus.level],
                _rawStatus.progress.unitsCompleted, _rawStatus.progress.unitsTotal, self.status.error);
     
-    if (post)
-        [_changeNotifier postChange: [[CBLReplicatorChange alloc] initWithReplicator: self
+    [_changeNotifier postChange: [[CBLReplicatorChange alloc] initWithReplicator: self
                                                                               status: self.status]];
 }
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -118,7 +118,7 @@ typedef enum {
         _docReplicationNotifier = [CBLChangeNotifier new];
         _status = [[CBLReplicatorStatus alloc] initWithStatus: {kC4Stopped, {}, {}}];
         
-        NSString* qName = $sprintf(@"Replicator <%@>", [self description]);
+        NSString* qName = self.description;
         _dispatchQueue = dispatch_queue_create(qName.UTF8String, DISPATCH_QUEUE_SERIAL);
         
         NSString* cqName = $sprintf(@"%@ : Conflicts", qName);
@@ -140,19 +140,20 @@ typedef enum {
 
 
 - (NSString*) description {
-    return [NSString stringWithFormat: @"%@[%s%s%s %@]",
-            self.class,
-            (isPull(_config.replicatorType) ? "<" : ""),
-            (_config.continuous ? "*" : "-"),
-            (isPush(_config.replicatorType)  ? ">" : ""),
-            _config.target];
+    if (!_desc)
+        _desc = [NSString stringWithFormat: @"%@[%s%s%s %@]",
+                 self.class,
+                 (isPull(_config.replicatorType) ? "<" : ""),
+                 (_config.continuous ? "*" : "-"),
+                 (isPush(_config.replicatorType)  ? ">" : ""),
+                 _config.target];
+    return _desc;
 }
 
 
 - (void) clearRepl {
     c4repl_free(_repl);
     _repl = nullptr;
-    _desc = nil;
 }
 
 
@@ -187,8 +188,6 @@ typedef enum {
 
 
 - (void) _start {
-    _desc = self.description;   // cache description; it may be called a lot when logging
-    
     // Target:
     id<CBLEndpoint> endpoint = _config.target;
     C4Address addr = {};

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -341,8 +341,17 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
 - (void) stopped {
     CBL_LOCK(self) {
         Assert(_rawStatus.level == kC4Stopped);
+        // Update state:
         _state = kCBLStateStopped;
         _deferStoppedNotification = NO;
+        
+        // Prevent self to get released when removing from the active replications:
+        CBLReplicator* repl = self;
+        CBL_LOCK(_config.database) {
+            [_config.database.activeReplications removeObject: repl];
+        }
+        
+        // Post status update:
         [self updateStatusAndPost: YES];
     }
 }
@@ -455,15 +464,6 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
         } else if (c4Status.level > kC4Connecting) {
             _retryCount = 0;
             [self stopReachabilityObserver];
-        }
-        
-        // Prevent self to get released when removing from the active replications:
-        CBLReplicator* repl = self;
-        if (c4Status.level == kC4Stopped) {
-            CBL_LOCK(_config.database) {
-                // Remove from the active replications before posting change:
-                [_config.database.activeReplications removeObject: repl];
-            }
         }
         
         // Record raw status:

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -52,9 +52,10 @@ typedef NS_ENUM(uint32_t, CBLCustomWebSocketCloseCode) {
 }
 
 @property (readonly, atomic) BOOL active;
-@property (atomic) BOOL suspended;
 @property (nonatomic) MYBackgroundMonitor* bgMonitor;
 @property (readonly, atomic) dispatch_queue_t dispatchQueue;
+
+- (void) setSuspended: (BOOL)suspended;
 
 @end
 


### PR DESCRIPTION
1. Refactored the replicator to use an enum state to control start, stop, and suspend.
2. Made conflict resolution concurrent and defer stopped until done.
3. Moved the logic to remove from the active replicator list to the stopped method so that the logic could go along with updating/posting stopped status.