### PR TITLE
Fix VALID_ARCHS mapping warnings

### DIFF
--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -32,7 +32,6 @@ ONLY_ACTIVE_ARCH                   = NO
 SKIP_INSTALL                       = YES
 SUPPORTED_PLATFORMS                = macosx iphoneos iphonesimulator appletvos appletvsimulator
 TARGETED_DEVICE_FAMILY             = 1,2
-VALID_ARCHS                        = arm64 armv7 armv7a x86_64 i386
 
 ALWAYS_SEARCH_USER_PATHS           = NO
 


### PR DESCRIPTION
Removed VALID_ARCHS manual settings to use the default valid arcs automatically determined by the SDK parameter of the xcodebuild command.