### PR TITLE
CBL-717: Fix in..batch API

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -362,9 +362,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 - (BOOL) inBatch: (NSError**)outError usingBlock: (void (NS_NOESCAPE ^)())block {
     CBLAssertNotNil(block);
     
-    return [self inBatch: outError usingThrowableBlock:^(NSError **) {
-        block();
-    }];
+    return [self inBatch: outError usingThrowableBlock:^(NSError **) { block(); }];
 }
 
 #pragma mark - DATABASE MAINTENANCE

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -319,7 +319,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 
 #pragma mark - BATCH OPERATION
 
-- (BOOL) inBatch: (NSError**)outError usingThrowableBlock: (void (NS_NOESCAPE ^)(NSError**))block {
+- (BOOL) inBatch: (NSError**)outError usingBlockWithError: (void (NS_NOESCAPE ^)(NSError**))block {
     CBLAssertNotNil(block);
     
     CBL_LOCK(self) {
@@ -362,7 +362,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 - (BOOL) inBatch: (NSError**)outError usingBlock: (void (NS_NOESCAPE ^)())block {
     CBLAssertNotNil(block);
     
-    return [self inBatch: outError usingThrowableBlock:^(NSError **) { block(); }];
+    return [self inBatch: outError usingBlockWithError: ^(NSError **) { block(); }];
 }
 
 #pragma mark - DATABASE MAINTENANCE

--- a/Objective-C/Internal/CBLDatabase+Swift.h
+++ b/Objective-C/Internal/CBLDatabase+Swift.h
@@ -23,4 +23,6 @@
 
 + (void) checkFileLogging: (BOOL)swift;
 
+- (BOOL) inBatch: (NSError**)error usingThrowableBlock: (void (NS_NOESCAPE ^)(NSError**))block NS_REFINED_FOR_SWIFT;
+
 @end

--- a/Objective-C/Internal/CBLDatabase+Swift.h
+++ b/Objective-C/Internal/CBLDatabase+Swift.h
@@ -23,6 +23,6 @@
 
 + (void) checkFileLogging: (BOOL)swift;
 
-- (BOOL) inBatch: (NSError**)error usingThrowableBlock: (void (NS_NOESCAPE ^)(NSError**))block NS_REFINED_FOR_SWIFT;
+- (BOOL) inBatch: (NSError**)error usingBlockWithError: (void (NS_NOESCAPE ^)(NSError**))block NS_REFINED_FOR_SWIFT;
 
 @end

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -368,6 +368,21 @@
     [self validateDocs: 10];
 }
 
+- (void) testPartialSaveInBatch {
+    __block NSError* error = nil;
+    [self ignoreException: ^{
+        BOOL success = [self.db inBatch: &error usingBlock: ^{
+            [self createDocs: 5];
+            [NSException raise: NSInternalInconsistencyException format: @""];
+        }];
+        AssertFalse(success);
+    }];
+    
+    AssertNotNil(error);
+    AssertEqual(error.code, CBLErrorUnexpectedError);
+    AssertEqual(self.db.count, 0u);
+}
+
 - (void) testSaveDocToClosedDB {
     [self closeDatabase: self.db];
     

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -204,16 +204,8 @@ public final class Database {
     /// - Parameter block: The block to be executed as a batch operations.
     /// - Throws: An error on a failure.
     public func inBatch(using block: () throws -> Void ) throws {
-        var caught: Error? = nil
-        try _impl.inBatch(usingBlock: {
-            do {
-                try block()
-            } catch let error {
-                caught = error
-            }
-        })
-        if let caught = caught {
-            throw caught
+        try _impl.inBatch {
+            try block()
         }
     }
     
@@ -422,4 +414,16 @@ public final class Database {
 
     let _impl: CBLDatabase
     
+}
+
+extension CBLDatabase {
+    func inBatch(block: () throws -> Void) throws -> Void {
+        try __inBatch(usingThrowableBlock: { (errPtr) in
+            do {
+                try block()
+            } catch {
+                errPtr?.pointee = error as NSError
+            }
+        })
+    }
 }

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -418,7 +418,7 @@ public final class Database {
 
 extension CBLDatabase {
     func inBatch(block: () throws -> Void) throws -> Void {
-        try __inBatch(usingThrowableBlock: { (errPtr) in
+        try __inBatch(usingBlockWithError: { (errPtr) in
             do {
                 try block()
             } catch {

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -231,6 +231,19 @@ class DatabaseTest: CBLTestCase {
         validateDocs(10)
     }
     
+    func testPartialSaveInBatch() throws {
+        do {
+            try self.db.inBatch {
+                try self.createDocs(10)
+                throw NSError(domain: "X", code: 101, userInfo: nil)
+            }
+        } catch {
+            XCTAssertNotNil(error);
+            XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
+        }
+        XCTAssertEqual(db.count, 0)
+    }
+    
     func testSaveManyDocs() throws {
         try createDocs(1000)
         XCTAssertEqual(db.count, 1000)


### PR DESCRIPTION
* in batch API when thrown exception(from block) was not cancelling the transaction.
* created separate method with throwable block and start handle when swift throws exception.
* in case of objc, same issue exists. 
* include unit tests