### PR TITLE
CBL-512: Local and remote deleted scenario 

### DIFF
--- a/Objective-C/CBLConflict.m
+++ b/Objective-C/CBLConflict.m
@@ -28,8 +28,6 @@
 - (instancetype) initWithID: (NSString*)documentID
               localDocument: (CBLDocument*)localDoc
              remoteDocument: (CBLDocument*)remoteDoc {
-    Assert(localDoc != nil || remoteDoc != nil, @"Local and remote document shouldn't be empty \
-           at same time, when resolving conflict.");
     self = [super init];
     if (self) {
         _documentID = documentID;

--- a/Objective-C/CBLConflict.m
+++ b/Objective-C/CBLConflict.m
@@ -28,6 +28,8 @@
 - (instancetype) initWithID: (NSString*)documentID
               localDocument: (CBLDocument*)localDoc
              remoteDocument: (CBLDocument*)remoteDoc {
+    Assert(localDoc != nil || remoteDoc != nil, @"Local and remote document \
+           shouldn't be empty at same time, when resolving conflict.");
     self = [super init];
     if (self) {
         _documentID = documentID;

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -964,20 +964,21 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration *config) {
         
         conflictResolver = conflictResolver ?: [CBLConflictResolver default];
         
-        CBLConflict* conflict = [[CBLConflict alloc] initWithID: docID
-                                                  localDocument: localDoc.isDeleted ? nil : localDoc
-                                                 remoteDocument: remoteDoc.isDeleted ? nil : remoteDoc];
-        
         // Resolve conflict:
         CBLDocument* resolvedDoc;
         @try {
             CBLLogInfo(Sync, @"Resolving doc '%@' (localDoc=%@ and remoteDoc=%@)",
                        docID, localDoc.revisionID, remoteDoc.revisionID);
             
-            if (localDoc.isDeleted && remoteDoc.isDeleted)
+            if (localDoc.isDeleted && remoteDoc.isDeleted) {
                 resolvedDoc = remoteDoc;
-            else
+            } else {
+                CBLConflict* conflict = [[CBLConflict alloc] initWithID: docID
+                                                          localDocument: localDoc.isDeleted ? nil : localDoc
+                                                         remoteDocument: remoteDoc.isDeleted ? nil : remoteDoc];
+                
                 resolvedDoc = [conflictResolver resolve: conflict];
+            }
             
             if (resolvedDoc && resolvedDoc.id != docID) {
                 CBLWarn(Sync, @"The document ID of the resolved document '%@' is not matching "

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -974,7 +974,10 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration *config) {
             CBLLogInfo(Sync, @"Resolving doc '%@' (localDoc=%@ and remoteDoc=%@)",
                        docID, localDoc.revisionID, remoteDoc.revisionID);
             
-            resolvedDoc = [conflictResolver resolve: conflict];
+            if (localDoc.isDeleted && remoteDoc.isDeleted)
+                resolvedDoc = remoteDoc;
+            else
+                resolvedDoc = [conflictResolver resolve: conflict];
             
             if (resolvedDoc && resolvedDoc.id != docID) {
                 CBLWarn(Sync, @"The document ID of the resolved document '%@' is not matching "

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -269,7 +269,8 @@
     
     [self run: pullConfig errorCode: 0 errorDomain: nil];
     
-    // it should only come into this once.
+    // it should only call resolver once. 
+    // since second time, both revisions are deleted, and automatically resolve
     AssertEqual(count, 1);
     
     // Check whether it deletes the document and returns nil.

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -247,6 +247,36 @@
                                                            includeDeleted: YES error: &error].sequence);
 }
 
+- (void) testConflictResolverDeletedBothRev {
+    NSString* docId = @"doc";
+    NSDictionary* localData = @{@"key1": @"value1"};
+    [self makeConflictFor: docId withLocal: localData withRemote: nil];
+    
+    TestConflictResolver* resolver;
+    CBLReplicatorConfiguration* pullConfig = [self config: kCBLReplicatorTypePull];
+    
+    __block int count = 0;
+    resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
+        count++;
+        AssertNil(con.remoteDocument);
+        AssertNotNil(con.localDocument);
+        NSError* error = nil;
+        [self.db deleteDocument: [self.db documentWithID: docId]
+                          error: &error];
+        return nil;
+    }];
+    pullConfig.conflictResolver = resolver;
+    
+    [self run: pullConfig errorCode: 0 errorDomain: nil];
+    
+    // it should only come into this once.
+    AssertEqual(count, 1);
+    
+    // Check whether it deletes the document and returns nil.
+    AssertEqual(self.db.count, 0u);
+    AssertNil([self.db documentWithID: @"doc"]);
+}
+
 - (void) testConflictResolverMergeDoc {
     NSString* docId = @"doc";
     NSDictionary* localData = @{@"key1": @"value1"};


### PR DESCRIPTION
* if local and remote are deleted, automatically choose the remote revision. No need to send it to resolve. 
* remove assertion 