### PR TITLE
CBL-563: refac: reachability initialized on start

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -430,6 +430,8 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
         return;
     
     _reachability = [[CBLReachability alloc] initWithURL: remoteURL];
+    __weak auto weakSelf = self;
+    _reachability.onChange = ^{ [weakSelf reachabilityChanged]; };
 }
 
 - (void) startReachabilityObserver {
@@ -438,8 +440,6 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
         return;
     }
     
-    __weak auto weakSelf = self;
-    _reachability.onChange = ^{ [weakSelf reachabilityChanged]; };
     [_reachability startOnQueue: _dispatchQueue];
 }
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -552,7 +552,7 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
     convertError(c4err, &error);
     
     // Transient error or maybe still reachable:
-    if (transient || _reachability.reachableWithoutStart) {
+    if (transient || _reachability.reachable) {
         // On transient error, retry periodically, with exponential backoff:
         auto delay = retryDelay(++_retryCount);
         CBLLogInfo(Sync, @"%@: Transient error (%@); will retry in %.0f sec...",

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -552,7 +552,7 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
     convertError(c4err, &error);
     
     // Transient error or maybe still reachable:
-    if (transient || _reachability.reachable) {
+    if (transient || _reachability.reachableWithoutStart) {
         // On transient error, retry periodically, with exponential backoff:
         auto delay = retryDelay(++_retryCount);
         CBLLogInfo(Sync, @"%@: Transient error (%@); will retry in %.0f sec...",

--- a/Objective-C/Internal/Replicator/CBLReachability.h
+++ b/Objective-C/Internal/Replicator/CBLReachability.h
@@ -79,9 +79,6 @@ typedef void (^CBLReachabilityOnChangeBlock)(void);
     The call will be on the runloop or dispatch queue specified in the start method. */
 @property (copy, nullable, nonatomic) CBLReachabilityOnChangeBlock onChange;
 
-/** Is this host reachable via SCNetworkReachabilityGetFlags */
-@property (readonly, nonatomic) BOOL reachableWithoutStart;
-
 #if DEBUG
 + (void) setAlwaysAssumesProxy: (BOOL)alwaysAssumesProxy;   // For debugging
 #endif

--- a/Objective-C/Internal/Replicator/CBLReachability.h
+++ b/Objective-C/Internal/Replicator/CBLReachability.h
@@ -79,6 +79,8 @@ typedef void (^CBLReachabilityOnChangeBlock)(void);
     The call will be on the runloop or dispatch queue specified in the start method. */
 @property (copy, nullable, nonatomic) CBLReachabilityOnChangeBlock onChange;
 
+/** Is this host reachable via SCNetworkReachabilityGetFlags */
+@property (readonly, nonatomic) BOOL reachableWithoutStart;
 
 #if DEBUG
 + (void) setAlwaysAssumesProxy: (BOOL)alwaysAssumesProxy;   // For debugging

--- a/Objective-C/Internal/Replicator/CBLReachability.h
+++ b/Objective-C/Internal/Replicator/CBLReachability.h
@@ -59,8 +59,8 @@ typedef void (^CBLReachabilityOnChangeBlock)(void);
 - (BOOL) startOnQueue: (dispatch_queue_t)queue;
 
 /** Stops tracking reachability.
-    This is called automatically by -dealloc, but to be safe you can call it when you release your
-    CBLReachability instance, to make sure that in case of a leak it isn't left running forever. */
+    This is called automatically by -dealloc, but to be safe you can call it when you want to unschedule
+    and remove `onChange` callbacks, to make sure that in case of a leak it isn't left running forever. */
 - (void) stop;
 
 /** YES if the host's reachability has been determined, NO if it hasn't or if there was an error. */

--- a/Objective-C/Internal/Replicator/CBLReachability.m
+++ b/Objective-C/Internal/Replicator/CBLReachability.m
@@ -205,17 +205,10 @@ static BOOL sAlwaysAssumeProxy = NO;
 
 - (BOOL) reachable {
     // We want 'reachable' flag to be on, but not if user intervention is required (like PPP login)
-    return _reachabilityKnown
-        &&  (_reachabilityFlags & kSCNetworkReachabilityFlagsReachable)
-        && !(_reachabilityFlags & kSCNetworkReachabilityFlagsInterventionRequired);
-}
-
-- (BOOL) reachableWithoutStart {
     SCNetworkReachabilityFlags flag;
-    if (SCNetworkReachabilityGetFlags(_ref, &flag)) {
+    if (SCNetworkReachabilityGetFlags(_ref, &flag))
         return (flag & kSCNetworkReachabilityFlagsReachable) &&
-        !(_reachabilityFlags & kSCNetworkReachabilityFlagsInterventionRequired);
-    }
+        !(flag & kSCNetworkReachabilityFlagsInterventionRequired);
     return false;
 }
 

--- a/Objective-C/Internal/Replicator/CBLReachability.m
+++ b/Objective-C/Internal/Replicator/CBLReachability.m
@@ -203,16 +203,13 @@ static BOOL sAlwaysAssumeProxy = NO;
 
 - (BOOL) reachable {
     // We want 'reachable' flag to be on, but not if user intervention is required (like PPP login)
+    SCNetworkReachabilityFlags flags;
     if (_reachabilityKnown)
-        return (_reachabilityFlags & kSCNetworkReachabilityFlagsReachable)
-        && !(_reachabilityFlags & kSCNetworkReachabilityFlagsInterventionRequired);
+        flags = _reachabilityFlags;
+    else if (!SCNetworkReachabilityGetFlags(_ref, &flags))
+        return false;
     
-    SCNetworkReachabilityFlags flag;
-    if (SCNetworkReachabilityGetFlags(_ref, &flag))
-        return (flag & kSCNetworkReachabilityFlagsReachable) &&
-        !(flag & kSCNetworkReachabilityFlagsInterventionRequired);
-    
-    return false;
+    return (flags & kSCNetworkReachabilityFlagsReachable) && !(flags & kSCNetworkReachabilityFlagsInterventionRequired);
 }
 
 - (BOOL) reachableByWiFi {

--- a/Objective-C/Internal/Replicator/CBLReachability.m
+++ b/Objective-C/Internal/Replicator/CBLReachability.m
@@ -180,9 +180,7 @@ static BOOL sAlwaysAssumeProxy = NO;
 }
 
 - (NSString*) status {
-    if (!_reachabilityKnown)
-        return @"unknown";
-    else if (!self.reachable)
+    if (!self.reachable)
         return @"unreachable";
 #if TARGET_OS_IPHONE
     else if (!self.reachableByWiFi)
@@ -205,10 +203,15 @@ static BOOL sAlwaysAssumeProxy = NO;
 
 - (BOOL) reachable {
     // We want 'reachable' flag to be on, but not if user intervention is required (like PPP login)
+    if (_reachabilityKnown)
+        return (_reachabilityFlags & kSCNetworkReachabilityFlagsReachable)
+        && !(_reachabilityFlags & kSCNetworkReachabilityFlagsInterventionRequired);
+    
     SCNetworkReachabilityFlags flag;
     if (SCNetworkReachabilityGetFlags(_ref, &flag))
         return (flag & kSCNetworkReachabilityFlagsReachable) &&
         !(flag & kSCNetworkReachabilityFlagsInterventionRequired);
+    
     return false;
 }
 

--- a/Objective-C/Internal/Replicator/CBLReachability.m
+++ b/Objective-C/Internal/Replicator/CBLReachability.m
@@ -210,6 +210,15 @@ static BOOL sAlwaysAssumeProxy = NO;
         && !(_reachabilityFlags & kSCNetworkReachabilityFlagsInterventionRequired);
 }
 
+- (BOOL) reachableWithoutStart {
+    SCNetworkReachabilityFlags flag;
+    if (SCNetworkReachabilityGetFlags(_ref, &flag)) {
+        return (flag & kSCNetworkReachabilityFlagsReachable) &&
+        !(_reachabilityFlags & kSCNetworkReachabilityFlagsInterventionRequired);
+    }
+    return false;
+}
+
 - (BOOL) reachableByWiFi {
     return self.reachable
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
* previously we were only initializing the replicator when there is some transient error happened.
* now refactored to initialize on start and start the observer when there is any transient error.
* move all reachability functions to a pragma mark.
* seems only the startReachability on dispatchQueue is only used, and run-loop is not used in code.
* convert the global variable "allowReachability" to a local one, since we are initializing on start.
* in case the reachability instance is not initialized, added a verbose log to print, for debugging.