### PR TITLE
fix: leak with blob contents

### DIFF
--- a/Objective-C/CBLBlob.mm
+++ b/Objective-C/CBLBlob.mm
@@ -173,7 +173,9 @@ static NSString* const kBlobType = @kC4ObjectType_Blob;
         if (![self getBlobStore: &blobStore andKey: &key])
             return nil;
         //TODO: If data is large, can get the file path & memory-map it
-        NSData* content = sliceResult2data(c4blob_getContents(blobStore, key, nullptr));
+        FLSliceResult res = c4blob_getContents(blobStore, key, nullptr);
+        NSData* content = sliceResult2data(res);
+        FLSliceResult_Free(res);
         if (content && content.length <= kMaxCachedContentLength)
             _content = content;
         return content;


### PR DESCRIPTION
* `c4blob_getContents` returns C4SliceResult, which needs to be freed. 
