### PR TITLE
Synchronize sending message in CBLMockConnection

### DIFF
--- a/Objective-C/Tests/Util/CBLMockConnection.m
+++ b/Objective-C/Tests/Util/CBLMockConnection.m
@@ -94,6 +94,7 @@
 }
 
 - (void) send: (CBLMessage*)message completion: (void (^)(BOOL success, CBLMessagingError* _Nullable))completion {
+    // Synchronize to prevent message getting sent out-of-order:
     @synchronized (self) {
         NSLog(@"%@: Sending message ...", self);
         CBLMessagingError* error;

--- a/Objective-C/Tests/Util/CBLMockConnection.m
+++ b/Objective-C/Tests/Util/CBLMockConnection.m
@@ -94,18 +94,20 @@
 }
 
 - (void) send: (CBLMessage*)message completion: (void (^)(BOOL success, CBLMessagingError* _Nullable))completion {
-    NSLog(@"%@: Sending message ...", self);
-    CBLMessagingError* error;
-    if(self.isClient && [self.errorLogic shouldCloseAtLocation: kCBLMockConnectionSend]) {
-        error = [self.errorLogic createError];
-        NSLog(@"%@: Send message failed with error : %@", self, error);
-        [self connectionBroken: error];
-    } else {
-        [self performWrite: [message toData]];
-        NSLog(@"%@: Send message completed", self);
+    @synchronized (self) {
+        NSLog(@"%@: Sending message ...", self);
+        CBLMessagingError* error;
+        if(self.isClient && [self.errorLogic shouldCloseAtLocation: kCBLMockConnectionSend]) {
+            error = [self.errorLogic createError];
+            NSLog(@"%@: Send message failed with error : %@", self, error);
+            [self connectionBroken: error];
+        } else {
+            [self performWrite: [message toData]];
+            NSLog(@"%@: Send message completed", self);
+        }
+        NSLog(@"%@: Complete send message with error: %@", self, error);
+        completion(!error, error);
     }
-    NSLog(@"%@: Complete send message with error: %@", self, error);
-    completion(!error, error);
 }
 
 - (void) close: (NSError*)error completion: (void (^)(void))completion {


### PR DESCRIPTION
* The message could be sent out-of-order and that causes the tests to failed intermittently due to the error such as "CouchbaseLite Network ERROR: {BLIPIO#5489} Caught exception handling incoming BLIP message: BLIP protocol error: Bad incoming REQ #2 (too high)".
* Synchronizing the sending message to prevent message out-of-order.

CBL-1092