### PR TITLE
Add swift client cert auth tests

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -869,6 +869,13 @@
 		9343F1AD207D63BF00F19A89 /* DocPerfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 275FF6581E412C66005F90DD /* DocPerfTest.m */; };
 		9343F1AF207D63BF00F19A89 /* CouchbaseLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9398D9121E03434200464432 /* CouchbaseLite.framework */; };
 		9343F1B1207D63BF00F19A89 /* iTunesMusicLibrary.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 275FF6081E3FC24D005F90DD /* iTunesMusicLibrary.json */; };
+		934608EB247F2B4500CF2F27 /* ListenerAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934608DD247F2B4400CF2F27 /* ListenerAuthenticator.swift */; };
+		934608EC247F2B4500CF2F27 /* ListenerCertificateAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934608E9247F2B4400CF2F27 /* ListenerCertificateAuthenticator.swift */; };
+		934608ED247F2B4500CF2F27 /* ListenerPasswordAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934608EA247F2B4400CF2F27 /* ListenerPasswordAuthenticator.swift */; };
+		934608F0247F35D500CF2F27 /* URLEndpointListenerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934608EE247F35CC00CF2F27 /* URLEndpointListenerTest.swift */; };
+		934608F1247F35D500CF2F27 /* URLEndpointListenerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934608EE247F35CC00CF2F27 /* URLEndpointListenerTest.swift */; };
+		934608F4247F694900CF2F27 /* ClientCertificateAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934608F3247F694900CF2F27 /* ClientCertificateAuthenticator.swift */; };
+		934608F7247F85E300CF2F27 /* CBLTLSIdentity+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 934608F6247F85DE00CF2F27 /* CBLTLSIdentity+Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		934A278C1F30E5A5003946A7 /* CBLAggregateExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 934A278A1F30E5A5003946A7 /* CBLAggregateExpression.h */; };
 		934A278D1F30E5A5003946A7 /* CBLAggregateExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 934A278A1F30E5A5003946A7 /* CBLAggregateExpression.h */; };
 		934A278E1F30E5A5003946A7 /* CBLAggregateExpression.m in Sources */ = {isa = PBXBuildFile; fileRef = 934A278B1F30E5A5003946A7 /* CBLAggregateExpression.m */; };
@@ -2016,6 +2023,12 @@
 		9343F1B7207D63BF00F19A89 /* CBLPerfTests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = CBLPerfTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "CBL ObjC Tests - iOS App.xcconfig"; sourceTree = "<group>"; };
 		9344A3621E44517B0091F581 /* CBL ObjC Tests - iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "CBL ObjC Tests - iOS.xcconfig"; sourceTree = "<group>"; };
+		934608DD247F2B4400CF2F27 /* ListenerAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListenerAuthenticator.swift; sourceTree = "<group>"; };
+		934608E9247F2B4400CF2F27 /* ListenerCertificateAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListenerCertificateAuthenticator.swift; sourceTree = "<group>"; };
+		934608EA247F2B4400CF2F27 /* ListenerPasswordAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListenerPasswordAuthenticator.swift; sourceTree = "<group>"; };
+		934608EE247F35CC00CF2F27 /* URLEndpointListenerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEndpointListenerTest.swift; sourceTree = "<group>"; };
+		934608F3247F694900CF2F27 /* ClientCertificateAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificateAuthenticator.swift; sourceTree = "<group>"; };
+		934608F6247F85DE00CF2F27 /* CBLTLSIdentity+Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLTLSIdentity+Swift.h"; sourceTree = "<group>"; };
 		934A278A1F30E5A5003946A7 /* CBLAggregateExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLAggregateExpression.h; sourceTree = "<group>"; };
 		934A278B1F30E5A5003946A7 /* CBLAggregateExpression.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLAggregateExpression.m; sourceTree = "<group>"; };
 		934A27901F30E5CA003946A7 /* CBLBinaryExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLBinaryExpression.h; sourceTree = "<group>"; };
@@ -2630,6 +2643,7 @@
 				1AA3D6B022A1A3490098E16B /* ReplicatorTest+CustomConflict.swift */,
 				1A690CC824214EE70084D017 /* ReplicatorTest+PendingDocIds.swift */,
 				93095B23246CF1DE005633B4 /* TLSIdentityTest.swift */,
+				934608EE247F35CC00CF2F27 /* URLEndpointListenerTest.swift */,
 				1AA91DC522B0356000BF0BDE /* CustomLogger.swift */,
 				93249D81246B99FD000A8A6E /* iOS */,
 				939B79241E679017009A70EF /* Info.plist */,
@@ -2744,6 +2758,9 @@
 		93249D7D246B6EFF000A8A6E /* Listener */ = {
 			isa = PBXGroup;
 			children = (
+				934608DD247F2B4400CF2F27 /* ListenerAuthenticator.swift */,
+				934608E9247F2B4400CF2F27 /* ListenerCertificateAuthenticator.swift */,
+				934608EA247F2B4400CF2F27 /* ListenerPasswordAuthenticator.swift */,
 				93095B31246DDF34005633B4 /* TLSIdentity.swift */,
 				1A4191292475DB3B008122BE /* URLEndpointListener.swift */,
 				1A41913B2475ED38008122BE /* URLEndpointListenerConfiguration.swift */,
@@ -2846,6 +2863,14 @@
 				27CDE75F207407280082D458 /* CBLDocumentChangeNotifier.mm */,
 			);
 			name = Database;
+			sourceTree = "<group>";
+		};
+		934608F2247F691200CF2F27 /* Authenticator */ = {
+			isa = PBXGroup;
+			children = (
+				934608F3247F694900CF2F27 /* ClientCertificateAuthenticator.swift */,
+			);
+			name = Authenticator;
 			sourceTree = "<group>";
 		};
 		934A27961F30E5CF003946A7 /* Expression */ = {
@@ -3298,6 +3323,7 @@
 		9392608E20A0C94100E5748C /* Replicator */ = {
 			isa = PBXGroup;
 			children = (
+				934608F2247F691200CF2F27 /* Authenticator */,
 				93E8FE8D20A363630061347F /* Message */,
 				932CC556207D9ED2000B4B78 /* DatabaseEndpoint.swift */,
 			);
@@ -3442,6 +3468,7 @@
 				93BD01692477792F00BAD40B /* CBLKeyChain.h */,
 				93BD016A2477792F00BAD40B /* CBLKeyChain.mm */,
 				939C5E60244FC72A007CEBAC /* CBLTLSIdentity+Internal.h */,
+				934608F6247F85DE00CF2F27 /* CBLTLSIdentity+Swift.h */,
 				939C5E5F244FC72A007CEBAC /* CBLURLEndpointListenerConfiguration+Internal.h */,
 				93BD01392474ECD500BAD40B /* CBLListenerCertificateAuthenticator+Internal.h */,
 				93BD01062474882300BAD40B /* CBLListenerPasswordAuthenticator+Internal.h */,
@@ -4079,6 +4106,7 @@
 				93E1873A211122EB001D52B9 /* MYURLUtils.h in Headers */,
 				9343F0D2207D61AB00F19A89 /* CBLQueryArrayExpression.h in Headers */,
 				9343F0D3207D61AB00F19A89 /* CBLQueryFullTextFunction.h in Headers */,
+				934608F7247F85E300CF2F27 /* CBLTLSIdentity+Swift.h in Headers */,
 				9343F0D4207D61AB00F19A89 /* CBLDictionaryFragment.h in Headers */,
 				9343F0D5207D61AB00F19A89 /* CBLQueryMeta.h in Headers */,
 				9343F0D6207D61AB00F19A89 /* CBLIndexBuilder.h in Headers */,
@@ -5356,6 +5384,7 @@
 				93BB1CA7246BB2D4004FFA00 /* DictionaryTest.swift in Sources */,
 				93BB1CAA246BB2D4004FFA00 /* FragmentTest.swift in Sources */,
 				93095B2F246CF1F0005633B4 /* TLSIdentityTest.swift in Sources */,
+				934608F0247F35D500CF2F27 /* URLEndpointListenerTest.swift in Sources */,
 				93BB1CB0246BB2DE004FFA00 /* QueryTest.swift in Sources */,
 				93BB1CAB246BB2D4004FFA00 /* LogTest.swift in Sources */,
 				93BB1CA8246BB2D4004FFA00 /* DocumentTest.swift in Sources */,
@@ -5568,8 +5597,10 @@
 				9343F03F207D61AB00F19A89 /* CBLReplicatorChange.m in Sources */,
 				9343F040207D61AB00F19A89 /* CBLTrustCheck.m in Sources */,
 				9343F041207D61AB00F19A89 /* DocumentFragment.swift in Sources */,
+				934608ED247F2B4500CF2F27 /* ListenerPasswordAuthenticator.swift in Sources */,
 				93BD019124784C8D00BAD40B /* CBLCert.mm in Sources */,
 				93E8FEAE20A367090061347F /* CBLMessageSocket.mm in Sources */,
+				934608EC247F2B4500CF2F27 /* ListenerCertificateAuthenticator.swift in Sources */,
 				9369A6A1207DBAA9009B5B83 /* CBLDatabase+Encryption.mm in Sources */,
 				9343F042207D61AB00F19A89 /* CBLFullTextMatchExpression.m in Sources */,
 				9343F043207D61AB00F19A89 /* Result.swift in Sources */,
@@ -5635,6 +5666,7 @@
 				9369A6B3207DDBE7009B5B83 /* Database+Encryption.swift in Sources */,
 				9343F074207D61AB00F19A89 /* CBLDocument.mm in Sources */,
 				9343F075207D61AB00F19A89 /* DataConverter.swift in Sources */,
+				934608F4247F694900CF2F27 /* ClientCertificateAuthenticator.swift in Sources */,
 				932CC55E207D9ED3000B4B78 /* DatabaseEndpoint.swift in Sources */,
 				9343F076207D61AB00F19A89 /* MutableDictionaryObject.swift in Sources */,
 				9343F077207D61AB00F19A89 /* DictionaryObject.swift in Sources */,
@@ -5711,6 +5743,7 @@
 				9388CC4821C250D1005CA66D /* Log.swift in Sources */,
 				9343F0B0207D61AB00F19A89 /* CollectionUtils.m in Sources */,
 				931713E522C182F500F1B5BF /* CBLQueryFunction+Vector.m in Sources */,
+				934608EB247F2B4500CF2F27 /* ListenerAuthenticator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5814,6 +5847,7 @@
 				9343F192207D636300F19A89 /* DatabaseTest.swift in Sources */,
 				9343F193207D636300F19A89 /* CBLTestHelper.m in Sources */,
 				93095B30246CF1F1005633B4 /* TLSIdentityTest.swift in Sources */,
+				934608F1247F35D500CF2F27 /* URLEndpointListenerTest.swift in Sources */,
 				1AA91DC722B0356000BF0BDE /* CustomLogger.swift in Sources */,
 				69845B0723354D0A00CC16BB /* DateTimeQueryFunctionTest.swift in Sources */,
 				9343F194207D636300F19A89 /* FragmentTest.swift in Sources */,

--- a/Objective-C/Tests/ReplicatorTest.h
+++ b/Objective-C/Tests/ReplicatorTest.h
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
                                             type: (CBLReplicatorType)type
                                       continuous: (BOOL)continuous
                                    authenticator: (nullable CBLAuthenticator*)authenticator
-                                pinnedServerCert: (nullable SecCertificateRef)serverCert;
+                                      serverCert: (nullable SecCertificateRef)serverCert;
 
 #pragma mark - Run Replicator
 
@@ -109,6 +109,14 @@ NS_ASSUME_NONNULL_BEGIN
    errorCode: (NSInteger)errorCode
  errorDomain: (nullable NSString*)errorDomain
 onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady;
+
+- (BOOL) runWithTarget: (id<CBLEndpoint>)target
+                  type: (CBLReplicatorType)type
+            continuous: (BOOL)continuous
+         authenticator: (nullable CBLAuthenticator*)authenticator
+            serverCert: (nullable SecCertificateRef)serverCert
+             errorCode: (NSInteger)errorCode
+           errorDomain: (nullable NSString*)errorDomain;
 
 - (BOOL) runWithReplicator: (CBLReplicator*)replicator
                  errorCode: (NSInteger)errorCode

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -215,7 +215,7 @@
                              type: type
                        continuous: continuous
                     authenticator: nil
-                 pinnedServerCert: nil];
+                       serverCert: nil];
 }
 
 - (CBLReplicatorConfiguration*) configWithTarget: (id<CBLEndpoint>)target
@@ -226,14 +226,14 @@
                              type: type
                        continuous: continuous
                     authenticator: authenticator
-                 pinnedServerCert: nil];
+                       serverCert: nil];
 }
 
 - (CBLReplicatorConfiguration*) configWithTarget: (id<CBLEndpoint>)target
                                             type: (CBLReplicatorType)type
                                       continuous: (BOOL)continuous
                                    authenticator: (nullable CBLAuthenticator*)authenticator
-                                pinnedServerCert: (nullable SecCertificateRef)serverCert
+                                      serverCert: (nullable SecCertificateRef)serverCert
 {
     CBLReplicatorConfiguration* c = [[CBLReplicatorConfiguration alloc] initWithDatabase: self.db
                                                                                   target: target];
@@ -287,6 +287,21 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady
         onReplicatorReady(repl);
     
     return [self runWithReplicator: repl errorCode: errorCode errorDomain: errorDomain];
+}
+
+- (BOOL) runWithTarget: (id<CBLEndpoint>)target
+                  type: (CBLReplicatorType)type
+            continuous: (BOOL)continuous
+         authenticator: (nullable CBLAuthenticator*)authenticator
+            serverCert: (nullable SecCertificateRef)serverCert
+             errorCode: (NSInteger)errorCode
+           errorDomain: (nullable NSString*)errorDomain {
+    id config = [self configWithTarget: target
+                                  type: type
+                            continuous: continuous
+                         authenticator: authenticator
+                            serverCert: serverCert];
+    return [self run: config errorCode: errorCode errorDomain: errorDomain];
 }
 
 - (BOOL) runWithReplicator: (CBLReplicator*)replicator

--- a/Swift/CouchbaseLiteSwift-EE.modulemap
+++ b/Swift/CouchbaseLiteSwift-EE.modulemap
@@ -98,6 +98,7 @@ framework module CouchbaseLiteSwift {
         header "CBLLog+Swift.h"
         
         // Enterprise:
+        header "CBLClientCertificateAuthenticator.h"
         header "CBLCoreMLPredictiveModel.h"
         header "CBLDatabaseConfiguration+Encryption.h"
         header "CBLDatabaseEndpoint.h"
@@ -106,6 +107,8 @@ framework module CouchbaseLiteSwift {
         header "CBLEncryptionKey.h"
         header "CBLIndexBuilder+Prediction.h"
         header "CBLListenerAuthenticator.h"
+        header "CBLListenerCertificateAuthenticator.h"
+        header "CBLListenerPasswordAuthenticator.h"
         header "CBLMessage.h"
         header "CBLMessageEndpoint.h"
         header "CBLMessageEndpointConnection.h"
@@ -120,5 +123,8 @@ framework module CouchbaseLiteSwift {
         header "CBLTLSIdentity.h"
         header "CBLURLEndpointListener.h"
         header "CBLURLEndpointListenerConfiguration.h"
+        
+        // Enterprise Swift Extensions:
+        header "CBLTLSIdentity+Swift.h"
     }
 }

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -60,6 +60,8 @@ class CBLTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         
+        Database.log.console.level = .info
+        
         try? deleteDB(name: databaseName);
         
         try? deleteDB(name: otherDatabaseName);

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -1,0 +1,182 @@
+//
+//  URLEndpontListenerTest.swift
+//  CouchbaseLite
+//
+//  Copyright (c) 2020 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import CouchbaseLiteSwift
+
+@available(macOS 10.12, iOS 10.0, *)
+class URLEndpontListenerTest: ReplicatorTest {
+    let wsPort: UInt16 = 4984
+    let wssPort: UInt16 = 4985
+    let clientCertLabel = "CBL-Client-Cert"
+    
+    var listener: URLEndpointListener?
+    
+    @discardableResult
+    func listen() throws -> URLEndpointListener {
+        return try listen(tls: true, auth: nil)
+    }
+    
+    @discardableResult
+    func listen(tls: Bool) throws -> URLEndpointListener {
+    return try! listen(tls: tls, auth: nil)
+    }
+    
+    @discardableResult
+    func listen(tls: Bool, auth: ListenerAuthenticator?) throws -> URLEndpointListener {
+        // Stop:
+        if let listener = self.listener {
+            listener.stop()
+        }
+        
+        // Listener:
+        let config = URLEndpointListenerConfiguration.init(database: self.oDB)
+        config.port = tls ? wssPort : wsPort
+        config.disableTLS = !tls
+        config.authenticator = auth
+        self.listener = URLEndpointListener.init(config: config)
+        
+        // Start:
+        try self.listener!.start()
+        
+        return self.listener!
+    }
+    
+    override func tearDown() {
+        if let listener = self.listener {
+            listener.stop()
+            if let identity = listener.config.tlsIdentity {
+                try! identity.deleteFromKeyChain()
+            }
+        }
+        super.tearDown()
+    }
+    
+    func testPasswordAuthenticator() throws {
+        // Listener:
+        let listenerAuth = ListenerPasswordAuthenticator.init {
+            (username, password) -> Bool in
+            return (username as NSString).isEqual(to: "daniel") &&
+                   (password as NSString).isEqual(to: "123")
+        }
+        let listener = try listen(tls: false, auth: listenerAuth)
+        
+        // Replicator - No Authenticator:
+        self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
+                 auth: nil, serverCert: nil, expectedError: CBLErrorHTTPAuthRequired)
+        
+        // Replicator - Wrong Credentials:
+        var auth = BasicAuthenticator.init(username: "daniel", password: "456")
+        self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
+                 auth: auth, serverCert: nil, expectedError: CBLErrorHTTPAuthRequired)
+        
+        // Replicator - Success:
+        auth = BasicAuthenticator.init(username: "daniel", password: "123")
+        self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
+                 auth: auth)
+        
+        listener.stop()
+    }
+    
+    #if os(OSX)
+    // Not working on iOS:
+    // https://issues.couchbase.com/browse/CBL-995
+    func testClientCertAuthenticatorWithClosure() throws {
+        if !self.keyChainAccessAllowed {
+            return
+        }
+        
+        // Listener:
+        let listenerAuth = ListenerCertificateAuthenticator.init { (certs) -> Bool in
+            XCTAssertEqual(certs.count, 1)
+            var commongName: CFString?
+            let status = SecCertificateCopyCommonName(certs[0], &commongName)
+            XCTAssertEqual(status, errSecSuccess)
+            XCTAssertNotNil(commongName)
+            XCTAssertEqual((commongName! as String), "daniel")
+            return true
+        }
+        let listener = try listen(tls: true, auth: listenerAuth)
+        XCTAssertNotNil(listener.config.tlsIdentity)
+        XCTAssertEqual(listener.config.tlsIdentity!.certs.count, 1)
+        
+        // Cleanup:
+        try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
+        
+        // Create client identity:
+        let attrs = [certAttrCommonName: "daniel"]
+        let identity = try TLSIdentity.createIdentity(forServer: false, attributes: attrs, expiration: nil, label: clientCertLabel)
+        
+        // Replicator:
+        let auth = ClientCertificateAuthenticator.init(identity: identity)
+        let serverCert = listener.config.tlsIdentity!.certs[0]
+        self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false, auth: auth, serverCert: serverCert)
+        
+        // Cleanup:
+        try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
+    }
+    #endif
+    
+    func testClientCertAuthenticatorWithRootCerts() throws {
+        if !self.keyChainAccessAllowed {
+            return
+        }
+        
+        // Root Cert:
+        let rootCertData = try dataFromResource(name: "identity/client-ca", ofType: "der")
+        let rootCert = SecCertificateCreateWithData(kCFAllocatorDefault, rootCertData as CFData)!
+        
+        // Listener:
+        let listenerAuth = ListenerCertificateAuthenticator.init(rootCerts: [rootCert])
+        let listener = try listen(tls: true, auth: listenerAuth)
+        
+        // Cleanup:
+        try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
+        
+        // Create client identity:
+        let clientCertData = try dataFromResource(name: "identity/client", ofType: "p12")
+        let identity = try TLSIdentity.importIdentity(withData: clientCertData, password: "123", label: clientCertLabel)
+        
+        // Replicator:
+        let auth = ClientCertificateAuthenticator.init(identity: identity)
+        let serverCert = listener.config.tlsIdentity!.certs[0]
+        
+        self.ignoreException {
+            self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false, auth: auth, serverCert: serverCert)
+        }
+        
+        // Cleanup:
+        try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
+    }
+}
+
+extension URLEndpointListener {
+    var localURL: URL {
+        assert(self.port != nil && self.port! > UInt16(0))
+        var comps = URLComponents()
+        comps.scheme = self.config.disableTLS ? "ws" : "wss"
+        comps.host = "localhost"
+        comps.port = Int(self.port!)
+        comps.path = "/\(self.config.database.name)"
+        return comps.url!
+    }
+    
+    var localURLEndpoint: URLEndpoint {
+        return URLEndpoint.init(url: self.localURL)
+    }
+}


### PR DESCRIPTION
* Added tests for Swift’s Client Cert Authentication.
* Added convenience run method that will create config and replicator at the same time.
* Fixed bugs not checking the error when running the Replicator in tests.
* Cleaned up some method signatures in tests.