### PR TITLE
fix: leak with collator

### DIFF
--- a/Objective-C/Internal/CBLCollationExpression.m
+++ b/Objective-C/Internal/CBLCollationExpression.m
@@ -41,4 +41,9 @@
     return @[@"COLLATE", [_collation asJSON], [_operand asJSON]];
 }
 
+- (void) dealloc {
+    _collation = nil;
+    _operand = nil;
+}
+
 @end


### PR DESCRIPTION
* _operator was assigned with QueryInstance([here](https://github.com/couchbase/couchbase-lite-ios/blob/6b09f2d2f51b1dbcb406fbdddd46bd46b0841f41/Objective-C/CBLQueryExpression.m#L310)), and was stuck without getting released when the collator itself was released. 
* cbl-540