### PR TITLE
CBL-570: Fix: iOS App Target Failure

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -4288,6 +4288,9 @@
 					9343F135207D61EC00F19A89 = {
 						DevelopmentTeam = N2Q372V7W2;
 					};
+					9343F153207D62C900F19A89 = {
+						DevelopmentTeam = N2Q372V7W2;
+					};
 					9343F18A207D636300F19A89 = {
 						DevelopmentTeam = N2Q372V7W2;
 					};
@@ -5832,6 +5835,7 @@
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",
@@ -6002,6 +6006,7 @@
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",
@@ -6236,7 +6241,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",
@@ -6250,7 +6257,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",
@@ -6264,7 +6273,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",
@@ -6278,7 +6289,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",
@@ -6713,6 +6726,7 @@
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",
@@ -6727,6 +6741,7 @@
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C",
 					"$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece",

--- a/xcconfigs/CBL ObjC Tests - iOS App.xcconfig
+++ b/xcconfigs/CBL ObjC Tests - iOS App.xcconfig
@@ -26,3 +26,4 @@ LD_RUNPATH_SEARCH_PATHS                    = $(inherited) @executable_path/Frame
 PRODUCT_BUNDLE_IDENTIFIER                  = com.couchbase.cbl-ios-tests-app
 PRODUCT_NAME                               = CBL Tests
 SDKROOT                                    = iphoneos
+HEADER_SEARCH_PATHS                        = $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece/Support/

--- a/xcconfigs/CBL ObjC Tests - iOS.xcconfig
+++ b/xcconfigs/CBL ObjC Tests - iOS.xcconfig
@@ -19,7 +19,7 @@
 
 BUNDLE_LOADER             = $(TEST_HOST)
 CODE_SIGN_IDENTITY        = iPhone Developer
-HEADER_SEARCH_PATHS       = $(SRCROOT)/vendor/couchbase-lite-core/C/include $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/ObjC
+HEADER_SEARCH_PATHS       = $(SRCROOT)/vendor/couchbase-lite-core/C/include $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/ObjC $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/API
 INFOPLIST_FILE            = $(SRCROOT)/Objective-C/Tests/iOS/Info-Tests.plist
 LD_RUNPATH_SEARCH_PATHS   = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
 PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.cbl-ios-tests


### PR DESCRIPTION
* Include support file path for benchmark.hh file.
* Include Fleece API path in the search path for iOS Test target
* Map the Couchbase Inc, signing team for EE iOS App Target.