### PR TITLE
fix: CBL-649: handle encode error

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -989,7 +989,7 @@ static C4DatabaseConfig c4DatabaseConfig (CBLDatabaseConfiguration *config) {
                 CBLConflict* conflict = [[CBLConflict alloc] initWithID: docID
                                                           localDocument: localDoc.isDeleted ? nil : localDoc
                                                          remoteDocument: remoteDoc.isDeleted ? nil : remoteDoc];
-                 
+                
                 resolvedDoc = [conflictResolver resolve: conflict];
             }
             

--- a/Objective-C/CBLMutableDocument.mm
+++ b/Objective-C/CBLMutableDocument.mm
@@ -183,9 +183,10 @@
         return {};
     }
     FLError flErr;
+    const char* errMessage = FLEncoder_GetErrorMessage(encoder);
     FLSliceResult body = FLEncoder_Finish(encoder, &flErr);
     if (!body.buf)
-        convertError(flErr, outError);
+        createError(flErr, [NSString stringWithUTF8String: errMessage], outError);
     return body;
 }
 

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -867,7 +867,6 @@
     [replicator removeChangeListenerWithToken: token];
     
     // using blob from remote document of user's- which is a different database
-    
     CBLDocument* otherDBDoc = [otherDB documentWithID: docID];
     [self makeConflictFor: docID withLocal: localData withRemote: remoteData];
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -838,7 +838,7 @@
     [replicator removeChangeListenerWithToken: docReplToken];
 }
 
-- (void)testConflictResolverReturningBlobFromDifferentDB {
+- (void) testConflictResolverReturningBlobFromDifferentDB {
     NSString* docID = @"doc";
     NSData* content = [@"I'm a blob." dataUsingEncoding: NSUTF8StringEncoding];
     CBLBlob* blob = [[CBLBlob alloc] initWithContentType:@"text/plain" data: content];
@@ -867,6 +867,7 @@
     [replicator removeChangeListenerWithToken: token];
     
     // using blob from remote document of user's- which is a different database
+    
     CBLDocument* otherDBDoc = [otherDB documentWithID: docID];
     [self makeConflictFor: docID withLocal: localData withRemote: remoteData];
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {


### PR DESCRIPTION
* previously when blob throws an nsexception it was returned back to CBL side, recently the Fleece APIs are noexcept, so exceptions thrown can be ignored and only look for error object.
* remove try..catch since the methods are no longer throwable.
* use utility method when creating the CBLError.
* fetch Fleece Error Message before finishing the Encoding, so if there is any error happened, we can pass the error message too.
* related PR: https://github.com/couchbaselabs/fleece/pull/69