### PR TITLE
CBL-437: fix: deprecated setlog level method

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -462,6 +462,9 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 + (void) setLogLevel: (CBLLogLevel)level domain: (CBLLogDomain)domain {
     CBLWarn(Database, @"This method has been deprecated. "
             "Please use CBLDatabase.log.console instead of -setLogLevel:domain:.");
+    
+    CBLDatabase.log.console.domains =  domain;
+    CBLDatabase.log.console.level = level;
 }
 
 + (CBLLog*) log {

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -463,7 +463,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     CBLWarn(Database, @"This method has been deprecated. "
             "Please use CBLDatabase.log.console instead of -setLogLevel:domain:.");
     
-    CBLDatabase.log.console.domains =  domain;
+    CBLDatabase.log.console.domains = kCBLLogDomainAll;
     CBLDatabase.log.console.level = level;
 }
 

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -371,7 +371,7 @@ public final class Database {
         Log.log(domain: .database, level: .warning, message:
             "This method has been deprecated. Please use Database.log.console instead of setLogLevel(_, domain:)")
         
-        Database.log.console.domains = LogDomains(rawValue: Int(domain.rawValue))
+        Database.log.console.domains = LogDomains(rawValue: LogDomain.all.hashValue)
         Database.log.console.level = level
     }
     

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -370,6 +370,7 @@ public final class Database {
     public class func setLogLevel(_ level: LogLevel, domain: LogDomain) {
         Log.log(domain: .database, level: .warning, message:
             "This method has been deprecated. Please use Database.log.console instead of setLogLevel(_, domain:)")
+        
         Database.log.console.domains = LogDomains(rawValue: Int(domain.rawValue))
         Database.log.console.level = level
     }

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -370,6 +370,8 @@ public final class Database {
     public class func setLogLevel(_ level: LogLevel, domain: LogDomain) {
         Log.log(domain: .database, level: .warning, message:
             "This method has been deprecated. Please use Database.log.console instead of setLogLevel(_, domain:)")
+        Database.log.console.domains = LogDomains(rawValue: Int(domain.rawValue))
+        Database.log.console.level = level
     }
     
     /// Log object used for configuring console, file, and custom logger.


### PR DESCRIPTION
* before deprecated means, no op. now we set console.log.domain and console.log.level from it.