### PR TITLE
CBL-711: feat: swift pending document ids APIs

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		1A4160DF228375990061A567 /* ReplicatorTest+CustomConflict.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A4160C52283673E0061A567 /* ReplicatorTest+CustomConflict.m */; };
 		1A4160E02283759A0061A567 /* ReplicatorTest+CustomConflict.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A4160C52283673E0061A567 /* ReplicatorTest+CustomConflict.m */; };
 		1A4FE76A225ED344009D5F43 /* MiscCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A4FE769225ED344009D5F43 /* MiscCppTest.mm */; };
+		1A690CD6242150DE0084D017 /* ReplicatorTest+PendingDocIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */; };
+		1A690CD7242150DF0084D017 /* ReplicatorTest+PendingDocIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */; };
 		1A8DD7DA21C9876E00741C47 /* DateTimeQueryFunctionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */; };
 		1AA3D6C122A1A41E0098E16B /* ReplicatorTest+CustomConflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */; };
 		1AA3D6C222A1A41F0098E16B /* ReplicatorTest+CustomConflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */; };
@@ -1647,6 +1649,7 @@
 		1A4160D6228367520061A567 /* ReplicatorTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReplicatorTest.h; sourceTree = "<group>"; };
 		1A4160D922836C7F0061A567 /* ReplicatorTest+Main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ReplicatorTest+Main.m"; sourceTree = "<group>"; };
 		1A4FE769225ED344009D5F43 /* MiscCppTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MiscCppTest.mm; sourceTree = "<group>"; };
+		1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReplicatorTest+PendingDocIds.swift"; sourceTree = "<group>"; };
 		1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeQueryFunctionTest.swift; sourceTree = "<group>"; };
 		1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReplicatorTest+CustomConflict.swift"; sourceTree = "<group>"; };
 		1AA3D77122AB06E10098E16B /* CustomLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomLogger.h; sourceTree = "<group>"; };
@@ -2367,6 +2370,7 @@
 				93AE16E2221DC92E00539C05 /* PredictiveQueryTest+CoreML.swift */,
 				93DB80021ED8FE5100C4F845 /* ReplicatorTest.swift */,
 				1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */,
+				1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */,
 				1AA91DC522B0356000BF0BDE /* CustomLogger.swift */,
 				939B79241E679017009A70EF /* Info.plist */,
 			);
@@ -4804,6 +4808,7 @@
 				27BE3B4D1E4E51C80012B74A /* DatabaseTest.swift in Sources */,
 				934C2CDE1F4FC0D20010316F /* CBLTestHelper.m in Sources */,
 				9388CC5521C25CC7005CA66D /* LogTest.swift in Sources */,
+				1A690CD6242150DE0084D017 /* ReplicatorTest+PendingDocIds.swift in Sources */,
 				93F74A9B1EC554D5001289F8 /* FragmentTest.swift in Sources */,
 				1A8DD7DA21C9876E00741C47 /* DateTimeQueryFunctionTest.swift in Sources */,
 				93A91C6C1E81CE4D003D01A2 /* QueryTest.swift in Sources */,
@@ -5242,6 +5247,7 @@
 				9343F18E207D636300F19A89 /* DocumentTest.swift in Sources */,
 				93E8FEBD20A3E4600061347F /* MessageEndpointTest.swift in Sources */,
 				9343F18F207D636300F19A89 /* ArrayTest.swift in Sources */,
+				1A690CD7242150DF0084D017 /* ReplicatorTest+PendingDocIds.swift in Sources */,
 				9343F190207D636300F19A89 /* ReplicatorTest.swift in Sources */,
 				9343F191207D636300F19A89 /* NotificationTest.swift in Sources */,
 				9343F192207D636300F19A89 /* DatabaseTest.swift in Sources */,

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -170,7 +170,7 @@ typedef struct {
  @return true if the document has one or more revisions pending, false otherwise
  
  */
-- (BOOL) isDocumentPending: (NSString*)documentID error: (NSError**)error;
+- (BOOL) isDocumentPending: (NSString*)documentID error: (NSError**)error NS_SWIFT_NOTHROW;
 
 @end
 

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -175,6 +175,29 @@ public final class Replicator {
         _impl.removeChangeListener(with: token._impl)
     }
     
+    /// Gets a set of document Ids, who have revisions pending push. This API is a snapshot and results
+    /// may change between the time the call was made and the time the call returns.
+    ///
+    /// - Returns: A  set of document Ids, each of which has one or more pending revisions
+    public func pendingDocumentIds() throws -> Set<String> {
+        return try _impl.pendingDocumentIDs()
+    }
+
+    /// Checks if the document with the given ID has revisions pending push.  This API is a snapshot and
+    /// results may change between the time the call was made and the time the call returns.
+    ///
+    /// - Parameter documentID: The ID of the document to check
+    /// - Returns: true if the document has one or more revisions pending, false otherwise
+    public func isDocumentPending(_ documentID: String) throws -> Bool {
+        var error: NSError?
+        let result = _impl.isDocumentPending(documentID, error: &error)
+        if let err = error {
+            throw err
+        }
+
+        return result
+    }
+    
     // MARK: Internal
     
     func registerActiveReplicator() {

--- a/Swift/Tests/ReplicatorTest+PendingDocIds.swift
+++ b/Swift/Tests/ReplicatorTest+PendingDocIds.swift
@@ -1,0 +1,166 @@
+//
+//  ReplicatorTest+PendingDocIds.swift
+//  CouchbaseLite
+//
+//  Copyright (c) 2020 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import CouchbaseLiteSwift
+
+class ReplicatorTest_PendingDocIds: ReplicatorTest {
+    let kActionKey = "action-key"
+    let kNoOfDocument = 5
+    let kCreateActionValue = "doc-create"
+    let kUpdateActionValue = "doc-update"
+    
+    // MARK: Helper methods
+    
+    /// create docs : [doc-1, doc-2, ...] upto `kNoOfDocument` docs.
+    func createDocs() throws -> Set<String> {
+        var docIds = Set<String>();
+        for i in 0..<kNoOfDocument {
+            let doc = createDocument("doc-\(i)")
+            doc.setValue(kCreateActionValue, forKey: kActionKey)
+            try saveDocument(doc)
+            docIds.insert("doc-\(i)")
+        }
+        return docIds
+    }
+    
+    func validatePendingDocumentIDs(_ docIds: Set<String>, config rConfig: ReplicatorConfiguration? = nil) {
+        var replConfig: ReplicatorConfiguration!
+        if rConfig != nil {
+            replConfig = rConfig
+        } else {
+            replConfig = config(target: DatabaseEndpoint(database: otherDB),
+                                type: .push, continuous: false)
+        }
+        
+        var replicator: Replicator!
+        var token: ListenerToken!
+        run(config: replConfig, reset: false, expectedError: nil) { (r) in
+            replicator = r
+            
+            // verify before starting the replicator
+            XCTAssertEqual(try! replicator.pendingDocumentIds(), docIds)
+            XCTAssertEqual(try! replicator.pendingDocumentIds().count, docIds.count)
+            
+            token = r.addChangeListener({ (change) in
+                let pDocIds = try! replicator.pendingDocumentIds()
+                
+                if change.status.activity == .connecting {
+                    XCTAssertEqual(pDocIds, docIds)
+                    XCTAssertEqual(pDocIds.count, docIds.count)
+                } else if change.status.activity == .stopped {
+                    XCTAssertEqual(pDocIds.count, 0)
+                }
+            })
+        }
+        
+        replicator.removeChangeListener(withToken: token)
+    }
+    
+    func validateIsDocumentPending() throws {
+        
+    }
+    
+    // MARK: Unit Tests
+    func testPendingDocIDsPullOnlyException() throws {
+        let target = DatabaseEndpoint(database: otherDB)
+        let replConfig = config(target: target, type: .pull, continuous: false)
+        
+        var replicator: Replicator!
+        var token: ListenerToken!
+        var pullOnlyError: NSError!
+        run(config: replConfig, reset: false, expectedError: nil) { (r) in
+            replicator = r
+            
+            token = r.addChangeListener({ (change) in
+                if change.status.activity == .connecting {
+                    self.ignoreException {
+                        do {
+                            let _ = try replicator.pendingDocumentIds()
+                        } catch {
+                            pullOnlyError = error as NSError
+                        }
+                    }
+                }
+            })
+        }
+        
+        XCTAssertEqual(pullOnlyError.code, CBLErrorUnsupported)
+        replicator.removeChangeListener(withToken: token)
+    }
+    
+    func testPendingDocIDsWithCreate() throws {
+        let docIds = try createDocs()
+        validatePendingDocumentIDs(docIds)
+    }
+    
+    func testPendingDocIDsWithUpdate() throws {
+        let _ = try createDocs()
+        
+        let target = DatabaseEndpoint(database: otherDB)
+        let replConfig = config(target: target, type: .push, continuous: false)
+        run(config: replConfig, expectedError: nil)
+        
+        let updatedIds: Set = ["doc-2", "doc-4"]
+        for docId in updatedIds {
+            let doc = db.document(withID: docId)!.toMutable()
+            doc.setString(kUpdateActionValue, forKey: kActionKey)
+            try saveDocument(doc)
+        }
+        
+        validatePendingDocumentIDs(updatedIds)
+    }
+    
+    func testPendingDocIdsWithDelete() throws {
+        let _ = try createDocs()
+        
+        let target = DatabaseEndpoint(database: otherDB)
+        let replConfig = config(target: target, type: .push, continuous: false)
+        run(config: replConfig, expectedError: nil)
+        
+        let deletedIds: Set = ["doc-2", "doc-4"]
+        for docId in deletedIds {
+            let doc = db.document(withID: docId)!
+            try db.deleteDocument(doc)
+        }
+        
+        validatePendingDocumentIDs(deletedIds)
+    }
+    
+    func testPendingDocIdsWithPurge() throws {
+        var docs = try createDocs()
+        
+        try db.purgeDocument(withID: "doc-3")
+        docs.remove("doc-3")
+        
+        validatePendingDocumentIDs(docs)
+    }
+    
+    func testPendingDocIdsWithFilter() throws {
+        let _ = try createDocs()
+        
+        let target = DatabaseEndpoint(database: otherDB)
+        let replConfig = config(target: target, type: .push, continuous: false)
+        replConfig.pushFilter = { (doc, flags) -> Bool in
+            return doc.id == "doc-3"
+        }
+        
+        validatePendingDocumentIDs(["doc-3"], config: replConfig)
+    }
+}


### PR DESCRIPTION
* copy pending document ids feature from previously reverted change.
* include unit tests for `pendingDocumentIDs` and `isDocumentPending` API
* include no-throw for swift, in objc header
* since the background and suspended state setting cannot be done from swift, skipping the offline test in swift. 

ref: #2583, #2567