### PR TITLE
CBL-418: Throw unsupported error when creating a partial value index

### DIFF
--- a/Objective-C/CBLValueIndex.m
+++ b/Objective-C/CBLValueIndex.m
@@ -24,7 +24,7 @@
 #import "CBLPropertyExpression.h"
 
 #ifdef COUCHBASE_ENTERPRISE
-#import "CBLQueryFunction+Prediction.h"
+#import "CBLFunctionExpression.h"
 #endif
 
 @implementation CBLValueIndex {
@@ -79,11 +79,12 @@
 + (CBLValueIndexItem*) expression: (CBLQueryExpression*)expression {
     CBLAssertNotNil(expression);
     
-    if (!([expression isKindOfClass: [CBLPropertyExpression class]]
-#ifdef COUCHBASE_ENTERPRISE
-        || [expression isKindOfClass: [CBLQueryPredictionFunction class]]
-#endif
-        )) {
+    NSArray* asJson = [expression asJSON];
+    if (!(// prediction function
+          [asJson.firstObject isEqualToString: @"PREDICTION()"] ||
+          // property expression
+          [asJson.firstObject characterAtIndex: 0] == '.'
+          )) {
         [NSException raise: NSInternalInconsistencyException
                     format: @"Partial Indexing is unsupported. Please use "
                     "property or prediction-function"];

--- a/Objective-C/CBLValueIndex.m
+++ b/Objective-C/CBLValueIndex.m
@@ -75,14 +75,13 @@
     CBLAssertNotNil(expression);
     
     NSArray* asJson = [expression asJSON];
-    if (!(// prediction function
-          [asJson.firstObject isEqualToString: @"PREDICTION()"] ||
-          // property expression
-          [asJson.firstObject characterAtIndex: 0] == '.'
-          )) {
+    if (!([asJson.firstObject isEqualToString: @"PREDICTION()"] ||
+          [asJson.firstObject characterAtIndex: 0] == '.')) {
+        
+        // only allow in case of prediction function & property expression
         [NSException raise: NSInternalInconsistencyException
                     format: @"Partial Indexing is unsupported. Please use "
-                    "property or prediction-function"];
+         "property or prediction-function"];
     }
     
     return [[CBLValueIndexItem alloc] initWithExpression: expression];

--- a/Objective-C/CBLValueIndex.m
+++ b/Objective-C/CBLValueIndex.m
@@ -21,6 +21,11 @@
 #import "CBLDatabase+Internal.h"
 #import "CBLIndex+Internal.h"
 #import "CBLQueryExpression+Internal.h"
+#import "CBLPropertyExpression.h"
+
+#ifdef COUCHBASE_ENTERPRISE
+#import "CBLQueryFunction+Prediction.h"
+#endif
 
 @implementation CBLValueIndex {
     NSArray<CBLValueIndexItem*>* _items;
@@ -73,6 +78,16 @@
 
 + (CBLValueIndexItem*) expression: (CBLQueryExpression*)expression {
     CBLAssertNotNil(expression);
+    
+    if (!([expression isKindOfClass: [CBLPropertyExpression class]]
+#ifdef COUCHBASE_ENTERPRISE
+        || [expression isKindOfClass: [CBLQueryPredictionFunction class]]
+#endif
+        )) {
+        [NSException raise: NSInternalInconsistencyException
+                    format: @"Partial Indexing is unsupported. Please use "
+                    "property or prediction-function"];
+    }
     
     return [[CBLValueIndexItem alloc] initWithExpression: expression];
 }

--- a/Objective-C/CBLValueIndex.m
+++ b/Objective-C/CBLValueIndex.m
@@ -21,11 +21,6 @@
 #import "CBLDatabase+Internal.h"
 #import "CBLIndex+Internal.h"
 #import "CBLQueryExpression+Internal.h"
-#import "CBLPropertyExpression.h"
-
-#ifdef COUCHBASE_ENTERPRISE
-#import "CBLFunctionExpression.h"
-#endif
 
 @implementation CBLValueIndex {
     NSArray<CBLValueIndexItem*>* _items;

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2045,17 +2045,13 @@
     CBLQueryExpression* lName = [CBLQueryExpression property: @"lastName"];
     
     CBLQueryExpression* sumExp = [CBLQueryFunction sum: fName];
+    [self expectException: NSInternalInconsistencyException in:^{
+         [CBLValueIndexItem expression: sumExp];
+     }];
+    
     
     [self expectException: NSInternalInconsistencyException in:^{
         [CBLValueIndexItem expression: [fName equalTo: lName]];
-    }];
-    
-    [self expectException: NSInternalInconsistencyException in:^{
-        [CBLValueIndexItem expression: sumExp];
-    }];
-    
-    [self expectException: NSInternalInconsistencyException in:^{
-        [CBLValueIndexItem expression: sumExp];
     }];
    
     CBLQueryVariableExpression* LIKE = [CBLQueryArrayExpression variableWithName: @"LIKE"];
@@ -2074,6 +2070,12 @@
     [self expectException: NSInternalInconsistencyException in:^{
         [CBLValueIndexItem expression: collationExp];
     }];
+    
+#ifdef COUCHBASE_ENTERPRISE
+    id input = EXPR_VAL(@{ @"fname": fName });
+    CBLQueryExpression* sumPrediction = PREDICTION_VALUE(@"name", input, @"sum");
+    [CBLValueIndexItem expression: sumPrediction];
+#endif
 }
 
 @end

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2039,4 +2039,41 @@
     Assert([self.db deleteIndexForName: @"index3" error: &error]);
 }
 
+- (void) testUnsupportedValueIndexItem {
+    // Create value index:
+    CBLQueryExpression* fName = [CBLQueryExpression property: @"firstName"];
+    CBLQueryExpression* lName = [CBLQueryExpression property: @"lastName"];
+    
+    CBLQueryExpression* sumExp = [CBLQueryFunction sum: fName];
+    
+    [self expectException: NSInternalInconsistencyException in:^{
+        [CBLValueIndexItem expression: [fName equalTo: lName]];
+    }];
+    
+    [self expectException: NSInternalInconsistencyException in:^{
+        [CBLValueIndexItem expression: sumExp];
+    }];
+    
+    [self expectException: NSInternalInconsistencyException in:^{
+        [CBLValueIndexItem expression: sumExp];
+    }];
+   
+    CBLQueryVariableExpression* LIKE = [CBLQueryArrayExpression variableWithName: @"LIKE"];
+    CBLQueryExpression* nameLike = [LIKE equalTo: [CBLQueryExpression string: @"mary"]];
+    CBLQueryExpression* arrayExp = [CBLQueryArrayExpression any: LIKE
+                                                             in: fName
+                                                      satisfies: nameLike];
+    [self expectException: NSInternalInconsistencyException in:^{
+        [CBLValueIndexItem expression: arrayExp];
+    }];
+    
+    CBLQueryCollation* collation = [CBLQueryCollation unicodeWithLocale: @"en"
+                                                                 ignoreCase: YES
+                                                              ignoreAccents: YES];
+    CBLQueryExpression* collationExp = [fName collate: collation];
+    [self expectException: NSInternalInconsistencyException in:^{
+        [CBLValueIndexItem expression: collationExp];
+    }];
+}
+
 @end


### PR DESCRIPTION
* only allow in case of prediction function & property expression. else throw an exception.
* test not completed, but will finish when logic works fine.