### PR TITLE
fix: memory leak due to holding fleecedata

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -925,8 +925,9 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration *config) {
         CBLStringBytes docID(document.id);
         *outDoc = c4doc_create(_c4db, docID, (FLSlice)body, revFlags, &err);
     }
-    
+
     FLSliceResult_Free(body);
+    
     if (!*outDoc && !(err.domain == LiteCoreDomain && err.code == kC4ErrorConflict)) {
         // conflict is not an error, at this level
         return convertError(err, outError);


### PR DESCRIPTION
* previously we were using Doc instance, which was expecting a alloc_slice, but we supply a FLSliceResult which was already owned, and it again retained and owned in the constructor.
* also the encode result FLSliceResult was not released after update/create the c4Doc.