### PR TITLE
Implement Replicator.serverCertificate property

### DIFF
--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -80,9 +80,9 @@ typedef struct {
 /** The replicator's current status: its activity level and progress. Observable. */
 @property (readonly, atomic) CBLReplicatorStatus* status;
 
-/** The SSL/TLS certificate received when connecting to the server. The application code needs to explicitly retain/release
-    the certificate object to ensure that the object is alive when keeping or working with the certificate object. */
-@property (readonly, atomic, nullable) SecCertificateRef serverCertificate;
+/** The SSL/TLS certificate received when connecting to the server. The application code takes responsibility
+    for releasing the certificate object when the application code finishes using the certificate. */
+@property (readonly, copy, atomic, nullable) __attribute__((NSObject)) SecCertificateRef serverCertificate;
 
 /** Initializes a replicator with the given configuration. */
 - (instancetype) initWithConfig: (CBLReplicatorConfiguration*)config;

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -80,6 +80,10 @@ typedef struct {
 /** The replicator's current status: its activity level and progress. Observable. */
 @property (readonly, atomic) CBLReplicatorStatus* status;
 
+/** The SSL/TLS certificate received when connecting to the server. The application code needs to explicitly retain/release
+    the certificate object to ensure that the object is alive when keeping or working with the certificate object. */
+@property (readonly, atomic, nullable) SecCertificateRef serverCertificate;
+
 /** Initializes a replicator with the given configuration. */
 - (instancetype) initWithConfig: (CBLReplicatorConfiguration*)config;
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -85,6 +85,7 @@ typedef enum {
     BOOL _resetCheckpoint;          // Reset the replicator checkpoint
     unsigned _conflictCount;        // Current number of conflict resolving tasks
     BOOL _deferReplicatorNotification; // Defer replicator notification until finishing all conflict resolving tasks
+    SecCertificateRef _serverCertificate;
 }
 
 @synthesize config=_config;
@@ -115,7 +116,12 @@ typedef enum {
 
 - (void) dealloc {
     [self stopReachability];
+    
+    // Free C4Replicator:
     c4repl_free(_repl);
+    
+    // Release server cert if available:
+    self.serverCertificate = NULL;
 }
 
 - (NSString*) description {
@@ -146,6 +152,7 @@ typedef enum {
         C4Error err;
         if ([self _setupC4Replicator: &err]) {
             // Start the C4Replicator:
+            self.serverCertificate = NULL;
             _state = kCBLStateStarting;
             c4repl_start(_repl, reset);
             _resetCheckpoint = NO;
@@ -320,6 +327,26 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
                         format: @"%@", kCBLErrorMessageReplicatorNotStopped];
         }
         _resetCheckpoint = YES;
+    }
+}
+
+#pragma mark - Server Certificate
+
+- (SecCertificateRef) serverCertificate {
+    CBL_LOCK(self) {
+        return _serverCertificate;
+    }
+}
+
+- (void) setServerCertificate: (SecCertificateRef)serverCertificate {
+    CBL_LOCK(self) {
+        SecCertificateRef oldCert = _serverCertificate;
+        if (serverCertificate)
+            _serverCertificate = (SecCertificateRef) CFRetain(serverCertificate);
+        else
+            _serverCertificate = NULL;
+        if (oldCert)
+            CFAutorelease(oldCert);
     }
 }
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -334,6 +334,11 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
 
 - (SecCertificateRef) serverCertificate {
     CBL_LOCK(self) {
+        if (_serverCertificate != NULL) {
+            CFDataRef data = SecCertificateCopyData(_serverCertificate);
+            CFAutorelease(data);
+            return SecCertificateCreateWithData(NULL, data);
+        }
         return _serverCertificate;
     }
 }

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -59,6 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) MYBackgroundMonitor* bgMonitor;
 @property (readonly, atomic) dispatch_queue_t dispatchQueue;
 
+// For CBLWebSocket to set the current server certificate
+@property (atomic, nullable) SecCertificateRef serverCertificate;
+
 - (void) setSuspended: (BOOL)suspended;
 
 @end

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, atomic) dispatch_queue_t dispatchQueue;
 
 // For CBLWebSocket to set the current server certificate
-@property (atomic, nullable) SecCertificateRef serverCertificate;
+@property (copy, atomic, nullable) __attribute__((NSObject)) SecCertificateRef serverCertificate;
 
 - (void) setSuspended: (BOOL)suspended;
 

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -91,6 +91,11 @@ public final class Replicator {
         return Status(withStatus: _impl.status)
     }
     
+    /// The SSL/TLS certificate received when connecting to the server.
+    public var serverCertificate: SecCertificate? {
+        return _impl.serverCertificate
+    }
+    
     /// Starts the replicator. This method returns immediately; the replicator runs asynchronously
     /// and will report its progress through the replicator change notification.
     public func start() {

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -644,6 +644,119 @@ class URLEndpontListenerTest: ReplicatorTest {
                  auth: nil, serverCert: self.listener!.tlsIdentity!.certs[0],
                  expectedError: CBLErrorHTTPForbidden)
     }
+    
+    func testReplicatorServerCertNoTLS() throws {
+        let x1 = expectation(description: "idle")
+        let x2 = expectation(description: "stopped")
+        
+        let listener = try listen(tls: false)
+        let repl = replicator(db: self.oDB,
+                              continuous: true,
+                              target: listener.localURLEndpoint,
+                              serverCert: nil)
+        repl.addChangeListener { (change) in
+            let activity = change.status.activity
+            if activity == .idle {
+                x1.fulfill()
+            } else if activity == .stopped && change.status.error == nil {
+                x2.fulfill()
+            }
+        }
+        XCTAssertNil(repl.serverCertificate)
+        
+        repl.start()
+        
+        wait(for: [x1], timeout: 5.0)
+        XCTAssertNil(repl.serverCertificate)
+        
+        repl.stop()
+        
+        wait(for: [x2], timeout: 5.0)
+        XCTAssertNil(repl.serverCertificate)
+        
+        try stopListen()
+    }
+    
+    func testReplicatorServerCertWithTLS() throws {
+        if !self.keyChainAccessAllowed { return }
+        
+        let x1 = expectation(description: "idle")
+        let x2 = expectation(description: "stopped")
+        
+        let listener = try listen()
+        
+        let serverCert = listener.tlsIdentity!.certs[0]
+        let repl = replicator(db: self.oDB,
+                              continuous: true,
+                              target: listener.localURLEndpoint,
+                              serverCert: serverCert)
+        repl.addChangeListener { (change) in
+            let activity = change.status.activity
+            if activity == .idle {
+                x1.fulfill()
+            } else if activity == .stopped && change.status.error == nil {
+                x2.fulfill()
+            }
+        }
+        XCTAssertNil(repl.serverCertificate)
+        
+        repl.start()
+        
+        wait(for: [x1], timeout: 5.0)
+        XCTAssertNotNil(repl.serverCertificate)
+        checkEqual(cert: serverCert, andCert: repl.serverCertificate!)
+        
+        repl.stop()
+        
+        wait(for: [x2], timeout: 5.0)
+        XCTAssertNotNil(repl.serverCertificate)
+        checkEqual(cert: serverCert, andCert: repl.serverCertificate!)
+        
+        try stopListen()
+    }
+    
+    func testReplicatorServerCertWithTLSError() throws {
+        if !self.keyChainAccessAllowed { return }
+        
+        let x1 = expectation(description: "stopped")
+        
+        let listener = try listen()
+        
+        let repl = replicator(db: self.oDB,
+                              continuous: true,
+                              target: listener.localURLEndpoint,
+                              serverCert: nil)
+        repl.addChangeListener { (change) in
+            let activity = change.status.activity
+            if activity == .stopped && change.status.error != nil {
+                x1.fulfill()
+            }
+        }
+        XCTAssertNil(repl.serverCertificate)
+        
+        repl.start()
+        
+        wait(for: [x1], timeout: 5.0)
+        XCTAssertNotNil(repl.serverCertificate)
+        
+        let serverCert = listener.tlsIdentity!.certs[0]
+        checkEqual(cert: serverCert, andCert: repl.serverCertificate!)
+        
+        try stopListen()
+    }
+    
+    func checkEqual(cert cert1: SecCertificate, andCert cert2: SecCertificate) {
+        if #available(iOS 11, *) {
+            var cn1: CFString?
+            XCTAssertEqual(SecCertificateCopyCommonName(cert1, &cn1), errSecSuccess)
+            
+            var cn2: CFString?
+            XCTAssertEqual(SecCertificateCopyCommonName(cert2, &cn2), errSecSuccess)
+            
+            XCTAssertEqual(cn1! as String, cn2! as String)
+        } 
+    }
+    
 }
 
 @available(macOS 10.12, iOS 10.0, *)


### PR DESCRIPTION
* Implement Replicator.serverCertificate property that has the value updated from CBLWebSocket.
* Reset the serverCertificate when starting the replicator.
* For Objective-C, add the note the API doc that the serverCertificate should be explictly retained / released as the CF Object doesn’t get ARC by default.

CBL-1095