### PR TITLE
CBL-745: `CBLNewDictionary` elements where not converted to `cbl_toCBLObject`

### DIFF
--- a/Objective-C/Internal/CBLNewDictionary.mm
+++ b/Objective-C/Internal/CBLNewDictionary.mm
@@ -218,7 +218,10 @@ using namespace cbl;
 }
 
 - (void) setData: (nullable NSDictionary<NSString*,id>*)data {
-    _dict = [data mutableCopy];
+    _dict = [NSMutableDictionary dictionaryWithCapacity: data.count];
+    [data enumerateKeysAndObjectsUsingBlock: ^(id key, id value, BOOL* stop) {
+        [_dict setObject:  [value cbl_toCBLObject] forKey: key];
+    }];
     _changed = true;
 }
 

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -625,6 +625,38 @@
     }];
 }
 
+- (void) testSetDateInsideData {
+    CBLMutableDocument* doc = [self createDocument: @"doc"];
+    NSDate* date = [NSDate date];
+    NSString* dateStr = [CBLJSON JSONObjectWithDate: date];
+    Assert(dateStr.length > 0);
+    
+    [doc setData: @{@"time": date}];
+    [self saveDocument: doc eval: ^(CBLDocument* d) {
+        AssertEqualObjects([CBLJSON JSONObjectWithDate: [d dateForKey: @"time"]], dateStr);
+    }];
+    
+    // Update:
+    NSDate* nuDate = [NSDate dateWithTimeInterval: 60.0 sinceDate: date];
+    NSString* nuDateStr = [CBLJSON JSONObjectWithDate: nuDate];
+    
+    
+    [doc setData: @{@"time": nuDate}];
+    [self saveDocument: doc eval: ^(CBLDocument* d) {
+        AssertEqualObjects([CBLJSON JSONObjectWithDate: [d dateForKey: @"time"]], nuDateStr);
+    }];
+    
+    // Get and update:
+    doc = [[self.db documentWithID: doc.id] toMutable];
+    nuDate = [NSDate dateWithTimeInterval: 120.0 sinceDate: date];
+    nuDateStr = [CBLJSON JSONObjectWithDate: nuDate];
+    
+    [doc setData: @{@"time": nuDate}];
+    [self saveDocument: doc eval: ^(CBLDocument* d) {
+        AssertEqualObjects([CBLJSON JSONObjectWithDate: [d dateForKey: @"time"]], nuDateStr);
+    }];
+}
+
 - (void) testGetDate {
     CBLMutableDocument* doc = [self createDocument: @"doc1"];
     [self populateData: doc];


### PR DESCRIPTION
* since the dictionary elements were not getting calls to cbl_toCBLObject. which was causing it to convert to respective type from fleece, which leads to fleece exception.
* unknown though, _dict inside CBLMutableDocument is converted to CBLNewDictionary than CBLMiutableDictionary during runtime?