### PR TITLE
CBL-817: Add unit tests for URLEndpointListener 

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		1A4FE76A225ED344009D5F43 /* MiscCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A4FE769225ED344009D5F43 /* MiscCppTest.mm */; };
 		1A690CD6242150DE0084D017 /* ReplicatorTest+PendingDocIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */; };
 		1A690CD7242150DF0084D017 /* ReplicatorTest+PendingDocIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */; };
+		1A6F0945246C78FC0097D8B5 /* URLEndpointListenerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A6F0941246C78FC0097D8B5 /* URLEndpointListenerTest.m */; };
+		1A6F0951246C792A0097D8B5 /* URLEndpointListenerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A6F0941246C78FC0097D8B5 /* URLEndpointListenerTest.m */; };
 		1A8DD7DA21C9876E00741C47 /* DateTimeQueryFunctionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */; };
 		1AA3D6C122A1A41E0098E16B /* ReplicatorTest+CustomConflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */; };
 		1AA3D6C222A1A41F0098E16B /* ReplicatorTest+CustomConflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */; };
@@ -1803,6 +1805,7 @@
 		1A4160D922836C7F0061A567 /* ReplicatorTest+Main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ReplicatorTest+Main.m"; sourceTree = "<group>"; };
 		1A4FE769225ED344009D5F43 /* MiscCppTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MiscCppTest.mm; sourceTree = "<group>"; };
 		1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReplicatorTest+PendingDocIds.swift"; sourceTree = "<group>"; };
+		1A6F0941246C78FC0097D8B5 /* URLEndpointListenerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = URLEndpointListenerTest.m; sourceTree = "<group>"; };
 		1A8DD7D921C9876E00741C47 /* DateTimeQueryFunctionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeQueryFunctionTest.swift; sourceTree = "<group>"; };
 		1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReplicatorTest+CustomConflict.swift"; sourceTree = "<group>"; };
 		1AA3D77122AB06E10098E16B /* CustomLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomLogger.h; sourceTree = "<group>"; };
@@ -3451,6 +3454,7 @@
 				1ACDD8C223FF5BB200AF5D56 /* ReplicatorTest+PendingDocIds.m */,
 				934EF80B2453770E0053A47C /* TLSIdentityTest.m */,
 				1ACEB9662256B74A00DED54C /* TrustCheckTest.m */,
+				1A6F0941246C78FC0097D8B5 /* URLEndpointListenerTest.m */,
 				1AA3D77122AB06E10098E16B /* CustomLogger.h */,
 				1AA3D77222AB06E10098E16B /* CustomLogger.m */,
 				93DECF3E200DBE5800F44953 /* Support */,
@@ -5647,6 +5651,7 @@
 				9343F13E207D61EC00F19A89 /* DocumentTest.m in Sources */,
 				939260B120A0FF0C00E5748C /* MessageEndpointTest.m in Sources */,
 				9343F140207D61EC00F19A89 /* DictionaryTest.m in Sources */,
+				1A6F0945246C78FC0097D8B5 /* URLEndpointListenerTest.m in Sources */,
 				9343F141207D61EC00F19A89 /* ConcurrentTest.m in Sources */,
 				9388CBAD21BD9185005CA66D /* DocumentExpirationTest.m in Sources */,
 				9343F142207D61EC00F19A89 /* ReplicatorTest.m in Sources */,
@@ -5697,6 +5702,7 @@
 				933F841E220BA4100093EC88 /* PredictiveQueryTest+CoreML.m in Sources */,
 				1AA3D78822AB07D80098E16B /* CustomLogger.m in Sources */,
 				9343F17B207D633300F19A89 /* ArrayTest.m in Sources */,
+				1A6F0951246C792A0097D8B5 /* URLEndpointListenerTest.m in Sources */,
 				9388CC4121C1E2BA005CA66D /* LogTest.m in Sources */,
 				9343F17C207D633300F19A89 /* FragmentTest.m in Sources */,
 				1AA6744D227924130018CC6D /* QueryTest+Join.m in Sources */,

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -35,7 +35,8 @@ typedef CBLURLEndpointListener Listener;
 @implementation URLEndpointListenerTest
 
 - (Listener*) listenAt: (uint16)port {
-    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: port];
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB];
+    config.port = port;
     config.disableTLS = YES;
     Listener* list = [[Listener alloc] initWithConfig: config];
     
@@ -49,7 +50,8 @@ typedef CBLURLEndpointListener Listener;
 
 - (void) testPort {
     // initialize a listener
-    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB];
+    config.port = kPort;
     config.disableTLS = YES;
     Listener* list = [[Listener alloc] initWithConfig: config];
     AssertEqual(list.port, 0);
@@ -67,7 +69,8 @@ typedef CBLURLEndpointListener Listener;
 
 - (void) testEmptyPort {
     // initialize a listener
-    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: 0];
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB];
+    config.port = 0;
     config.disableTLS = YES;
     Listener* list = [[Listener alloc] initWithConfig: config];
     AssertEqual(list.port, 0);
@@ -87,7 +90,8 @@ typedef CBLURLEndpointListener Listener;
     Listener* list1 = [self listenAt: kPort];
     
     // initialize a listener at same port
-    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB];
+    config.port = kPort;
     config.disableTLS = YES;
     Listener* list2 = [[Listener alloc] initWithConfig: config];
     
@@ -105,7 +109,8 @@ typedef CBLURLEndpointListener Listener;
 
 // TODO: https://issues.couchbase.com/browse/CBL-948
 - (void) _testURLs {
-    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB];
+    config.port = kPort;
     config.disableTLS = YES;
     Listener* list = [[Listener alloc] initWithConfig: config];
     AssertEqual(list.urls.count, 0);
@@ -121,10 +126,10 @@ typedef CBLURLEndpointListener Listener;
     AssertEqual(list.urls.count, 0);
 }
 
-// TODO: LiteCore-EE C++ Test "P2P Sync connection count" Failure!
-- (void) _testStatus {
+- (void) testStatus {
     CBLDatabase.log.console.level = kCBLLogLevelDebug;
-    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB];
+    config.port = kPort;
     config.disableTLS = YES;
     Listener* list = [[Listener alloc] initWithConfig: config];
     AssertEqual(list.status.connectionCount, 0);

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -9,8 +9,10 @@
 #import "ReplicatorTest.h"
 #import "CBLURLEndpointListener.h"
 #import "CBLURLEndpointListenerConfiguration.h"
+#import "CollectionUtils.h"
 
 #define kPort 4984
+#define kURL [NSURL URLWithString: $sprintf(@"ws://localhost:%d/otherdb", kPort)]
 
 API_AVAILABLE(macos(10.12), ios(10.0))
 @interface URLEndpointListenerTest : ReplicatorTest
@@ -88,6 +90,62 @@ typedef CBLURLEndpointListener Listener;
     
     // stops
     [list1 stop];
+}
+
+// TODO: https://issues.couchbase.com/browse/CBL-948
+- (void) _testURLs {
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    config.disableTLS = YES;
+    Listener* list = [[Listener alloc] initWithConfig: config];
+    AssertEqual(list.urls.count, 0);
+    
+    // start listener
+    NSError* err = nil;
+    Assert([list startWithError: &err]);
+    AssertNil(err);
+    Assert(list.urls.count != 0);
+    
+    // stops
+    [list stop];
+    AssertEqual(list.urls.count, 0);
+}
+
+// TODO: LiteCore-EE C++ Test "P2P Sync connection count" Failure!
+- (void) _testStatus {
+    CBLDatabase.log.console.level = kCBLLogLevelDebug;
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    config.disableTLS = YES;
+    Listener* list = [[Listener alloc] initWithConfig: config];
+    AssertEqual(list.status.connectionCount, 0);
+    AssertEqual(list.status.activeConnectionCount, 0);
+    
+    // start listener
+    NSError* err = nil;
+    Assert([list startWithError: &err]);
+    AssertNil(err);
+    AssertEqual(list.status.connectionCount, 0);
+    AssertEqual(list.status.activeConnectionCount, 0);
+    
+    [self generateDocumentWithID: @"doc-1"];
+    CBLURLEndpoint* target = [[CBLURLEndpoint alloc] initWithURL: kURL];
+    id rConfig = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: NO];
+    __block Listener* tempListener = list;
+    __block uint64 maxConnectionCount = 0, maxActiveCount = 0;
+    [self run: rConfig reset: NO errorCode: 0 errorDomain: nil onReplicatorReady:^(CBLReplicator * r) {
+        Listener* sListener = tempListener;
+        [r addChangeListener:^(CBLReplicatorChange * change) {
+            maxConnectionCount = MAX(sListener.status.connectionCount, maxConnectionCount);
+            maxActiveCount = MAX(sListener.status.activeConnectionCount, maxActiveCount);
+        }];
+    }];
+    AssertEqual(maxActiveCount, 1);
+    AssertEqual(maxConnectionCount, 1);
+    AssertEqual(self.otherDB.count, 1);
+    
+    // stops
+    [list stop];
+    AssertEqual(list.status.connectionCount, 0);
+    AssertEqual(list.status.activeConnectionCount, 0);
 }
 
 @end

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -2,8 +2,19 @@
 //  URLEndpointListenerTest.m
 //  CouchbaseLite
 //
-//  Created by Jayahari Vavachan on 5/13/20.
-//  Copyright © 2020 Couchbase. All rights reserved.
+//  Copyright (c) 2020 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "ReplicatorTest.h"

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1,0 +1,93 @@
+//
+//  URLEndpointListenerTest.m
+//  CouchbaseLite
+//
+//  Created by Jayahari Vavachan on 5/13/20.
+//  Copyright © 2020 Couchbase. All rights reserved.
+//
+
+#import "ReplicatorTest.h"
+#import "CBLURLEndpointListener.h"
+#import "CBLURLEndpointListenerConfiguration.h"
+
+#define kPort 4984
+
+API_AVAILABLE(macos(10.12), ios(10.0))
+@interface URLEndpointListenerTest : ReplicatorTest
+typedef CBLURLEndpointListenerConfiguration Config;
+typedef CBLURLEndpointListener Listener;
+
+@end
+
+@implementation URLEndpointListenerTest
+
+- (Listener*) listenAt: (uint16)port {
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: port];
+    config.disableTLS = YES;
+    Listener* list = [[Listener alloc] initWithConfig: config];
+    
+    // start listener
+    NSError* err = nil;
+    Assert([list startWithError: &err]);
+    AssertNil(err);
+    
+    return list;
+}
+
+- (void) testPort {
+    // initialize a listener
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    config.disableTLS = YES;
+    Listener* list = [[Listener alloc] initWithConfig: config];
+    AssertEqual(list.port, 0);
+    
+    // start listener
+    NSError* err = nil;
+    Assert([list startWithError: &err]);
+    AssertNil(err);
+    AssertEqual(list.port, kPort);
+    
+    // stops
+    [list stop];
+    AssertEqual(list.port, 0);
+}
+
+- (void) testEmptyPort {
+    // initialize a listener
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: 0];
+    config.disableTLS = YES;
+    Listener* list = [[Listener alloc] initWithConfig: config];
+    AssertEqual(list.port, 0);
+    
+    // start listener
+    NSError* err = nil;
+    Assert([list startWithError: &err]);
+    AssertNil(err);
+    Assert(list.port != 0);
+    
+    // stops
+    [list stop];
+    AssertEqual(list.port, 0);
+}
+
+- (void) testBusyPort {
+    Listener* list1 = [self listenAt: kPort];
+    
+    // initialize a listener at same port
+    Config* config = [[Config alloc] initWithDatabase: self.otherDB port: kPort];
+    config.disableTLS = YES;
+    Listener* list2 = [[Listener alloc] initWithConfig: config];
+    
+    // already in use when starting the second listener
+    [self ignoreException:^{
+        NSError* err = nil;
+        [list2 startWithError: &err];
+        AssertEqual(err.code, EADDRINUSE);
+        AssertEqual(err.domain, NSPOSIXErrorDomain);
+    }];
+    
+    // stops
+    [list1 stop];
+}
+
+@end


### PR DESCRIPTION
* add test for validating  ports.
* add tests for get URLs, but test fails due to wrong scheme in URLs
* add tests for connection status, but again fails the active connection count, lite core fails.
