### PR TITLE
CBL-518: CBL-519: fix: blob

### DIFF
--- a/Objective-C/CBLBlob.mm
+++ b/Objective-C/CBLBlob.mm
@@ -280,7 +280,7 @@ static NSString* const kBlobType = @kC4ObjectType_Blob;
         uint8_t buffer[kReadBufferSize];
         NSInteger bytesRead = 0;
         _length = 0;
-        NSInputStream *contentStream = [self contentStream];
+        NSInputStream *contentStream = _initialContentStream;
         [contentStream open];
         success = true;
         while(success && (bytesRead = [contentStream read:buffer maxLength: kReadBufferSize]) > 0) {

--- a/Objective-C/CBLBlob.mm
+++ b/Objective-C/CBLBlob.mm
@@ -135,6 +135,12 @@ static NSString* const kBlobType = @kC4ObjectType_Blob;
     return self;
 }
 
+- (void) dealloc {
+    if (_initialContentStream)
+        [_initialContentStream close];
+    _initialContentStream = nil;
+}
+
 - (NSDictionary*) properties {
     if (_properties) {
         // Blob read from database;
@@ -212,8 +218,7 @@ static NSString* const kBlobType = @kC4ObjectType_Blob;
             return nil;
         return [[CBLBlobStream alloc] initWithStore: blobStore key: key];
     } else {
-        NSData* content = self.content;
-        return content ? [[NSInputStream alloc] initWithData: content] : nil;
+        return _content ? [[NSInputStream alloc] initWithData: _content] : nil;
     }
 }
 

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -1582,7 +1582,7 @@
     NSError* error;
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString *documentsPath =
-        [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
+        [NSSearchPathForDirectoriesInDomains(NSCachesDirectory,
                                              NSUserDomainMask, YES) firstObject];
     NSString *filePath = [documentsPath stringByAppendingPathComponent:@"sample.txt"];
     [fileManager createFileAtPath: filePath contents:nil attributes: nil];

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -1578,27 +1578,58 @@
     AssertEqual(bytesRead, 0);
 }
 
+- (NSURL*) writeBlobToFile {
+    NSError* error;
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *documentsPath =
+        [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
+                                             NSUserDomainMask, YES) firstObject];
+    NSString *filePath = [documentsPath stringByAppendingPathComponent:@"sample.txt"];
+    [fileManager createFileAtPath: filePath contents:nil attributes: nil];
+    [kDocumentTestBlob writeToFile: filePath
+                        atomically: YES
+                          encoding: NSUTF8StringEncoding error: &error];
+    return [NSURL fileURLWithPath: filePath];
+}
+
 - (void)testBlobWithStream {
     NSData* content = [kDocumentTestBlob dataUsingEncoding:NSUTF8StringEncoding];
     NSInputStream *contentStream = [[NSInputStream alloc] initWithData:content];
     NSError* error;
-    CBLBlob *data = [[CBLBlob alloc] initWithContentType:@"text/plain" contentStream:contentStream];
-    Assert(data, @"Failed to create blob: %@", error);
+    CBLBlob *blob1 = [[CBLBlob alloc] initWithContentType: @"text/plain"
+                                            contentStream:contentStream];
+    Assert(blob1, @"Failed to create blob: %@", error);
+    
+    CBLBlob *blob2 = [[CBLBlob alloc] initWithContentType: @"text/plain"
+                                                     data: content];
+    Assert(blob2, @"Failed to create blob: %@", error);
+    
+    CBLBlob *blob3 = [[CBLBlob alloc] initWithContentType: @"text/plain"
+                                                  fileURL: [self writeBlobToFile]
+                                                    error: &error];
+    Assert(blob3, @"Failed to create blob: %@", error);
+    
+    // SAVE
     CBLMutableDocument* doc = [self createDocument: @"doc1"];
-    [doc setValue: data forKey: @"data"];
+    [doc setValue: blob1 forKey: @"blob1"];
+    [doc setValue: blob2 forKey: @"blob2"];
+    [doc setValue: blob3 forKey: @"blob3"];
     Assert([self.db saveDocument: doc error: &error], @"Saving error: %@", error);
     
+    // Validate result
     CBLDocument* savedDoc = [self.db documentWithID: doc.id];
-    Assert([[savedDoc valueForKey: @"data"] isKindOfClass:[CBLBlob class]]);
-    CBLBlob *savedData = [savedDoc valueForKey: @"data"];
-    AssertEqual(savedData.length, data.length);
-    AssertEqualObjects(savedData.content, content);
-    contentStream = savedData.contentStream;
-    [contentStream open];
-    uint8_t buffer[10];
-    NSInteger bytesRead = [contentStream read:buffer maxLength:10];
-    [contentStream close];
-    AssertEqual(bytesRead, 8);
+    for (NSString* key in @[@"blob1", @"blob2", @"blob3"]) {
+        Assert([[savedDoc valueForKey: key] isKindOfClass:[CBLBlob class]]);
+        CBLBlob *savedData = [savedDoc valueForKey: key];
+        AssertEqual(savedData.length, blob1.length);
+        AssertEqualObjects(savedData.content, content);
+        contentStream = savedData.contentStream;
+        [contentStream open];
+        uint8_t buffer[10];
+        NSInteger bytesRead = [contentStream read:buffer maxLength:10];
+        [contentStream close];
+        AssertEqual(bytesRead, 8);
+    }
 }
 
 - (void)testMultipleBlobRead {

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -1579,7 +1579,7 @@
 }
 
 - (void)testBlobWithStream {
-    NSData* content = [@"" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData* content = [kDocumentTestBlob dataUsingEncoding:NSUTF8StringEncoding];
     NSInputStream *contentStream = [[NSInputStream alloc] initWithData:content];
     NSError* error;
     CBLBlob *data = [[CBLBlob alloc] initWithContentType:@"text/plain" contentStream:contentStream];
@@ -1590,15 +1590,15 @@
     
     CBLDocument* savedDoc = [self.db documentWithID: doc.id];
     Assert([[savedDoc valueForKey: @"data"] isKindOfClass:[CBLBlob class]]);
-    data = [savedDoc valueForKey: @"data"];
-    AssertEqual(data.length, 0ull);
-    AssertEqualObjects(data.content, content);
-    contentStream = data.contentStream;
+    CBLBlob *savedData = [savedDoc valueForKey: @"data"];
+    AssertEqual(savedData.length, data.length);
+    AssertEqualObjects(savedData.content, content);
+    contentStream = savedData.contentStream;
     [contentStream open];
     uint8_t buffer[10];
     NSInteger bytesRead = [contentStream read:buffer maxLength:10];
     [contentStream close];
-    AssertEqual(bytesRead, 0);
+    AssertEqual(bytesRead, 8);
 }
 
 - (void)testMultipleBlobRead {

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -1592,7 +1592,7 @@
     return [NSURL fileURLWithPath: filePath];
 }
 
-- (void)testBlobWithStream {
+- (void)testBlobStream {
     NSData* content = [kDocumentTestBlob dataUsingEncoding:NSUTF8StringEncoding];
     NSInputStream *contentStream = [[NSInputStream alloc] initWithData:content];
     NSError* error;


### PR DESCRIPTION
* corrected objc test for blob with object stream
* when blob content not used, it is not closed. so release it in dealloc
* return nil, in case of contentStream property asks for it before getting the contents.
* make it in sync with .NET and Android
