### PR TITLE
Fix CBL-107 Swift XCode editor crash due to BridgingConflictResolver

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -210,6 +210,10 @@
 		932565BF21ED16BF0092F4E0 /* CBLLogFileConfiguration+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 932565BB21ED16BF0092F4E0 /* CBLLogFileConfiguration+Internal.h */; };
 		932565C121ED51290092F4E0 /* LogFileConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932565C021ED51290092F4E0 /* LogFileConfiguration.swift */; };
 		932565C221ED51290092F4E0 /* LogFileConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932565C021ED51290092F4E0 /* LogFileConfiguration.swift */; };
+		93292D9E22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 93292D9C22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		93292D9F22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 93292D9C22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		93292DA022BD448400A0862A /* CBLReplicatorConfiguration+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = 93292D9D22BD448400A0862A /* CBLReplicatorConfiguration+Swift.m */; };
+		93292DA122BD448400A0862A /* CBLReplicatorConfiguration+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = 93292D9D22BD448400A0862A /* CBLReplicatorConfiguration+Swift.m */; };
 		932CC557207D9ED2000B4B78 /* CBLDatabaseEndpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 932CC552207D9ED2000B4B78 /* CBLDatabaseEndpoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		932CC558207D9ED2000B4B78 /* CBLDatabaseEndpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 932CC552207D9ED2000B4B78 /* CBLDatabaseEndpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		932CC559207D9ED2000B4B78 /* CouchbaseLite.h in Headers */ = {isa = PBXBuildFile; fileRef = 932CC553207D9ED2000B4B78 /* CouchbaseLite.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1748,6 +1752,8 @@
 		932565A321ED13290092F4E0 /* CBLLogFileConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLLogFileConfiguration.m; sourceTree = "<group>"; };
 		932565BB21ED16BF0092F4E0 /* CBLLogFileConfiguration+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLLogFileConfiguration+Internal.h"; sourceTree = "<group>"; };
 		932565C021ED51290092F4E0 /* LogFileConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFileConfiguration.swift; sourceTree = "<group>"; };
+		93292D9C22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLReplicatorConfiguration+Swift.h"; sourceTree = "<group>"; };
+		93292D9D22BD448400A0862A /* CBLReplicatorConfiguration+Swift.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CBLReplicatorConfiguration+Swift.m"; sourceTree = "<group>"; };
 		932CC552207D9ED2000B4B78 /* CBLDatabaseEndpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLDatabaseEndpoint.h; sourceTree = "<group>"; };
 		932CC553207D9ED2000B4B78 /* CouchbaseLite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CouchbaseLite.h; sourceTree = "<group>"; };
 		932CC554207D9ED2000B4B78 /* CBLDatabaseEndpoint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLDatabaseEndpoint.m; sourceTree = "<group>"; };
@@ -2280,6 +2286,7 @@
 			isa = PBXGroup;
 			children = (
 				937F01E51EFB280000060D64 /* CBLAuthenticator+Internal.h */,
+				1AAB273F2273AB420037A880 /* CBLConflict+Internal.h */,
 				935A58CD21AFAD31009A29CB /* CBLDocumentReplication+Internal.h */,
 				2753AFF11EC39CA200C12E98 /* CBLHTTPLogic.h */,
 				2753AFF21EC39CA200C12E98 /* CBLHTTPLogic.m */,
@@ -2294,7 +2301,8 @@
 				9374A851201165AE00BA0D9E /* CBLURLEndpoint+Internal.h */,
 				2753AFF31EC39CA200C12E98 /* CBLWebSocket.h */,
 				2753AFF41EC39CA200C12E98 /* CBLWebSocket.mm */,
-				1AAB273F2273AB420037A880 /* CBLConflict+Internal.h */,
+				93292D9C22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h */,
+				93292D9D22BD448400A0862A /* CBLReplicatorConfiguration+Swift.m */,
 			);
 			path = Replicator;
 			sourceTree = "<group>";
@@ -3371,6 +3379,7 @@
 				932565BD21ED16BF0092F4E0 /* CBLLogFileConfiguration+Internal.h in Headers */,
 				939B1B602009C0F200FAA3CB /* CBLQueryVariableExpression+Internal.h in Headers */,
 				938196341EC15F890032CC51 /* CBLStatus.h in Headers */,
+				93292D9E22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h in Headers */,
 				9381962D1EC15F470032CC51 /* CBLData.h in Headers */,
 				933207AF1E773CFB000D9993 /* CBLJSONCoding.h in Headers */,
 				270AB2BD2073EF57009A4596 /* CBLChangeNotifier.h in Headers */,
@@ -3647,6 +3656,7 @@
 			files = (
 				1AAB2784227793DE0037A880 /* CBLConflict.h in Headers */,
 				9343F0B5207D61AB00F19A89 /* CBLQueryResultArray.h in Headers */,
+				93292D9F22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h in Headers */,
 				9343F0B6207D61AB00F19A89 /* CBLReachability.h in Headers */,
 				9343F0B7207D61AB00F19A89 /* CBLQueryResult+Internal.h in Headers */,
 				9388CC5B21C25FDE005CA66D /* CBLLog+Swift.h in Headers */,
@@ -4636,6 +4646,7 @@
 				9383A58D1F1EE8EF0083053D /* CBLQueryResult.mm in Sources */,
 				934A27D51F310764003946A7 /* ArrayExpressionSatisfies.swift in Sources */,
 				933F45F51EC29EF100863ECB /* MutableFragment.swift in Sources */,
+				93292DA022BD448400A0862A /* CBLReplicatorConfiguration+Swift.m in Sources */,
 				93CED8CF20488C4000E6F0A4 /* ListenerToken.swift in Sources */,
 				938196161EC113650032CC51 /* CBLDocumentFragment.m in Sources */,
 				9322DCE21F14603400C4ACF7 /* CBLQueryLimit.m in Sources */,
@@ -5024,6 +5035,7 @@
 				9343F05E207D61AB00F19A89 /* CBLReachability.m in Sources */,
 				9343F05F207D61AB00F19A89 /* FullTextExpression.swift in Sources */,
 				9343F060207D61AB00F19A89 /* CBLData.mm in Sources */,
+				93292DA122BD448400A0862A /* CBLReplicatorConfiguration+Swift.m in Sources */,
 				9343F062207D61AB00F19A89 /* ArrayExpressionIn.swift in Sources */,
 				93D7FA8D20A4CB0400EC54A4 /* MessageEndpointListener.swift in Sources */,
 				9369A6B5207DE722009B5B83 /* EncryptionKey.swift in Sources */,

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -18,6 +18,7 @@
 //
 
 #import "CBLReplicatorConfiguration.h"
+#import "CBLReplicatorConfiguration+Swift.h"
 #import "CBLAuthenticator+Internal.h"
 #import "CBLReplicator+Internal.h"
 #import "CBLDatabase+Internal.h"

--- a/Objective-C/Internal/Replicator/CBLReplicatorConfiguration+Swift.h
+++ b/Objective-C/Internal/Replicator/CBLReplicatorConfiguration+Swift.h
@@ -1,0 +1,53 @@
+//
+//  CBLReplicatorConfiguration+Swift.h
+//  CouchbaseLite
+//
+//  Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "CBLReplicatorConfiguration.h"
+#import "CBLConflictResolver.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef CBLDocument* __nullable (^CBLConflictResolverBlock)(CBLConflict*);
+
+/**
+ * As CBLConflictResolver definition will not be exposed to CBL Swift Public API,
+ * defining a bridging resolver class in Swift could cause the Swift editor to crash.
+ * The solution here is allow Swift ReplicatorConfiguration to set the conflict resolver
+ * using a resolver block and CBLReplicatorConfiguration will create an internal bridging
+ * conflict resolver that will call into the resolver block to get the result.
+ */
+@interface CBLReplicatorConfiguration (Swift)
+
+- (void) setConflictResolverUsingBlock: (_Nullable CBLConflictResolverBlock)block;
+
+@end
+
+/**
+ * Bridging Conflict Resolver for CBL Swift
+ */
+@interface CBLConflictResolverBridge: NSObject<CBLConflictResolver>
+
+// set this resolver, which will be used while resolving the conflict
+- (instancetype) initWithResolverBlock: (CBLConflictResolverBlock)resolver;
+
+- (instancetype) init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/Replicator/CBLReplicatorConfiguration+Swift.m
+++ b/Objective-C/Internal/Replicator/CBLReplicatorConfiguration+Swift.m
@@ -1,0 +1,49 @@
+//
+//  CBLReplicatorConfiguration+Swift.m
+//  CouchbaseLite
+//
+//  Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "CBLReplicatorConfiguration+Swift.h"
+
+@implementation CBLReplicatorConfiguration (Swift)
+
+- (void) setConflictResolverUsingBlock: (CBLConflictResolverBlock)block {
+    if (block)
+        self.conflictResolver = [[CBLConflictResolverBridge alloc] initWithResolverBlock: block];
+    else
+        self.conflictResolver = nil;
+}
+
+@end
+
+@implementation CBLConflictResolverBridge {
+    CBLConflictResolverBlock _resolver;
+}
+
+- (instancetype) initWithResolverBlock: (CBLConflictResolverBlock)resolver {
+    self = [super init];
+    if (self) {
+        _resolver = resolver;
+    }
+    return self;
+}
+
+- (CBLDocument*) resolve: (CBLConflict *)conflict {
+    return _resolver(conflict);
+}
+
+@end

--- a/Swift/CouchbaseLiteSwift-EE.modulemap
+++ b/Swift/CouchbaseLiteSwift-EE.modulemap
@@ -92,6 +92,7 @@ framework module CouchbaseLiteSwift {
         // Swift Extensions:
         header "CBLArray+Swift.h"
         header "CBLBlob+Swift.h"
+        header "CBLReplicatorConfiguration+Swift.h"
         header "CBLDatabase+Swift.h"
         header "CBLDictionary+Swift.h"
         header "CBLLog+Swift.h"

--- a/Swift/CouchbaseLiteSwift.modulemap
+++ b/Swift/CouchbaseLiteSwift.modulemap
@@ -92,6 +92,7 @@ framework module CouchbaseLiteSwift {
         // Swift Extensions:
         header "CBLArray+Swift.h"
         header "CBLBlob+Swift.h"
+        header "CBLReplicatorConfiguration+Swift.h"
         header "CBLDatabase+Swift.h"
         header "CBLDictionary+Swift.h"
         header "CBLLog+Swift.h"


### PR DESCRIPTION
* BridgingConflictResolver referenced to CBLConflictResolverProtocol which is not visible publicly in CouchbaseLiteSwift.framework, as a result, the swift XCode editor couldn’t fine the definition of CBLConflictResolverProtocol and crashed.

* Bridged between Swift and Objective-C conflict resolver by using Resolver Block instead. The bridging resolver class calling to the Resolver Block is done internally in Objective-C