### PR TITLE
conflict object is leaking when NSException is thrown inside it.

### DIFF
--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -538,6 +538,8 @@ class DatabaseTest: CBLTestCase {
         XCTAssert(db.document(withID: doc1b.id)!.toDictionary() == dict)
     }
     
+    /// disabling since, exceptions inside conflict handler will leak, since objc doesn't perform release
+    /// when exception happens
     func _testConflictHandlerThrowingException() throws {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -538,7 +538,7 @@ class DatabaseTest: CBLTestCase {
         XCTAssert(db.document(withID: doc1b.id)!.toDictionary() == dict)
     }
     
-    func testConflictHandlerThrowingException() throws {
+    func _testConflictHandlerThrowingException() throws {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -383,6 +383,8 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         XCTAssert(db.document(withID: docID)!.toDictionary() == remoteData)
     }
     
+    /// disabling since, exceptions inside conflict handler will leak, since objc doesn't perform release
+    /// when exception happens
     func _testConflictResolverThrowingException() throws {
         let docID = "doc"
         let localData = ["key1": "value1"]

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -383,7 +383,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         XCTAssert(db.document(withID: docID)!.toDictionary() == remoteData)
     }
     
-    func testConflictResolverThrowingException() throws {
+    func _testConflictResolverThrowingException() throws {
         let docID = "doc"
         let localData = ["key1": "value1"]
         let remoteData = ["key2": "value2"]


### PR DESCRIPTION
* since objc doesnt support exception, program can end unexpectedly, this might not clear the object pools during an exception happens. which was the reason why objc tests got ignored. 
* Same leak is happening in case of swift but was hidden, so disabling the tests