### PR TITLE
Add VALID_ARCHS to Project.xcconfig

### DIFF
--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -33,6 +33,13 @@ SKIP_INSTALL                       = YES
 SUPPORTED_PLATFORMS                = macosx iphoneos iphonesimulator appletvos appletvsimulator
 TARGETED_DEVICE_FAMILY             = 1,2
 
+VALID_ARCHS                        = x86_64 arm64 armv7 armv7s
+VALID_ARCHS[sdk=macosx*]           = x86_64
+VALID_ARCHS[sdk=iphonesimulator*]  = x86_64
+VALID_ARCHS[sdk=appletvsimulator*] = x86_64
+VALID_ARCHS[sdk=iphoneos*]         =        arm64 armv7 armv7s
+VALID_ARCHS[sdk=appletvos*]        =        arm64
+
 ALWAYS_SEARCH_USER_PATHS           = NO
 
 CLANG_CXX_LANGUAGE_STANDARD        = gnu++0x


### PR DESCRIPTION
The values are based on the VALID_ARCHS defined in LiteCore. 

Note: It's not cleared if 'arm64e' will be needed or not so I haven't included it.

CBL-942