### PR TITLE
fix: changes from cobalt

### DIFF
--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -140,6 +140,8 @@
         _channels = config.channels;
         _pushFilter = config.pushFilter;
         _pullFilter = config.pullFilter;
+        _heartbeatInterval = config.heartbeatInterval;
+        _checkpointInterval = config.checkpointInterval;
 #if TARGET_OS_IPHONE
         _allowReplicatingInBackground = config.allowReplicatingInBackground;
 #endif


### PR DESCRIPTION
* set heartbeat and checkpoint interval
* timeout from the CBL side is removed, and litecore is handling the timeout of 5.0 seconds.