### PR TITLE
Implement Replicator's start(reset) and deprecate resetCheckpoint()

### DIFF
--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -92,6 +92,14 @@ typedef struct {
  */
 - (void) start;
 
+/**
+Starts the replicator with an option to reset the local checkpoint of the replicator. When the local checkpoint
+is reset, the replicator will sync all changes since the beginning of time from the remote database.
+This method returns immediately; the replicator runs asynchronously and will report its progress throuh
+the replicator change notification.
+*/
+- (void) startWithReset: (BOOL)reset;
+
 /** 
  Stops a running replicator. This method returns immediately; when the replicator actually
  stops, the replicator will change its status's activity level to `kCBLStopped`
@@ -100,11 +108,11 @@ typedef struct {
 - (void) stop;
 
 /**
- Resets the local checkpoint of the replicator, meaning that it will read all
+ This method is deprecated. Resets the local checkpoint of the replicator, meaning that it will sync all
  changes since the beginning of time from the remote database. This can only be
  called when the replicator is in a stopped state.
  */
-- (void) resetCheckpoint;
+- (void) resetCheckpoint __attribute__((deprecated("Use -startWithReset: instead.")));
 
 /** 
  Adds a replicator change listener. Changes will be posted on the main queue.

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -98,7 +98,7 @@ is reset, the replicator will sync all changes since the beginning of time from 
 This method returns immediately; the replicator runs asynchronously and will report its progress throuh
 the replicator change notification.
  
- @param reset Reset the local checkpoint before starting the replicator.
+ @param reset Resets the local checkpoint before starting the replicator.
 */
 - (void) startWithReset: (BOOL)reset;
 

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -97,6 +97,8 @@ Starts the replicator with an option to reset the local checkpoint of the replic
 is reset, the replicator will sync all changes since the beginning of time from the remote database.
 This method returns immediately; the replicator runs asynchronously and will report its progress throuh
 the replicator change notification.
+ 
+ @param reset Reset the local checkpoint before starting the replicator.
 */
 - (void) startWithReset: (BOOL)reset;
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -130,6 +130,10 @@ typedef enum {
 }
 
 - (void) start {
+    [self startWithReset: _resetCheckpoint];
+}
+
+- (void) startWithReset: (BOOL)reset {
     CBL_LOCK(self) {
         CBLLogInfo(Sync, @"%@: Starting...", self);
         if (_state != kCBLStateStopped && _state != kCBLStateSuspended) {
@@ -137,13 +141,13 @@ typedef enum {
                     self,  _state, _rawStatus.level);
             return;
         }
-
+        
         C4ReplicatorStatus status;
         C4Error err;
         if ([self _setupC4Replicator: &err]) {
             // Start the C4Replicator:
             _state = kCBLStateStarting;
-            c4repl_start(_repl, _resetCheckpoint);
+            c4repl_start(_repl, reset);
             _resetCheckpoint = NO;
             status = c4repl_getStatus(_repl);
             [_config.database addActiveReplicator: self];
@@ -160,7 +164,7 @@ typedef enum {
                          self, error.localizedDescription);
             status = {kC4Stopped, {}, err};
         }
-
+        
         // Post an initial notification:
         statusChanged(_repl, status, (__bridge void*)self);
     }

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -494,11 +494,101 @@
     AssertEqual(self.db.count, 0u);
     
     // Reset and pull:
-    [self run: config reset: YES errorCode: 0 errorDomain: nil];
+    CBLReplicator* replicator = [[CBLReplicator alloc] initWithConfig: config];
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [replicator resetCheckpoint];
+    #pragma clang diagnostic pop
+    [self runWithReplicator: replicator errorCode: 0 errorDomain: nil];
     AssertEqual(self.db.count, 2u);
 }
 
 - (void) testResetCheckpointContinuous {
+    NSError* error;
+    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc1 setString: @"Tiger" forKey: @"species"];
+    [doc1 setString: @"Hobbes" forKey: @"name"];
+    Assert([self.db saveDocument: doc1 error: &error]);
+    
+    CBLMutableDocument* doc2 = [[CBLMutableDocument alloc] initWithID: @"doc2"];
+    [doc2 setString: @"Tiger" forKey: @"species"];
+    [doc2 setString: @"striped" forKey: @"pattern"];
+    Assert([self.db saveDocument: doc2 error: &error]);
+    
+    // Push:
+    id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
+    id config = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: YES];
+    [self run: config errorCode: 0 errorDomain: nil];
+    
+    // Pull:
+    config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: YES];
+    [self run: config errorCode: 0 errorDomain: nil];
+    
+    AssertEqual(self.db.count, 2u);
+    
+    CBLDocument* doc = [self.db documentWithID: @"doc1"];
+    Assert([self.db purgeDocument: doc error: &error]);
+    
+    doc = [self.db documentWithID: @"doc2"];
+    Assert([self.db purgeDocument: doc error: &error]);
+    
+    AssertEqual(self.db.count, 0u);
+    
+    // Pull again, shouldn't have any new changes:
+    [self run: config errorCode: 0 errorDomain: nil];
+    AssertEqual(self.db.count, 0u);
+    
+    // Reset and pull:
+    CBLReplicator* replicator = [[CBLReplicator alloc] initWithConfig: config];
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [replicator resetCheckpoint];
+    #pragma clang diagnostic pop
+    [self runWithReplicator: replicator errorCode: 0 errorDomain: nil];
+    AssertEqual(self.db.count, 2u);
+}
+
+- (void) testStartWithResetCheckpoint {
+    NSError* error;
+    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc1 setString: @"Tiger" forKey: @"species"];
+    [doc1 setString: @"Hobbes" forKey: @"name"];
+    Assert([self.db saveDocument: doc1 error: &error]);
+    
+    CBLMutableDocument* doc2 = [[CBLMutableDocument alloc] initWithID: @"doc2"];
+    [doc2 setString: @"Tiger" forKey: @"species"];
+    [doc2 setString: @"striped" forKey: @"pattern"];
+    Assert([self.db saveDocument: doc2 error: &error]);
+    
+    // Push:
+    id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
+    id config = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: NO];
+    [self run: config errorCode: 0 errorDomain: nil];
+    
+    // Pull:
+    config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: NO];
+    [self run: config errorCode: 0 errorDomain: nil];
+    
+    AssertEqual(self.db.count, 2u);
+    
+    CBLDocument* doc = [self.db documentWithID: @"doc1"];
+    Assert([self.db purgeDocument: doc error: &error]);
+    
+    doc = [self.db documentWithID: @"doc2"];
+    Assert([self.db purgeDocument: doc error: &error]);
+    
+    AssertEqual(self.db.count, 0u);
+    
+    // Pull again, shouldn't have any new changes:
+    [self run: config errorCode: 0 errorDomain: nil];
+    AssertEqual(self.db.count, 0u);
+    
+    // Reset and pull:
+    [self run: config reset: YES errorCode: 0 errorDomain: nil];
+    AssertEqual(self.db.count, 2u);
+}
+
+- (void) testStartWithResetCheckpointContinuous {
     NSError* error;
     CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
     [doc1 setString: @"Tiger" forKey: @"species"];

--- a/Objective-C/Tests/ReplicatorTest.h
+++ b/Objective-C/Tests/ReplicatorTest.h
@@ -143,6 +143,11 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady;
                  errorCode: (NSInteger)errorCode
                errorDomain: (nullable NSString*)errorDomain;
 
+- (BOOL) runWithReplicator: (CBLReplicator*)replicator
+                     reset: (BOOL)reset
+                 errorCode: (NSInteger)errorCode
+               errorDomain: (nullable NSString*)errorDomain;
+
 #pragma mark - Verify Replicator Change
 
 - (void) verifyChange: (CBLReplicatorChange*)change

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -98,6 +98,15 @@ public final class Replicator {
         _impl.start()
     }
     
+    /// Starts the replicator with an option to reset the local checkpoint of the replicator. When the local checkpoint
+    /// is reset, the replicator will sync all changes since the beginning of time from the remote database.
+    /// This method returns immediately; the replicator runs asynchronously and will report its progress throuh
+    /// the replicator change notification.
+    public func start(reset: Bool) {
+        registerActiveReplicator()
+        _impl.start(withReset: reset);
+    }
+    
     /// Stops a running replicator. This method returns immediately; when the replicator actually
     /// stops, the replicator will change its status's activity level to `.stopped`
     /// and the replicator change notification will be notified accordingly.
@@ -105,9 +114,10 @@ public final class Replicator {
         _impl.stop()
     }
     
-    /// Resets the local checkpoint of the replicator, meaning that it will read all
+    /// Resets the local checkpoint of the replicator, meaning that it will sync all
     /// changes since the beginning of time from the remote database. This can only be
     /// called when the replicator is in a stopped state.
+    @available(*, deprecated, message: "Use start(reset:) instead.")
     public func resetCheckpoint() {
         _impl.resetCheckpoint()
     }

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -102,6 +102,9 @@ public final class Replicator {
     /// is reset, the replicator will sync all changes since the beginning of time from the remote database.
     /// This method returns immediately; the replicator runs asynchronously and will report its progress throuh
     /// the replicator change notification.
+    ///
+    /// - Parameters:
+    ///   - reset: Reset the local checkpoint before starting the replicator.
     public func start(reset: Bool) {
         registerActiveReplicator()
         _impl.start(withReset: reset);

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -100,7 +100,7 @@ public final class Replicator {
     
     /// Starts the replicator with an option to reset the local checkpoint of the replicator. When the local checkpoint
     /// is reset, the replicator will sync all changes since the beginning of time from the remote database.
-    /// This method returns immediately; the replicator runs asynchronously and will report its progress throuh
+    /// This method returns immediately; the replicator runs asynchronously and will report its progress through
     /// the replicator change notification.
     ///
     /// - Parameters:

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -104,7 +104,7 @@ public final class Replicator {
     /// the replicator change notification.
     ///
     /// - Parameters:
-    ///   - reset: Reset the local checkpoint before starting the replicator.
+    ///   - reset: Resets the local checkpoint before starting the replicator.
     public func start(reset: Bool) {
         registerActiveReplicator()
         _impl.start(withReset: reset);


### PR DESCRIPTION
* Implemented Replicator's start(reset) and deprecate resetCheckpoint()
* Fixed replicator not getting stopped in Objective-C unit tests

CBL-1012