### PR TITLE
CBL-138: fix: multiple retry logic

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -200,17 +200,19 @@ typedef enum {
 }
 
 - (void) retry {
-    dispatch_async(_dispatchQueue, ^{
-        CBL_LOCK(self) {
-            CBLLogInfo(Sync, @"%@: Retrying...", self);
-            if (_repl || _state <= kCBLStateStopping) {
-                CBLLogInfo(Sync, @"%@: Ignore retrying (state = %d, status = %d)",
-                           self, _state, _rawStatus.level);
-                return;
+    if (_state == kCBLStateOffline || _state == kCBLStateSuspended) {
+        dispatch_async(_dispatchQueue, ^{
+            CBL_LOCK(self) {
+                CBLLogInfo(Sync, @"%@: Retrying...", self);
+                if (_repl || _state <= kCBLStateStopping) {
+                    CBLLogInfo(Sync, @"%@: Ignore retrying (state = %d, status = %d)",
+                               self, _state, _rawStatus.level);
+                    return;
+                }
+                [self _start];
             }
-            [self _start];
-        }
-    });
+        });
+    }
 }
 
 - (void) _start {

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -539,8 +539,7 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
         auto delay = retryDelay(++_retryCount);
         CBLLogInfo(Sync, @"%@: Transient error (%@); will retry in %.0f sec...",
                    self, error.localizedDescription, delay);
-        if (_state == kCBLStateOffline)
-            [self scheduleRetry: delay];
+        [self scheduleRetry: delay];
     } else {
         CBLLogInfo(Sync, @"%@: Network error (%@); will retry when network changes...",
                    self, error.localizedDescription);

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -173,14 +173,12 @@ typedef enum {
 - (void) scheduleRetry: (NSTimeInterval)delay {
     [self cancelPrviousRetry];
     
-    if (_state == kCBLStateOffline) {
-        // to register the perform selector in the main run loop
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self performSelector: @selector(retry)
-                       withObject: nil
-                       afterDelay: delay];
-        });
-    }
+    // to register the perform selector in the main run loop
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self performSelector: @selector(retry)
+                   withObject: nil
+                   afterDelay: delay];
+    });
 }
 
 - (void) resetRetryCount {
@@ -541,7 +539,8 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
         auto delay = retryDelay(++_retryCount);
         CBLLogInfo(Sync, @"%@: Transient error (%@); will retry in %.0f sec...",
                    self, error.localizedDescription, delay);
-        [self scheduleRetry: delay];
+        if (_state == kCBLStateOffline)
+            [self scheduleRetry: delay];
     } else {
         CBLLogInfo(Sync, @"%@: Network error (%@); will retry when network changes...",
                    self, error.localizedDescription);


### PR DESCRIPTION
* cancel the previous retry before starting a new one.
* only allow to retry from specific two states, suspended or offline.
* replicator can start from stopped state but that shouldn't come through a retry but start itself.