### PR TITLE
-no-serialize-debugging-options

### DIFF
--- a/xcconfigs/Project_Release.xcconfig
+++ b/xcconfigs/Project_Release.xcconfig
@@ -37,3 +37,4 @@ SWIFT_COMPILATION_MODE           = wholemodule           // Swift Compilation Mo
 SWIFT_OPTIMIZATION_LEVEL         = -O                    // Optimize for Speed
 VALIDATE_PRODUCT                 = YES                   // Perform validation checks on the product
 BUILD_LIBRARY_FOR_DISTRIBUTION   = YES
+SWIFT_SERIALIZE_DEBUGGING_OPTIONS = NO


### PR DESCRIPTION
* enable this to remove all absolute path from binary & dsym
* https://bugs.swift.org/browse/SR-12783?focusedCommentId=56548&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-56548

* But the issue(CBL-896, Couldn't IRGen expression) we encounter with XCode 11.x is not present in XCode 12 Beta. 
* i have tested only on my machine. probably needs to test this again, once the Jenkins job builds it. 