### PR TITLE
Fix missing listener log domain in Swift

### DIFF
--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -856,6 +856,8 @@
     
     [replicator removeChangeListenerWithToken: changeToken];
     [replicator removeChangeListenerWithToken: docReplToken];
+    
+    CBLDatabase.log.custom = nil;
 }
 
 - (void) testConflictResolverReturningBlobFromDifferentDB {

--- a/Swift/Logger.swift
+++ b/Swift/Logger.swift
@@ -26,12 +26,14 @@ import Foundation
 /// query:      Query domain.
 /// replicator: Replicator domain.
 /// network:    Network domain.
+/// listener:   Listener domain.
 public enum LogDomain: UInt8 {
-    case all            = 15
+    case all            = 31
     case database       = 1
     case query          = 2
     case replicator     = 4
     case network        = 8
+    case listener       = 16
 }
 
 /// Log level.

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -342,6 +342,8 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         XCTAssertEqual(customLogger.lines.last,
                        "The document ID of the resolved document '\(wrongDocID)' is not matching " +
             "with the document ID of the conflicting document '\(docID)'.")
+        
+        Database.log.custom = nil
     }
     
     func testConflictResolverDifferentDBDoc() throws {


### PR DESCRIPTION
* Added listener log domain to Swift
* Fixed tests that didn’t reset the custom logger back to nil