### PR TITLE
CBL-520: include revision-id with filters

### DIFF
--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -125,6 +125,9 @@ using namespace fleece;
 }
 
 - (CBLMutableDocument*) toMutable {
+    if (_revID)
+        [NSException raise: NSInternalInconsistencyException
+                    format: @"%@", kCBLErrorMessageNoDocEditInReplicationFilter];
     return [self mutableCopy];
 }
 

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -46,6 +46,7 @@ using namespace fleece;
     if (self) {
         _database = database;
         _id = documentID;
+        _revID = nil;
         [self setC4Doc: c4Doc];
     }
     return self;
@@ -60,6 +61,7 @@ using namespace fleece;
         _database = database;
         _id = documentID;
         _fleeceData = body;
+        _revID = nil;
         [self updateDictionary];
     }
     return self;
@@ -90,6 +92,7 @@ using namespace fleece;
     self = [self initWithDatabase: database documentID: documentID c4Doc: nil];
     if (self) {
         _database = database;
+        _revID = nil;
         CBLStringBytes docId(documentID);
         C4Error err;
         auto doc = c4doc_get(database.c4db, docId, true, &err);
@@ -125,7 +128,7 @@ using namespace fleece;
 }
 
 - (CBLMutableDocument*) toMutable {
-    if (_revID)
+    if (_revID && !_c4Doc)
         [NSException raise: NSInternalInconsistencyException
                     format: @"%@", kCBLErrorMessageNoDocEditInReplicationFilter];
     return [self mutableCopy];

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -67,6 +67,23 @@ using namespace fleece;
 
 - (instancetype) initWithDatabase: (CBLDatabase*)database
                        documentID: (NSString*)documentID
+                       revisionID: (NSString*)revisionID
+                             body: (nullable FLDict)body {
+    NSParameterAssert(documentID != nil);
+    NSParameterAssert(revisionID != nil);
+    self = [self initWithDatabase: database documentID: documentID c4Doc: nil];
+    if (self) {
+        _database = database;
+        _id = documentID;
+        _fleeceData = body;
+        _revID = revisionID;
+        [self updateDictionary];
+    }
+    return self;
+}
+
+- (instancetype) initWithDatabase: (CBLDatabase*)database
+                       documentID: (NSString*)documentID
                    includeDeleted: (BOOL)includeDeleted
                             error: (NSError**)outError
 {
@@ -208,7 +225,7 @@ using namespace fleece;
 
 - (NSString*) revisionID {
     CBL_LOCK(self) {
-        return _c4Doc != nil ?  slice2string(_c4Doc.revID) : nil;
+        return _c4Doc != nil ?  slice2string(_c4Doc.revID) : _revID;
     }
 }
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -722,25 +722,30 @@ static void onDocsEnded(C4Replicator* repl,
 
 #pragma mark - Push/Pull Filter
 
-static bool pushFilter(C4String docID, C4RevisionFlags flags, FLDict flbody, void *context) {
+static bool pushFilter(C4String docID, C4String revID, C4RevisionFlags flags,
+                       FLDict flbody, void *context) {
     auto replicator = (__bridge CBLReplicator*)context;
-    return [replicator filterDocument: docID flags: flags body: flbody pushing: true];
+    return [replicator filterDocument: docID revID: revID flags: flags
+                                 body: flbody pushing: true];
 }
 
-static bool pullFilter(C4String docID, C4RevisionFlags flags, FLDict flbody, void *context) {
+static bool pullFilter(C4String docID, C4String revID, C4RevisionFlags flags,
+                       FLDict flbody, void *context) {
     auto replicator = (__bridge CBLReplicator*)context;
-    return [replicator filterDocument: docID flags: flags body: flbody pushing: false];
+    return [replicator filterDocument: docID revID: revID flags: flags
+                                 body: flbody pushing: false];
 }
 
 - (bool) filterDocument: (C4String)docID
+                  revID: (C4String)revID
                   flags: (C4RevisionFlags)flags
                    body: (FLDict)body
                 pushing: (bool)pushing
 {
     auto doc = [[CBLDocument alloc] initWithDatabase: _config.database
                                           documentID: slice2string(docID)
+                                          revisionID: slice2string(revID)
                                                 body: body];
-    
     CBLDocumentFlags docFlags = 0;
     if ((flags & kRevDeleted) == kRevDeleted)
         docFlags |= kCBLDocumentFlagsDeleted;

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
     @protected
     CBLDictionary* _dict;
     BOOL _isInvalidated;
+    NSString* _revID;
 }
 
 @property (nonatomic, nullable) CBLDatabase* database;
@@ -75,6 +76,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype) initWithDatabase: (nullable CBLDatabase*)database
                        documentID: (NSString*)documentID
+                             body: (nullable FLDict)body;
+
+- (instancetype) initWithDatabase: (CBLDatabase*)database
+                       documentID: (NSString*)documentID
+                       revisionID: (NSString*)revisionID
                              body: (nullable FLDict)body;
 
 - (nullable instancetype) initWithDatabase: (CBLDatabase*)database

--- a/Objective-C/Internal/CBLErrorMessage.h
+++ b/Objective-C/Internal/CBLErrorMessage.h
@@ -60,6 +60,7 @@ extern NSString* const kCBLErrorMessageNoAliasInJoin;
 extern NSString* const kCBLErrorMessageInvalidQueryDBNull;
 extern NSString* const kCBLErrorMessageInvalidQueryMissingSelectOrFrom;
 extern NSString* const kCBLErrorMessagePullOnlyPendingDocIDs;
+extern NSString* const kCBLErrorMessageNoDocEditInReplicationFilter;
 
 @end
 

--- a/Objective-C/Internal/CBLErrorMessage.m
+++ b/Objective-C/Internal/CBLErrorMessage.m
@@ -58,6 +58,7 @@ NSString* const kCBLErrorMessageNoAliasInJoin = @"The default database must have
 NSString* const kCBLErrorMessageInvalidQueryDBNull = @"Invalid query: The database is null.";
 NSString* const kCBLErrorMessageInvalidQueryMissingSelectOrFrom = @"Invalid query: missing Select or From.";
 NSString* const kCBLErrorMessagePullOnlyPendingDocIDs = @"Pending Document IDs are not supported on pull-only replicators.";
+NSString* const kCBLErrorMessageNoDocEditInReplicationFilter = @"Documents from a replication filter cannot be edited.";
 
 @end
 

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -1153,6 +1153,7 @@
     config.pushFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
         // Check document ID:
         AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         
         // isDeleted:
         BOOL isDeleted = (flags & kCBLDocumentFlagsDeleted) == kCBLDocumentFlagsDeleted;
@@ -1230,6 +1231,7 @@
     config.pullFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
         // Check document ID:
         AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         
         // isDeleted:
         BOOL isDeleted = (flags & kCBLDocumentFlagsDeleted) == kCBLDocumentFlagsDeleted;
@@ -1341,6 +1343,7 @@
                                                      continuous: isContinuous];
     config.pullFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
         AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         BOOL isAccessRemoved = (flags & kCBLDocumentFlagsAccessRemoved) == kCBLDocumentFlagsAccessRemoved;
         if (isAccessRemoved) {
             [docIds addObject: document.id];
@@ -1411,6 +1414,7 @@
                                                      continuous: isContinuous];
     config.pushFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
         AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         
         BOOL isDeleted = (flags & kCBLDocumentFlagsDeleted) == kCBLDocumentFlagsDeleted;
         if (isDeleted) {
@@ -1462,6 +1466,7 @@
                                                      continuous: isContinuous];
     config.pullFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
         AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         
         BOOL isDeleted = (flags & kCBLDocumentFlagsDeleted) == kCBLDocumentFlagsDeleted;
         if (isDeleted) {
@@ -1516,6 +1521,7 @@
                                                      continuous: YES];
     config.pushFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
         AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         [docIds addObject: document.id];
         
         // allow all docs with `name = pass`
@@ -1566,6 +1572,8 @@
                                                      continuous: YES];
     config.pullFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
         AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
+        
         [docIds addObject: document.id];
         
         // allow all docs with `name = pass`
@@ -1853,9 +1861,13 @@
                                                            type: kCBLReplicatorTypePush
                                                      continuous: YES];
     id pushFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
+        AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         return (flags & kCBLDocumentFlagsDeleted) == kCBLDocumentFlagsDeleted;
     };
     id pullFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
+        AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
         return [[document valueForKey: @"someKey"] isEqualToString: @"pass"];
     };
     config.pushFilter = pushFilter;

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -1610,6 +1610,60 @@
     AssertEqual(self.db.count, 2u);
 }
 
+- (void) testRevisionIdInPushPullFilters {
+    // Create documents:
+    NSError* error;
+    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc1 setString: @"Tiger" forKey: @"species"];
+    Assert([self.db saveDocument: doc1 error: &error]);
+    
+    CBLMutableDocument* doc2 = [[CBLMutableDocument alloc] initWithID: @"doc2"];
+    [doc2 setString: @"Stripes" forKey: @"pattern"];
+    Assert([otherDB saveDocument: doc2 error: &error]);
+    
+    // Create replicator with push filter:
+    NSMutableSet<NSString*>* pushDocIds = [NSMutableSet set];
+    NSMutableSet<NSString*>* pullDocIds = [NSMutableSet set];
+    id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: otherDB];
+    CBLReplicatorConfiguration* config = [self configWithTarget: target
+                                                           type: kCBLReplicatorTypePushAndPull
+                                                     continuous: false];
+    config.pushFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
+        AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
+        
+        [self expectException: @"NSInternalInconsistencyException" in:^{
+            [document toMutable];
+        }];
+        
+        // Gather document ID:
+        [pushDocIds addObject: document.id];
+        return YES;
+    };
+    
+    config.pullFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
+        AssertNotNil(document.id);
+        AssertNotNil(document.revisionID);
+        
+        [self expectException: @"NSInternalInconsistencyException" in:^{
+            [document toMutable];
+        }];
+        
+        // Gather document ID:
+        [pullDocIds addObject: document.id];
+        return YES;
+    };
+    
+    [self run: config errorCode: 0 errorDomain: nil];
+    
+    // Check documents passed to the filter:
+    AssertEqual(pullDocIds.count, 1u);
+    Assert([pullDocIds containsObject: @"doc2"]);
+    
+    AssertEqual(pushDocIds.count, 1u);
+    Assert([pushDocIds containsObject: @"doc1"]);
+}
+
 #endif // COUCHBASE_ENTERPRISE
 
 #pragma mark - Sync Gateway Tests
@@ -1956,60 +2010,6 @@
     AssertEqual(replicatedDoc.c4Error.code, 0);
     AssertEqual(replicatedDoc.c4Error.domain, 0);
     AssertNil(replicatedDoc.error);
-}
-
-- (void) testRevisionIdInPushPullFilters {
-    // Create documents:
-    NSError* error;
-    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
-    [doc1 setString: @"Tiger" forKey: @"species"];
-    Assert([self.db saveDocument: doc1 error: &error]);
-    
-    CBLMutableDocument* doc2 = [[CBLMutableDocument alloc] initWithID: @"doc2"];
-    [doc2 setString: @"Stripes" forKey: @"pattern"];
-    Assert([otherDB saveDocument: doc2 error: &error]);
-    
-    // Create replicator with push filter:
-    NSMutableSet<NSString*>* pushDocIds = [NSMutableSet set];
-    NSMutableSet<NSString*>* pullDocIds = [NSMutableSet set];
-    id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: otherDB];
-    CBLReplicatorConfiguration* config = [self configWithTarget: target
-                                                           type: kCBLReplicatorTypePushAndPull
-                                                     continuous: false];
-    config.pushFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
-        AssertNotNil(document.id);
-        AssertNotNil(document.revisionID);
-        
-        [self expectException: @"NSInternalInconsistencyException" in:^{
-            [document toMutable];
-        }];
-        
-        // Gather document ID:
-        [pushDocIds addObject: document.id];
-        return YES;
-    };
-    
-    config.pullFilter = ^BOOL(CBLDocument* document, CBLDocumentFlags flags) {
-        AssertNotNil(document.id);
-        AssertNotNil(document.revisionID);
-        
-        [self expectException: @"NSInternalInconsistencyException" in:^{
-            [document toMutable];
-        }];
-        
-        // Gather document ID:
-        [pullDocIds addObject: document.id];
-        return YES;
-    };
-    
-    [self run: config errorCode: 0 errorDomain: nil];
-    
-    // Check documents passed to the filter:
-    AssertEqual(pullDocIds.count, 1u);
-    Assert([pullDocIds containsObject: @"doc2"]);
-    
-    AssertEqual(pushDocIds.count, 1u);
-    Assert([pushDocIds containsObject: @"doc1"]);
 }
 
 @end


### PR DESCRIPTION
* include revision-id with document
* check c4doc exists, if not return the revision-id
* include revision-id check with all filter unit tests
* update the revision-id signature form lite-core.
* when tries to create the c4doc_singleRevision, but deleted document returns nil with NotFound error. so in that case, we might again needs to save the revision-id and return. so not possible to create c4doc with revision-id, document-id and other info.