### PR TITLE
fix: swift header missing issue

### DIFF
--- a/Swift/Conflict.swift
+++ b/Swift/Conflict.swift
@@ -24,12 +24,12 @@ public struct Conflict {
     
     ///The document id of the conflicting document.
     public var documentID: String {
-        return impl.documentID
+        return toImpl().documentID
     }
     
     /// The document in the local database. If nil, document is deleted.
     public var localDocument: Document? {
-        guard let doc = impl.localDocument else {
+        guard let doc = toImpl().localDocument else {
             return nil
         }
         return Document(doc)
@@ -37,13 +37,23 @@ public struct Conflict {
     
     /// The document replicated from the remote database. If nil, document is deleted.
     public var remoteDocument: Document? {
-        guard let doc = impl.remoteDocument else {
+        guard let doc = toImpl().remoteDocument else {
             return nil
         }
         return Document(doc)
     }
     
     // MARK: Internal
-    let impl: CBLConflict
+    
+    // Use Any to workaround
+    private var impl: Any
+    
+    init(impl: Any) {
+        self.impl = impl
+    }
+    
+    func toImpl() -> CBLConflict {
+        return self.impl as! CBLConflict
+    }
     
 }

--- a/Swift/ConflictResolver.swift
+++ b/Swift/ConflictResolver.swift
@@ -49,7 +49,7 @@ public final class ConflictResolver {
     }
     
     func resolve(conflict: Conflict) -> Document? {
-        guard let doc = resolver.resolve(conflict.impl) else {
+        guard let doc = resolver.resolve(conflict.toImpl()) else {
             return nil
         }
         


### PR DESCRIPTION
* swift was not finding the CBLConflict instance or so. and it was returning an empty instance when used class pointer as variable in struct.
* we suspect it might be due to the removal of private headers
* validated with a sample project