### PR TITLE
CBL-769 : Implement Query’s Meta.revisionID

### DIFF
--- a/Objective-C/CBLQueryExpression.m
+++ b/Objective-C/CBLQueryExpression.m
@@ -40,9 +40,7 @@
 + (CBLQueryExpression*) property: (NSString*)property from: (nullable NSString*)alias {
     CBLAssertNotNil(property);
     
-    return [[CBLPropertyExpression alloc] initWithKeyPath: property
-                                               columnName: nil
-                                                     from: alias];
+    return [[CBLPropertyExpression alloc] initWithKeyPath: property from: alias];
 }
 
 + (CBLQueryExpression*) all {

--- a/Objective-C/CBLQueryMeta.h
+++ b/Objective-C/CBLQueryMeta.h
@@ -44,6 +44,21 @@ NS_ASSUME_NONNULL_BEGIN
 + (CBLQueryExpression*) idFrom: (nullable NSString*)alias;
 
 /**
+ A metadata expression refering to the revision ID of the document.
+ 
+ @return The revision ID expression.
+ */
++ (CBLQueryExpression*) revisionID;
+
+/**
+ A metadata expression refering to the revision ID of the document.
+ 
+ @param alias The data source alias name.
+ @return The revision ID expression.
+ */
++ (CBLQueryExpression*) revisionIDFrom: (nullable NSString*)alias;
+
+/**
  Sequence number expression. The sequence number indicates how recently
  the document has been changed. If one document's `sequence` is greater
  than another's, that means it was changed more recently.

--- a/Objective-C/CBLQueryMeta.m
+++ b/Objective-C/CBLQueryMeta.m
@@ -22,16 +22,10 @@
 #import "CBLPropertyExpression.h"
 
 #define kCBLQueryMetaIDKeyPath @"_id"
-#define kCBLQueryMetaIDColumnName @"id"
-
+#define kCBLQueryMetaRevIDKeyPath @"_revisionID"
 #define kCBLQueryMetaSequenceKeyPath @"_sequence"
-#define kCBLQueryMetaSequenceColumnName @"sequence"
-
 #define kCBLQueryMetaIsDeletedKeyPath @"_deleted"
-#define kCBLQueryMetaIsDeletedColumnName @"deleted"
-
 #define kCBLQueryMetaExpiredKeyPath @"_expiration"
-#define kCBLQueryMetaExpiredColumnName @"expiration"
 
 @implementation CBLQueryMeta
 
@@ -41,7 +35,6 @@
 
 + (CBLQueryExpression*) idFrom: (nullable NSString *)alias {
     return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaIDKeyPath
-                                               columnName: kCBLQueryMetaIDColumnName
                                                      from: alias];
 }
 
@@ -51,7 +44,6 @@
 
 + (CBLQueryExpression*) sequenceFrom: (nullable NSString*)alias {
     return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaSequenceKeyPath
-                                               columnName: kCBLQueryMetaSequenceColumnName
                                                      from: alias];
 }
 
@@ -61,7 +53,6 @@
 
 + (CBLQueryExpression*) isDeletedFrom: (nullable NSString*)alias {
     return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaIsDeletedKeyPath
-                                               columnName: kCBLQueryMetaIsDeletedColumnName
                                                      from: alias];
 }
 
@@ -71,7 +62,15 @@
 
 + (CBLQueryExpression*) expirationFrom: (NSString*)alias {
     return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaExpiredKeyPath
-                                               columnName: kCBLQueryMetaExpiredColumnName
+                                                     from: alias];
+}
+
++ (CBLQueryExpression*) revisionID {
+    return [self revisionIDFrom: nil];
+}
+
++ (CBLQueryExpression*) revisionIDFrom: (NSString*)alias {
+    return [[CBLPropertyExpression alloc] initWithKeyPath: kCBLQueryMetaRevIDKeyPath
                                                      from: alias];
 }
 

--- a/Objective-C/CBLQuerySelectResult.m
+++ b/Objective-C/CBLQuerySelectResult.m
@@ -69,17 +69,6 @@
     return self;
 }
 
-- (nullable NSString*) columnName {
-    if (_alias)
-        return _alias;
-    
-    CBLPropertyExpression* property = $castIf(CBLPropertyExpression, _expression);
-    if (property)
-        return property.columnName;
-    
-    return nil;
-}
-
 - (id) asJSON {
     id json = [_expression asJSON];
     if (_alias)

--- a/Objective-C/Internal/CBLPropertyExpression.h
+++ b/Objective-C/Internal/CBLPropertyExpression.h
@@ -28,14 +28,9 @@ extern NSString* const kCBLAllPropertiesName;
 
 @property(nonatomic, readonly) NSString* keyPath;
 
-@property(nonatomic, readonly) NSString* columnName;
-
 @property(nonatomic, readonly, nullable) NSString* from; // Data Source Alias
 
-- (instancetype) initWithKeyPath: (NSString*)keyPath
-                      columnName: (nullable NSString*)columnName
-                            from: (nullable NSString*)from;
-
+- (instancetype) initWithKeyPath: (NSString*)keyPath from: (nullable NSString*)from;
 
 + (instancetype) allFrom: (nullable NSString*)from;
 

--- a/Objective-C/Internal/CBLPropertyExpression.m
+++ b/Objective-C/Internal/CBLPropertyExpression.m
@@ -24,24 +24,20 @@ NSString* const kCBLAllPropertiesName = @"";
 
 @implementation CBLPropertyExpression
 
-@synthesize keyPath=_keyPath, columnName=_columnName, from=_from;
+@synthesize keyPath=_keyPath, from=_from;
 
 - (instancetype) initWithKeyPath: (NSString*)keyPath
-                      columnName: (nullable NSString*)columnName
                             from: (NSString*)from {
     self = [super initWithNone];
     if (self) {
         _keyPath = keyPath;
-        _columnName = columnName;
         _from = from;
     }
     return self;
 }
 
 + (instancetype) allFrom: (nullable NSString*)from {
-    // Use data source alias name as the column name if specified:
-    NSString* colName = from ? from : kCBLAllPropertiesName;
-    return [[self alloc] initWithKeyPath: kCBLAllPropertiesName columnName: colName from: from];
+    return [[self alloc] initWithKeyPath: kCBLAllPropertiesName from: from];
 }
 
 - (id) asJSON {
@@ -51,12 +47,6 @@ NSString* const kCBLAllPropertiesName = @"";
     else
         [json addObject: [NSString stringWithFormat: @".%@", _keyPath]];
     return json;
-}
-
-- (NSString*) columnName {
-    if (!_columnName)
-        _columnName = [_keyPath componentsSeparatedByString: @"."].lastObject;
-    return _columnName;
 }
 
 @end

--- a/Objective-C/Internal/CBLQuery+Internal.h
+++ b/Objective-C/Internal/CBLQuery+Internal.h
@@ -69,8 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype) initWithExpression: (CBLQueryExpression*)expression
                                  as: (nullable NSString*)alias;
 
-@property (nonatomic, readonly, nullable) NSString* columnName;
-
 @end
 
 

--- a/Objective-C/Tests/QueryTest.h
+++ b/Objective-C/Tests/QueryTest.h
@@ -20,6 +20,7 @@
 #import "CBLTestCase.h"
 
 #define kDOCID      [CBLQuerySelectResult expression: [CBLQueryMeta id]]
+#define kREVID      [CBLQuerySelectResult expression: [CBLQueryMeta revisionID]]
 #define kSEQUENCE   [CBLQuerySelectResult expression: [CBLQueryMeta sequence]]
 
 @interface QueryTest : CBLTestCase

--- a/Swift/Meta.swift
+++ b/Swift/Meta.swift
@@ -39,6 +39,11 @@ public final class Meta {
         return MetaExpression(type: .id)
     }
     
+    /// A metadata expression refering to the revisionID of the document.
+    public static var revisionID: MetaExpressionProtocol {
+        return MetaExpression(type: .revisionID)
+    }
+    
     /// A metadata expression refering to the sequence number of the document.
     /// The sequence number indicates how recently the document has been changed. If one document's
     /// `sequence` is greater than another's, that means it was changed more recently.
@@ -59,7 +64,7 @@ public final class Meta {
 }
 
 /* internal */ enum MetaType {
-    case id, sequence, isDeleted, expiration
+    case id, revisionID, sequence, isDeleted, expiration
 }
 
 /* internal */ class MetaExpression: QueryExpression, MetaExpressionProtocol {
@@ -85,6 +90,8 @@ public final class Meta {
         switch type {
         case .id:
             return CBLQueryMeta.id(from: from)
+        case .revisionID:
+            return CBLQueryMeta.revisionID(from: from)
         case .sequence:
             return CBLQueryMeta.sequence(from: from)
         case .isDeleted:

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -191,6 +191,7 @@ class CBLTestCase: XCTestCase {
         }
     }
     
+    @discardableResult
     func verifyQuery(_ query: Query, block: (UInt64, Result) throws ->Void) throws -> UInt64 {
         var n: UInt64 = 0
         for row in try query.execute() {


### PR DESCRIPTION
* Implemented Query’s Meta.revisionID in ObjC and Swift
* Removed obsolete code that was used for computing the column name on Meta and All properties.