### PR TITLE
Add option to crash when the replicator not stopped in tests

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -2094,6 +2094,7 @@
 		936483B41E4431C6008D08B3 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		936483B51E4431C6008D08B3 /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		936483B61E4431C6008D08B3 /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		9367E86E24948C3F00775F97 /* xctest_crash_log.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = xctest_crash_log.sh; sourceTree = "<group>"; };
 		9369A676207DB3D4009B5B83 /* CBLEncryptionKey+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CBLEncryptionKey+Internal.h"; sourceTree = "<group>"; };
 		9369A677207DB3D4009B5B83 /* CBLEncryptionKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLEncryptionKey.m; sourceTree = "<group>"; };
 		9369A678207DB3D4009B5B83 /* CBLEncryptionKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLEncryptionKey.h; sourceTree = "<group>"; };
@@ -3138,6 +3139,7 @@
 				6992582A22DFE9A100E0D1D2 /* build_xcframework.sh */,
 				9388CB9521BCDF8B005CA66D /* strip_frameworks.sh */,
 				9388CB9621BCDF8B005CA66D /* generate_release_zip.sh */,
+				9367E86E24948C3F00775F97 /* xctest_crash_log.sh */,
 			);
 			path = Scripts;
 			sourceTree = "<group>";

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -1118,7 +1118,7 @@
         }];
     }];
     
-    [self waitForExpectationsWithTimeout: 5.0 handler: nil];
+    [self waitForExpectations: @[expectation] timeout:5.0];
     
     AssertEqual(self.db.count, 0u);
     AssertEqual(self.otherDB.count, 1u);
@@ -1707,7 +1707,7 @@
     AssertNil(err);
     
     // Wait for the document get expired.
-    [self waitForExpectationsWithTimeout: 5.0 handler: nil];
+    [self waitForExpectations: @[expectation] timeout: 5.0];
     [self.db removeChangeListenerWithToken: token];
     
     // Erase remote data:

--- a/Objective-C/Tests/ReplicatorTest+MessageEndPoint.m
+++ b/Objective-C/Tests/ReplicatorTest+MessageEndPoint.m
@@ -199,6 +199,8 @@
 }
 
 - (void) testMEP2PWithMessageStream {
+    self.crashWhenStoppedTimeoutOccurred = YES;
+    
     CBLProtocolType protocolType = kCBLProtocolTypeMessageStream;
     
     CBLMutableDocument* mdoc = [CBLMutableDocument documentWithID: @"livesindb"];
@@ -287,6 +289,8 @@
 }
 
 - (void) testMEP2PWithByteStream {
+    self.crashWhenStoppedTimeoutOccurred = YES;
+    
     CBLProtocolType protocolType = kCBLProtocolTypeByteStream;
     
     CBLMutableDocument* mdoc = [CBLMutableDocument documentWithID: @"livesindb"];

--- a/Objective-C/Tests/ReplicatorTest.h
+++ b/Objective-C/Tests/ReplicatorTest.h
@@ -55,6 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL disableDefaultServerCertPinning;
 
+@property (nonatomic) BOOL crashWhenStoppedTimeoutOccurred;
+
 - (SecCertificateRef) defaultServerCert;
 
 - (NSString*) getCertificateID: (SecCertificateRef)cert;

--- a/Scripts/generate_release_zip.sh
+++ b/Scripts/generate_release_zip.sh
@@ -7,6 +7,13 @@ function usage
   echo "Usage: ${0} -o <Output Directory> [-v <Version (<Version Number>[-<Build Number>])>] [--xcframework] [--EE] [--notest] [--nocov] [--pretty]"
 }
 
+function checkCrashLogs
+{
+  echo "Check for xctest crash logs ..."
+  sh Scripts/xctest_crash_log.sh
+  exit 1
+}
+
 while [[ $# -gt 0 ]]
 do
   key=${1}
@@ -100,11 +107,14 @@ then
   instruments -s devices
 
   echo "Run ObjC macOS tests ..."
-  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "${SCHEME_PREFIX}_ObjC" -configuration "$CONFIGURATION_TEST" -sdk macosx
-
+  sh Scripts/xctest_crash_log.sh --delete-all
+  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "${SCHEME_PREFIX}_ObjC" -configuration "$CONFIGURATION_TEST" -sdk macosx || checkCrashLogs
+  
   echo "Run ObjC iOS tests ..."
-  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "${SCHEME_PREFIX}_ObjC" -configuration "$CONFIGURATION_TEST" -sdk iphonesimulator -destination "$TEST_SIMULATOR" -enableCodeCoverage YES
-
+  sh Scripts/xctest_crash_log.sh --delete-all
+  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "${SCHEME_PREFIX}_ObjC" -configuration "$CONFIGURATION_TEST" -sdk iphonesimulator -destination "$TEST_SIMULATOR" -enableCodeCoverage YES || checkCrashLogs
+  
+  
   if [ -z "$NO_COV" ]
   then
     # Objective-C:

--- a/Scripts/xctest_crash_log.sh
+++ b/Scripts/xctest_crash_log.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+function usage 
+{
+  echo "Usage: ${0} [delete-all]"
+}
+
+while [[ $# -gt 0 ]]
+do
+  key=${1}
+  case $key in
+    --delete-all)
+    DELETE_ALL="Y"
+    ;;
+    *)
+    usage
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+if [ -z "$DELETE_ALL" ]
+then
+  shopt -s nullglob
+  i=0
+  for fname in ~/Library/Logs/DiagnosticReports/xctest*.crash ; do
+     i=$((i+1))
+     echo -e ">> Crash Log #$i : $fname\n"
+     cat $fname
+  done
+  if [[ $i = 0 ]]; then
+    echo "No crash logs found"
+  fi
+else
+  echo "Delete all xctest crash logs ..."
+  rm -f ~/Library/Logs/DiagnosticReports/xctest*.crash
+fi


### PR DESCRIPTION
* Added crashWhenStoppedTimeoutOccurred property in ReplicatorTest
* Enabled crashWhenStoppedTimeoutOccurred in testMEP2PWithMessageStream and testMEP2PWithByteStream for investigating the replicator stalls issue.
* Added Scripts/xctest_crash_log.sh to print all xctest’s crash logs or delete all xctest crash logs.
* Used xctest_crash_log.sh in genearte_release_zip to print out the crash logs when test fails.