### PR TITLE
Fix break point in replicator tests when an exception is thrown

### DIFF
--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -319,7 +319,8 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady
         [self waitForExpectations: @[x] timeout: timeout];
     }
     @finally {
-        [replicator stop];
+        if (replicator.status.activity != kCBLReplicatorStopped)
+            [replicator stop];
         [replicator removeChangeListenerWithToken: token];
     }
     return fulfilled;

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -312,7 +312,9 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         resolver = TestConflictResolver() { [unowned self] (conflict) -> Document? in
             return self.otherDB.document(withID: "doc")
         }
-        try validateDocumentReplicationEventForConflictedDocs(resolver)
+        ignoreException {
+            try self.validateDocumentReplicationEventForConflictedDocs(resolver)
+        }
         
         // when resolution is successfull but wrong docID
         resolver = TestConflictResolver() { (conflict) -> Document? in
@@ -419,16 +421,20 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         var token: ListenerToken!
         var replicator: Replicator!
         var error: NSError?
-        run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
-            replicator = repl
-            token = repl.addDocumentReplicationListener({ (docRepl) in
-                if let err = docRepl.documents.first?.error as NSError? {
-                    error = err
-                    XCTAssertEqual(err.code, CBLErrorConflict)
-                    XCTAssertEqual(err.domain, CBLErrorDomain)
-                }
+        
+        ignoreException {
+            self.run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
+                replicator = repl
+                token = repl.addDocumentReplicationListener({ (docRepl) in
+                    if let err = docRepl.documents.first?.error as NSError? {
+                        error = err
+                        XCTAssertEqual(err.code, CBLErrorConflict)
+                        XCTAssertEqual(err.domain, CBLErrorDomain)
+                    }
+                })
             })
-        })
+        }
+        
         XCTAssertNotNil(error)
         replicator.removeChangeListener(withToken: token)
         resolver = TestConflictResolver() { (conflict) -> Document? in
@@ -457,16 +463,20 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         var token: ListenerToken!
         var replicator: Replicator!
         var error: NSError?
-        run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
-            replicator = repl
-            token = repl.addDocumentReplicationListener({ (docRepl) in
-                if let err = docRepl.documents.first?.error as NSError? {
-                    error = err
-                    XCTAssertEqual(err.code, CBLErrorConflict)
-                    XCTAssertEqual(err.domain, CBLErrorDomain)
-                }
+        
+        ignoreException {
+            self.run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
+                replicator = repl
+                token = repl.addDocumentReplicationListener({ (docRepl) in
+                    if let err = docRepl.documents.first?.error as NSError? {
+                        error = err
+                        XCTAssertEqual(err.code, CBLErrorConflict)
+                        XCTAssertEqual(err.domain, CBLErrorDomain)
+                    }
+                })
             })
-        })
+        }
+        
         XCTAssertNotNil(error)
         replicator.removeChangeListener(withToken: token)
         resolver = TestConflictResolver() { (conflict) -> Document? in
@@ -627,14 +637,16 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
             return mDoc
         }
         config.conflictResolver = resolver
-        run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
-            replicator = repl
-            token = repl.addDocumentReplicationListener({ (docRepl) in
-                if let err = docRepl.documents.first?.error as NSError? {
-                    XCTAssertEqual(err.code, CBLErrorUnexpectedError)
-                }
+        ignoreException {
+            self.run(config: config, reset: false, expectedError: nil, onReplicatorReady: {(repl) in
+                replicator = repl
+                token = repl.addDocumentReplicationListener({ (docRepl) in
+                    if let err = docRepl.documents.first?.error as NSError? {
+                        XCTAssertEqual(err.code, CBLErrorUnexpectedError)
+                    }
+                })
             })
-        })
+        }
         
         replicator.removeChangeListener(withToken: token)
     }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -95,7 +95,9 @@ class ReplicatorTest: CBLTestCase {
         replicator.start()
         wait(for: [x], timeout: 5.0)
         
-        replicator.stop()
+        if replicator.status.activity != .stopped {
+            replicator.stop()
+        }
         replicator.removeChangeListener(withToken: token)
     }
 }


### PR DESCRIPTION
* Wrapped the replicator tests that have an expcetion thrown in either ignoreException() or expectException() so that the tests will not be breaked.
* In ReplicatorTest.run(), check if the replicator is stopped or not before calling stop() to avoid the warning message.