### PR TITLE
fix: ignore exception when start discovery

### DIFF
--- a/Objective-C/Tests/MessageEndpointTest.m
+++ b/Objective-C/Tests/MessageEndpointTest.m
@@ -174,9 +174,7 @@ MCSessionDelegate, CBLMessageEndpointDelegate, MultipeerConnectionDelegate>
     _browser.delegate = self;
     [_browser startBrowsingForPeers];
     
-    [self ignoreException:^{
-        [self waitForExpectations: @[_clientConnected, _serverConnected] timeout: 10.0];
-    }];
+    [self waitForExpectations: @[_clientConnected, _serverConnected] timeout: 10.0];
 }
 
 - (void) run: (CBLReplicatorConfiguration*)config
@@ -370,7 +368,9 @@ didStartReceivingResourceWithName: (nonnull NSString*)resourceName
                                            protocolType: kCBLProtocolTypeMessageStream
                                                delegate: self];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: NO];
-    [self run: config errorCode: 0 errorDomain: nil];
+    [self ignoreException:^{
+        [self run: config errorCode: 0 errorDomain: nil];
+    }];
     
     AssertEqual(_otherDB.count, 2u);
     CBLDocument* savedDoc = [_otherDB documentWithID: @"doc1"];
@@ -392,7 +392,9 @@ didStartReceivingResourceWithName: (nonnull NSString*)resourceName
                                            protocolType: kCBLProtocolTypeMessageStream
                                                delegate: self];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: NO];
-    [self run: config errorCode: 0 errorDomain: nil];
+    [self ignoreException:^{
+        [self run: config errorCode: 0 errorDomain: nil];
+    }];
     
     AssertEqual(_db.count, 2u);
     CBLDocument* savedDoc = [_db documentWithID: @"doc2"];
@@ -414,7 +416,9 @@ didStartReceivingResourceWithName: (nonnull NSString*)resourceName
                                            protocolType: kCBLProtocolTypeMessageStream
                                                delegate: self];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePushAndPull continuous: NO];
-    [self run: config errorCode: 0 errorDomain: nil];
+    [self ignoreException:^{
+        [self run: config errorCode: 0 errorDomain: nil];
+    }];
     
     AssertEqual(_otherDB.count, 2u);
     CBLDocument* savedDoc1 = [_db documentWithID: @"doc1"];
@@ -440,7 +444,9 @@ didStartReceivingResourceWithName: (nonnull NSString*)resourceName
                                            protocolType: kCBLProtocolTypeMessageStream
                                                delegate: self];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: YES];
-    [self run: config errorCode: 0 errorDomain: nil];
+    [self ignoreException:^{
+        [self run: config errorCode: 0 errorDomain: nil];
+    }];
     
     AssertEqual(_otherDB.count, 2u);
     CBLDocument* savedDoc = [_otherDB documentWithID: @"doc1"];
@@ -462,7 +468,9 @@ didStartReceivingResourceWithName: (nonnull NSString*)resourceName
                                            protocolType: kCBLProtocolTypeMessageStream
                                                delegate: self];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: NO];
-    [self run: config errorCode: 0 errorDomain: nil];
+    [self ignoreException:^{
+        [self run: config errorCode: 0 errorDomain: nil];
+    }];
     
     AssertEqual(_db.count, 2u);
     CBLDocument* savedDoc = [_db documentWithID: @"doc2"];
@@ -484,7 +492,9 @@ didStartReceivingResourceWithName: (nonnull NSString*)resourceName
                                            protocolType: kCBLProtocolTypeMessageStream
                                                delegate: self];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePushAndPull continuous: YES];
-    [self run: config errorCode: 0 errorDomain: nil];
+    [self ignoreException:^{
+        [self run: config errorCode: 0 errorDomain: nil];
+    }];
     
     AssertEqual(_otherDB.count, 2u);
     CBLDocument* savedDoc1 = [_db documentWithID: @"doc1"];

--- a/Objective-C/Tests/MessageEndpointTest.m
+++ b/Objective-C/Tests/MessageEndpointTest.m
@@ -174,7 +174,9 @@ MCSessionDelegate, CBLMessageEndpointDelegate, MultipeerConnectionDelegate>
     _browser.delegate = self;
     [_browser startBrowsingForPeers];
     
-    [self waitForExpectations: @[_clientConnected, _serverConnected] timeout: 10.0];
+    [self ignoreException:^{
+        [self waitForExpectations: @[_clientConnected, _serverConnected] timeout: 10.0];
+    }];
 }
 
 - (void) run: (CBLReplicatorConfiguration*)config


### PR DESCRIPTION
* when running the test, its stops on exception break point, saying the c4exception thrown. assuming its due to the reset connection by peer, and later on getting connected successfully. 
* reset connection exceptions where thrown when starting the discovery and listening. which can be ignored for uninterrupted unit test run. 
```
2019-12-12 05:40:53.528577+0530 xctest[90996:1950914] [] nw_socket_handle_socket_event [C3:1] Socket SO_ERROR [54: Connection reset by peer]
2019-12-12 05:40:53.530900+0530 xctest[90996:1950498] [MCNearbyServiceAdvertiser] PeerConnection connectedHandler (advertiser side) - error [Unable to connect].
2019-12-12 05:40:53.531055+0530 xctest[90996:1950498] [MCNearbyServiceAdvertiser] PeerConnection connectedHandler remoteServiceName is nil.
2019-12-12 05:40:53.532908+0530 xctest[90996:1950974] [] nw_socket_handle_socket_event [C4:1] Socket SO_ERROR [54: Connection reset by peer]
2019-12-12 05:40:53.533527+0530 xctest[90996:1950498] [MCNearbyServiceAdvertiser] PeerConnection connectedHandler (advertiser side) - error [Unable to connect].
2019-12-12 05:40:53.533593+0530 xctest[90996:1950498] [MCNearbyServiceAdvertiser] PeerConnection connectedHandler remoteServiceName is nil.
2019-12-12 05:40:53.535680+0530 xctest[90996:1950974] *** Connecting : client
2019-12-12 05:40:53.589306+0530 xctest[90996:1950974] *** Connecting : server
2019-12-12 05:40:53.947138+0530 xctest[90996:1950914] *** Connected : client
2019-12-12 05:40:53.947497+0530 xctest[90996:1950915] *** Connected : server
```