### PR TITLE
CBL-342: fix: race condition

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -288,8 +288,8 @@ typedef enum {
         if (!_repl) {
             NSError *error = nil;
             convertError(err, &error);
-            CBLLogInfo(Sync, @"%@: Replicator cannot be created: %@", self,
-                       error.localizedDescription);
+            CBLWarnError(Sync, @"%@: Replicator cannot be created: %@",
+                         self, error.localizedDescription);
             return;
         }
         c4repl_start(_repl);

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -275,6 +275,7 @@ typedef enum {
         .onDocumentsEnded = &onDocsEnded,
         .callbackContext = (__bridge void*)self,
         .socketFactory = &socketFactory,
+        .dontStart = true,
     };
     
     _state = kCBLStateStarting;
@@ -283,6 +284,15 @@ typedef enum {
     C4Error err;
     CBL_LOCK(_config.database) {
         _repl = c4repl_new(_config.database.c4db, addr, dbName, otherDB.c4db, params, &err);
+        
+        if (!_repl) {
+            NSError *error = nil;
+            convertError(err, &error);
+            CBLLogInfo(Sync, @"%@: Replicator cannot be created: %@", self,
+                       error.localizedDescription);
+            return;
+        }
+        c4repl_start(_repl);
     }
     
     C4ReplicatorStatus status;


### PR DESCRIPTION
* when replicator starts before its handle being created the nullptr was returned.
* fix by returning replicator handle, and then start the replicator
* agree with Blake on this. https://github.com/couchbase/couchbase-lite-java/pull/139#discussion_r322407475