### PR TITLE
CBL-517: Lazy initialize c4replicator instance

### DIFF
--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -158,9 +158,9 @@ typedef struct {
  change between the time the call was made and the time the call returns.
  
  @param error error On return, the error if any.
- @return A  set of document Ids, each of which has one or more pending revisions
+ @return A  set of document Ids, each of which has one or more pending revisions. If error, nil.
  */
-- (NSSet<NSString*>*) pendingDocumentIds: (NSError**)error;
+- (nullable NSSet<NSString*>*) pendingDocumentIds: (NSError**)error;
 
 /**
  Checks if the document with the given ID has revisions pending push.  This API is a snapshot and results may
@@ -171,7 +171,7 @@ typedef struct {
  @return true if the document has one or more revisions pending, false otherwise
  
  */
-- (BOOL) isDocumentPending: (NSString*)documentID error: (NSError**)error;
+- (BOOL) isDocumentPending: (NSString*)documentID error: (NSError**)error NS_SWIFT_NOTHROW;
 
 @end
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -296,7 +296,7 @@ typedef enum {
 - (void) _start {
     C4Error err;
     C4Replicator* repl = [self c4repl: &err];
-    if (!_repl) {
+    if (!repl) {
         NSError *error = nil;
         convertError(err, &error);
         CBLWarnError(Sync, @"%@: Replicator cannot be created: %@", self, error.localizedDescription);
@@ -323,7 +323,7 @@ typedef enum {
     }
     
     // Post an initial notification:
-    statusChanged(_repl, status, (__bridge void*)self);
+    statusChanged(repl, status, (__bridge void*)self);
 }
 
 static C4ReplicatorMode mkmode(BOOL active, BOOL continuous) {

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -457,12 +457,12 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
             *error = [NSError errorWithDomain: CBLErrorDomain
                                          code: CBLErrorUnsupported
                                      userInfo: @{NSLocalizedDescriptionKey: kCBLErrorMessagePullOnlyPendingDocIDs}];
-        return [NSSet set];
+        return nil;
     }
     
     if (!_repl) {
         CBLLogInfo(Sync, @"Trying to fetch pending documentIds without a c4replicator %@", _repl);
-        return [NSSet set];
+        return nil;
     }
     
     C4Error c4err = {};
@@ -470,7 +470,7 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
     if (c4err.code > 0) {
         convertError(c4err, error);
         CBLWarnError(Sync, @"Error while fetching pending documentIds: %d/%d", c4err.domain, c4err.code);
-        return [NSSet set];
+        return nil;
     }
     
     if (result.size <= 0)

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -134,80 +134,10 @@ typedef enum {
     return _config;
 }
 
-- (void) dealloc {
-    c4repl_free(_repl);
-    [_reachability stop];
-}
-
-- (NSString*) description {
-    if (!_desc)
-        _desc = [NSString stringWithFormat: @"%@[%s%s%s %@]",
-                 self.class,
-                 (isPull(_config.replicatorType) ? "<" : ""),
-                 (_config.continuous ? "*" : "-"),
-                 (isPush(_config.replicatorType)  ? ">" : ""),
-                 _config.target];
-    return _desc;
-}
-
-- (void) clearRepl {
-    c4repl_free(_repl);
-    _repl = nullptr;
-}
-
-- (void) start {
-    CBL_LOCK(self) {
-        CBLLogInfo(Sync, @"%@: Starting...", self);
-        if (_state != kCBLStateStopped && _state != kCBLStateSuspended) {
-            CBLWarn(Sync, @"%@ has already started (state = %d, status = %d); ignored.",
-                    self,  _state, _rawStatus.level);
-            return;
-        }
-        Assert(!_repl);
-        _retryCount = 0;
-        [self _start];
-    }
-}
-
-- (void) resetAndScheduleRetry {
-    [self resetRetryCount];
-    [self scheduleRetry: 0];
-}
-
-- (void) scheduleRetry: (NSTimeInterval)delayInSeconds {
-    [self cancelRetry];
+- (C4Replicator*) c4repl: (nullable C4Error*)c4err {
+    if (_repl)
+        return _repl;
     
-    __weak CBLReplicator *weakSelf = self;
-    _retryTimer = [CBLTimer scheduleIn: _dispatchQueue
-                                 after: delayInSeconds
-                                 block: ^{
-        [weakSelf _retry];
-    }];
-}
-
-- (void) resetRetryCount {
-    CBLLogVerbose(Sync, @"%@: Resetting the retry count", self);
-    _retryCount = 0;
-}
-
-- (void) _retry {
-    CBL_LOCK(self) {
-        CBLLogInfo(Sync, @"%@: Retrying...", self);
-        if (_repl || _state <= kCBLStateStopping) {
-            CBLLogInfo(Sync, @"%@: Ignore retrying (state = %d, status = %d)",
-                       self, _state, _rawStatus.level);
-            return;
-        }
-        [self _start];
-    }
-}
-
-- (void) cancelRetry {
-    [CBLTimer cancel: _retryTimer];
-    _retryTimer = nil;
-}
-
-- (void) _start {
     // Target:
     id<CBLEndpoint> endpoint = _config.target;
     C4Address addr = {};
@@ -292,14 +222,97 @@ typedef enum {
             convertError(err, &error);
             CBLWarnError(Sync, @"%@: Replicator cannot be created: %@",
                          self, error.localizedDescription);
+            *c4err = err;
+            return nil;
+        }
+    }
+    
+    return _repl;
+}
+
+- (void) dealloc {
+    c4repl_free(_repl);
+    [_reachability stop];
+}
+
+- (NSString*) description {
+    if (!_desc)
+        _desc = [NSString stringWithFormat: @"%@[%s%s%s %@]",
+                 self.class,
+                 (isPull(_config.replicatorType) ? "<" : ""),
+                 (_config.continuous ? "*" : "-"),
+                 (isPush(_config.replicatorType)  ? ">" : ""),
+                 _config.target];
+    return _desc;
+}
+
+- (void) clearRepl {
+    c4repl_free(_repl);
+    _repl = nullptr;
+}
+
+- (void) start {
+    CBL_LOCK(self) {
+        CBLLogInfo(Sync, @"%@: Starting...", self);
+        if (_state != kCBLStateStopped && _state != kCBLStateSuspended) {
+            CBLWarn(Sync, @"%@ has already started (state = %d, status = %d); ignored.",
+                    self,  _state, _rawStatus.level);
             return;
         }
-        c4repl_start(_repl);
+        
+        _retryCount = 0;
+        [self _start];
+    }
+}
+
+- (void) resetAndScheduleRetry {
+    [self resetRetryCount];
+    [self scheduleRetry: 0];
+}
+
+- (void) scheduleRetry: (NSTimeInterval)delayInSeconds {
+    [self cancelRetry];
+    
+    __weak CBLReplicator *weakSelf = self;
+    _retryTimer = [CBLTimer scheduleIn: _dispatchQueue
+                                 after: delayInSeconds
+                                 block: ^{
+        [weakSelf _retry];
+    }];
+}
+
+- (void) resetRetryCount {
+    CBLLogVerbose(Sync, @"%@: Resetting the retry count", self);
+    _retryCount = 0;
+}
+
+- (void) _retry {
+    CBL_LOCK(self) {
+        CBLLogInfo(Sync, @"%@: Retrying...", self);
+        if (_repl || _state <= kCBLStateStopping) {
+            CBLLogInfo(Sync, @"%@: Ignore retrying (state = %d, status = %d)",
+                       self, _state, _rawStatus.level);
+            return;
+        }
+        [self _start];
+    }
+}
+
+- (void) cancelRetry {
+    [CBLTimer cancel: _retryTimer];
+    _retryTimer = nil;
+}
+
+- (void) _start {
+    C4Error err;
+    C4Replicator* repl = [self c4repl: &err];
+    CBL_LOCK(_config.database) {
+        c4repl_start(repl);
     }
     
     C4ReplicatorStatus status;
-    if (_repl) {
-        status = c4repl_getStatus(_repl);
+    if (repl) {
+        status = c4repl_getStatus(repl);
         CBL_LOCK(_config.database) {
             [_config.database.activeReplications addObject: self];     // keeps me from being dealloced
         }

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -175,6 +175,29 @@ public final class Replicator {
         _impl.removeChangeListener(with: token._impl)
     }
     
+    /// Gets a set of document Ids, who have revisions pending push. This API is a snapshot and results
+    /// may change between the time the call was made and the time the call returns.
+    ///
+    /// - Returns: A  set of document Ids, each of which has one or more pending revisions
+    public func pendingDocumentIds() throws -> Set<String> {
+        return try _impl.pendingDocumentIds()
+    }
+    
+    /// Checks if the document with the given ID has revisions pending push.  This API is a snapshot and
+    /// results may change between the time the call was made and the time the call returns.
+    ///
+    /// - Parameter documentID: The ID of the document to check
+    /// - Returns: true if the document has one or more revisions pending, false otherwise
+    public func isDocumentPending(_ documentID: String) throws -> Bool {
+        var error: NSError?
+        let result = _impl.isDocumentPending(documentID, error: &error)
+        if let err = error {
+            throw err
+        }
+        
+        return result
+    }
+    
     // MARK: Internal
     
     func registerActiveReplicator() {


### PR DESCRIPTION
* move everything which creates the c4replicator to a method. 
* if any error, returned so that the initial status can include the error.
* remove assertion to check `_repl` not exists before starting it. 