### PR TITLE
Fix missed handling the replicator in stopping state

### DIFF
--- a/Objective-C/Internal/Replicator/CBLReachability.h
+++ b/Objective-C/Internal/Replicator/CBLReachability.h
@@ -75,6 +75,9 @@ typedef void (^CBLReachabilityOnChangeBlock)(void);
 /** Is this host reachable by WiFi (or wired Ethernet)? */
 @property (readonly, nonatomic) BOOL reachableByWiFi;
 
+/** Is this host reachable by WiFi (or wired Ethernet)? */
+@property (readonly, nonatomic) BOOL isMonitoring;
+
 /** If you set this, the block will be called whenever the reachability related properties change.
     The call will be on the runloop or dispatch queue specified in the start method. */
 @property (copy, nullable, nonatomic) CBLReachabilityOnChangeBlock onChange;

--- a/Objective-C/Internal/Replicator/CBLReachability.m
+++ b/Objective-C/Internal/Replicator/CBLReachability.m
@@ -220,6 +220,10 @@ static BOOL sAlwaysAssumeProxy = NO;
     ;
 }
 
+- (BOOL) isMonitoring {
+    return (_runLoop || _queue);
+}
+
 + (NSSet*) keyPathsForValuesAffectingReachable {
     return [NSSet setWithObjects: @"reachabilityKnown", @"reachabilityFlags", nil];
 }


### PR DESCRIPTION
* Make sure to not set the internal state to others after the replicator is in stopping state.
* Make sure to not start the reachability in stopping state.
* Make sure to check whether the reachability is still mornitoring instead of checking if the instance is nil or not as now when we stop the reachability, we don’t set the reachability to nil.

#CBL-1053