### PR TITLE
Refact: clean code XCTSkip 

### DIFF
--- a/Objective-C/Tests/CBLTestCase.h
+++ b/Objective-C/Tests/CBLTestCase.h
@@ -166,6 +166,9 @@ NS_ASSUME_NONNULL_BEGIN
             randomAccess: (BOOL)randomAccess
                     test: (void (^)(uint64_t n, CBLQueryResult *result))block;
 
+/** skips the test if the keychain access is not available for the config */
+- (void) skipIfKeychainNotAccessible;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/Tests/CBLTestCase.m
+++ b/Objective-C/Tests/CBLTestCase.m
@@ -372,4 +372,10 @@
     return NSProcessInfo.processInfo.environment[@"PROFILING"] != nil;
 }
 
+- (void) skipIfKeychainNotAccessible {
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
+}
+
 @end

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -1488,18 +1488,12 @@
 
 - (void) testAuthenticationFailure_SG {
     id target = [self remoteEndpointWithName: @"seekrit" secure: NO];
-    if (!target)
-        return;
-    
     id config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: NO];
     [self run: config errorCode: CBLErrorHTTPAuthRequired errorDomain: CBLErrorDomain];
 }
 
 - (void) testAuthenticatedPull_SG {
     id target = [self remoteEndpointWithName: @"seekrit" secure: NO];
-    if (!target)
-        return;
-    
     id auth = [[CBLBasicAuthenticator alloc] initWithUsername: @"pupshaw" password: @"frank"];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: NO authenticator: auth];
     [self run: config errorCode: 0 errorDomain: nil];
@@ -1507,8 +1501,6 @@
 
 - (void) testPushBlob_SG {
     id target = [self remoteEndpointWithName: @"scratch" secure: NO];
-    if (!target)
-        return;
     
     NSError* error;
     CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
@@ -1532,18 +1524,12 @@
     timeout = 200;
 
     id target = [[CBLURLEndpoint alloc] initWithURL:[NSURL URLWithString:@"ws://foo.couchbase.com/db"]];
-    if (!target)
-        return;
-    
     id config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: YES];
     [self run: config errorCode: 0 errorDomain: nil];
 }
 
 - (void) testSelfSignedSSLFailure_SG {
     id target = [self remoteEndpointWithName: @"scratch" secure: YES];
-    if (!target)
-        return;
-    
     self.disableDefaultServerCertPinning = YES;    // without this, SSL handshake will fail
     id config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: NO];
     [self run: config errorCode: CBLErrorTLSCertUnknownRoot errorDomain: CBLErrorDomain];
@@ -1551,9 +1537,6 @@
 
 - (void) testSelfSignedSSLPinned_SG {
     id target = [self remoteEndpointWithName: @"scratch" secure: YES];
-    if (!target)
-        return;
-    
     id config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: NO];
     [self run: config errorCode: 0 errorDomain: nil];
 }
@@ -1562,8 +1545,6 @@
     // NOTE: This test never stops even after the replication goes idle.
     // It can be used to test the response to connectivity issues like killing the remote server.
     id target = [self remoteEndpointWithName: @"scratch" secure: NO];
-    if (!target)
-        return;
     id config = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: YES];
     repl = [[CBLReplicator alloc] initWithConfig: config];
     [repl start];
@@ -1605,8 +1586,6 @@
 
 - (void) testPullConflictDeleteWins_SG {
     id target = [self remoteEndpointWithName: @"scratch" secure: NO];
-    if (!target)
-        return;
     
     NSError* error;
     CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID:@"doc1"];
@@ -1648,8 +1627,6 @@
 - (void) testPushAndPullBigBodyDocument_SG {
     timeout = 200;
     id target = [self remoteEndpointWithName: @"scratch" secure: NO];
-    if (!target)
-        return;
     
     // Create a big document (~500KB)
     CBLMutableDocument *doc = [[CBLMutableDocument alloc] init];
@@ -1681,8 +1658,6 @@
 - (void) testPushAndPullExpiredDocument_SG {
     timeout = 200;
     id target = [self remoteEndpointWithName: @"scratch" secure: NO];
-    if (!target)
-        return;
     
     NSError* error;
     NSString* propertyKey = @"expiredDocumentKey";

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -103,10 +103,9 @@
 
 - (CBLURLEndpoint*) remoteEndpointWithName: (NSString*)dbName secure: (BOOL)secure {
     NSString* host = NSProcessInfo.processInfo.environment[@"CBL_TEST_HOST"];
-    if (!host) {
-        Log(@"NOTE: Skipping test: no CBL_TEST_HOST configured in environment");
-        return nil;
-    }
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(host, @"NOTE: Skipping test: no CBL_TEST_HOST configured in environment");
+    }];
     
     NSString* portKey = secure ? @"CBL_TEST_PORT_SSL" : @"CBL_TEST_PORT";
     NSInteger port = NSProcessInfo.processInfo.environment[portKey].integerValue;

--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -193,7 +193,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateGetDeleteServerIdentity {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -237,7 +239,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateDuplicateServerIdentity {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -272,7 +276,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateGetDeleteClientIdentity {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -316,7 +322,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateDuplicateClientIdentity {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -351,7 +359,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testGetIdentityWithIdentity {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     // Use SecPKCS12Import to import the PKCS12 data:
     __block CFArrayRef result = NULL;
@@ -404,7 +414,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testImportIdentity {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSData* data = [self dataFromResource: @"identity/certs" ofType: @"p12"];
     
@@ -442,7 +454,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateIdentityWithNoAttributes {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -469,7 +483,9 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCertificateExpiration {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
 
     NSError* error;
     CBLTLSIdentity* identity;

--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -193,9 +193,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateGetDeleteServerIdentity {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -239,9 +237,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateDuplicateServerIdentity {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -276,9 +272,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateGetDeleteClientIdentity {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -322,9 +316,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateDuplicateClientIdentity {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -359,9 +351,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testGetIdentityWithIdentity {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     // Use SecPKCS12Import to import the PKCS12 data:
     __block CFArrayRef result = NULL;
@@ -414,9 +404,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testImportIdentity {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSData* data = [self dataFromResource: @"identity/certs" ofType: @"p12"];
     
@@ -454,9 +442,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCreateIdentityWithNoAttributes {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSError* error;
     CBLTLSIdentity* identity;
@@ -483,9 +469,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 }
 
 - (void) testCertificateExpiration {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
 
     NSError* error;
     CBLTLSIdentity* identity;

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -316,7 +316,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testTLSIdentity {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     // Disabled TLS:
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
@@ -364,7 +366,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testURLs {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     _listener = [[Listener alloc] initWithConfig: config];
@@ -458,7 +462,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testClientCertAuthenticatorWithBlock API_AVAILABLE(macos(10.12), ios(10.3)) {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     // Listener:
     CBLListenerCertificateAuthenticator* listenerAuth =
@@ -506,7 +512,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testClientCertAuthenticatorRootCerts {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSData* rootCertData = [self dataFromResource: @"identity/client-ca" ofType: @"der"];
     SecCertificateRef rootCertRef = SecCertificateCreateWithData(kCFAllocatorDefault, (CFDataRef)rootCertData);
@@ -551,7 +559,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testServerCertVerificationModeSelfSignedCert {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     // Listener:
     Listener* listener = [self listenWithTLS: YES];
@@ -588,7 +598,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testServerCertVerificationModeCACert {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     // Listener:
     Listener* listener = [self listenWithTLS: YES];
@@ -625,7 +637,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testEmptyNetworkInterface {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     [self listen];
     NSArray* urls = _listener.urls;
@@ -679,7 +693,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testUnavailableNetworkInterface {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     config.networkInterface = @"1.1.1.256";
@@ -694,7 +710,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testNetworkInterfaceName {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     NSArray* interfaces = [Listener allInterfaceNames];
     for (NSString* i in interfaces) {
@@ -710,7 +728,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testMultipleListenersOnSameDatabase {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     Listener* listener1 = [[Listener alloc] initWithConfig: config];
@@ -739,7 +759,9 @@ typedef CBLURLEndpointListener Listener;
 
 // TODO: https://issues.couchbase.com/browse/CBL-1033
 - (void) _testMultipleReplicatorsToListener {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     [self listen]; // writable listener
     
@@ -757,7 +779,9 @@ typedef CBLURLEndpointListener Listener;
 
 // TODO: https://issues.couchbase.com/browse/CBL-1033
 - (void) _testMultipleReplicatorsOnReadOnlyListener {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     config.readOnly = YES;
@@ -781,7 +805,9 @@ typedef CBLURLEndpointListener Listener;
  3. Replicator#2  (DB#2 -> otherDB)
  */
 - (void) testReplicatorAndListenerOnSameDatabase {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     XCTestExpectation* exp1 = [self expectationWithDescription: @"replicator#1 stopped"];
     XCTestExpectation* exp2 = [self expectationWithDescription: @"replicator#2 stopped"];
@@ -851,7 +877,9 @@ typedef CBLURLEndpointListener Listener;
 
 // TODO: https://issues.couchbase.com/browse/CBL-954
 - (void) _testReadOnlyListener {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     config.readOnly = YES;
@@ -873,7 +901,9 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testCloseWithActiveListener {
-    if (!self.keyChainAccessAllowed) return;
+    [self ignoreExceptionBreakPointOnly: ^{
+        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
+    }];
     
     [self listen];
     

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -316,9 +316,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testTLSIdentity {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     // Disabled TLS:
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
@@ -366,9 +364,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testURLs {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     _listener = [[Listener alloc] initWithConfig: config];
@@ -462,9 +458,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testClientCertAuthenticatorWithBlock API_AVAILABLE(macos(10.12), ios(10.3)) {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     // Listener:
     CBLListenerCertificateAuthenticator* listenerAuth =
@@ -512,9 +506,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testClientCertAuthenticatorRootCerts {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSData* rootCertData = [self dataFromResource: @"identity/client-ca" ofType: @"der"];
     SecCertificateRef rootCertRef = SecCertificateCreateWithData(kCFAllocatorDefault, (CFDataRef)rootCertData);
@@ -559,9 +551,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testServerCertVerificationModeSelfSignedCert {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     // Listener:
     Listener* listener = [self listenWithTLS: YES];
@@ -598,9 +588,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testServerCertVerificationModeCACert {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     // Listener:
     Listener* listener = [self listenWithTLS: YES];
@@ -637,9 +625,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testEmptyNetworkInterface {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     [self listen];
     NSArray* urls = _listener.urls;
@@ -693,9 +679,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testUnavailableNetworkInterface {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     config.networkInterface = @"1.1.1.256";
@@ -710,9 +694,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testNetworkInterfaceName {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     NSArray* interfaces = [Listener allInterfaceNames];
     for (NSString* i in interfaces) {
@@ -728,9 +710,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testMultipleListenersOnSameDatabase {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     Listener* listener1 = [[Listener alloc] initWithConfig: config];
@@ -759,9 +739,7 @@ typedef CBLURLEndpointListener Listener;
 
 // TODO: https://issues.couchbase.com/browse/CBL-1033
 - (void) _testMultipleReplicatorsToListener {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     [self listen]; // writable listener
     
@@ -779,9 +757,7 @@ typedef CBLURLEndpointListener Listener;
 
 // TODO: https://issues.couchbase.com/browse/CBL-1033
 - (void) _testMultipleReplicatorsOnReadOnlyListener {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     config.readOnly = YES;
@@ -805,9 +781,7 @@ typedef CBLURLEndpointListener Listener;
  3. Replicator#2  (DB#2 -> otherDB)
  */
 - (void) testReplicatorAndListenerOnSameDatabase {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     XCTestExpectation* exp1 = [self expectationWithDescription: @"replicator#1 stopped"];
     XCTestExpectation* exp2 = [self expectationWithDescription: @"replicator#2 stopped"];
@@ -877,9 +851,7 @@ typedef CBLURLEndpointListener Listener;
 
 // TODO: https://issues.couchbase.com/browse/CBL-954
 - (void) _testReadOnlyListener {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     Config* config = [[Config alloc] initWithDatabase: self.otherDB];
     config.readOnly = YES;
@@ -901,9 +873,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 - (void) testCloseWithActiveListener {
-    [self ignoreExceptionBreakPointOnly: ^{
-        XCTSkipUnless(self.keyChainAccessAllowed, @"Skipping, keychain not accessible in this config");
-    }];
+    [self skipIfKeychainNotAccessible];
     
     [self listen];
     

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -240,6 +240,10 @@ class CBLTestCase: XCTestCase {
         return n
     }
     
+    func skipIfKeychainNotAccessible() throws {
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+    }
+    
 }
 
 /** Comparing JSON Dictionary */

--- a/Swift/Tests/TLSIdentityTest.swift
+++ b/Swift/Tests/TLSIdentityTest.swift
@@ -149,7 +149,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateGetDeleteServerIdentity() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
@@ -183,7 +183,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateDuplicateServerIdentity() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Create:
         var identity: TLSIdentity?
@@ -211,7 +211,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateGetDeleteClientIdentity() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
@@ -245,7 +245,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateDuplicateClientIdentity() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Create:
         var identity: TLSIdentity?
@@ -273,7 +273,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testGetIdentityWithIdentity() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Use SecPKCS12Import to import the PKCS12 data:
         var result : CFArray?
@@ -318,7 +318,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testImportIdentity() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let data = try dataFromResource(name: "identity/certs", ofType: "p12")
         
@@ -351,7 +351,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateIdentityWithNoAttributes() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
@@ -370,7 +370,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCertificateExpiration() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)

--- a/Swift/Tests/TLSIdentityTest.swift
+++ b/Swift/Tests/TLSIdentityTest.swift
@@ -149,7 +149,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateGetDeleteServerIdentity() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
@@ -183,7 +183,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateDuplicateServerIdentity() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Create:
         var identity: TLSIdentity?
@@ -211,7 +211,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateGetDeleteClientIdentity() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
@@ -245,7 +245,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateDuplicateClientIdentity() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Create:
         var identity: TLSIdentity?
@@ -273,7 +273,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testGetIdentityWithIdentity() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Use SecPKCS12Import to import the PKCS12 data:
         var result : CFArray?
@@ -318,7 +318,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testImportIdentity() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let data = try dataFromResource(name: "identity/certs", ofType: "p12")
         
@@ -351,7 +351,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCreateIdentityWithNoAttributes() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
@@ -370,7 +370,7 @@ class TLSIdentityTest: CBLTestCase {
     }
     
     func testCertificateExpiration() throws {
-        if (!keyChainAccessAllowed) { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Delete:
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -179,7 +179,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testTLSIdentity() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Disabled TLS:
         var config = URLEndpointListenerConfiguration.init(database: self.oDB)
@@ -250,7 +250,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     
     @available(macOS 10.12, iOS 10.3, *)
     func testClientCertAuthenticatorWithClosure() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Listener:
         let listenerAuth = ListenerCertificateAuthenticator.init { (certs) -> Bool in
@@ -284,7 +284,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testClientCertAuthenticatorWithRootCerts() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Root Cert:
         let rootCertData = try dataFromResource(name: "identity/client-ca", ofType: "der")
@@ -315,7 +315,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testServerCertVerificationModeSelfSignedCert() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Listener:
         let listener = try listen(tls: true)
@@ -339,7 +339,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testServerCertVerificationModeCACert() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         // Listener:
         let listener = try listen(tls: true)
@@ -364,7 +364,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testPort() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.port = wsPort
@@ -380,7 +380,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testEmptyPort() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         self.listener = URLEndpointListener(config: config)
@@ -395,7 +395,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testBusyPort() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         try listen()
         
@@ -409,7 +409,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testURLs() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.port = wsPort
@@ -425,7 +425,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testConnectionStatus() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.port = wsPort
@@ -460,7 +460,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testMultipleListenersOnSameDatabase() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         let listener1 = URLEndpointListener(config: config)
@@ -483,7 +483,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testReplicatorAndListenerOnSameDatabase() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let exp1 = expectation(description: "replicator#1 stop")
         let exp2 = expectation(description: "replicator#2 stop")
@@ -545,7 +545,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testCloseWithActiveListener() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         try listen()
         
@@ -559,7 +559,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testEmptyNetworkInterface() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         try listen()
         let urls = self.listener!.urls!
@@ -599,7 +599,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testMultipleReplicatorsToListener() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         try listen()
         
@@ -614,7 +614,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     
     // TODO: https://issues.couchbase.com/browse/CBL-954
     func _testReadOnlyListener() throws {
-        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
+        try skipIfKeychainNotAccessible()
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.readOnly = true

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -179,9 +179,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testTLSIdentity() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Disabled TLS:
         var config = URLEndpointListenerConfiguration.init(database: self.oDB)
@@ -252,9 +250,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     
     @available(macOS 10.12, iOS 10.3, *)
     func testClientCertAuthenticatorWithClosure() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Listener:
         let listenerAuth = ListenerCertificateAuthenticator.init { (certs) -> Bool in
@@ -288,9 +284,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testClientCertAuthenticatorWithRootCerts() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Root Cert:
         let rootCertData = try dataFromResource(name: "identity/client-ca", ofType: "der")
@@ -321,9 +315,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testServerCertVerificationModeSelfSignedCert() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Listener:
         let listener = try listen(tls: true)
@@ -347,9 +339,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testServerCertVerificationModeCACert() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         // Listener:
         let listener = try listen(tls: true)
@@ -374,9 +364,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testPort() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.port = wsPort
@@ -392,9 +380,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testEmptyPort() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         self.listener = URLEndpointListener(config: config)
@@ -409,9 +395,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testBusyPort() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         try listen()
         
@@ -425,9 +409,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testURLs() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.port = wsPort
@@ -443,9 +425,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testConnectionStatus() throws {
-        if !self.keyChainAccessAllowed {
-            return
-        }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.port = wsPort
@@ -480,7 +460,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testMultipleListenersOnSameDatabase() throws {
-        if !self.keyChainAccessAllowed { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         let listener1 = URLEndpointListener(config: config)
@@ -503,7 +483,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testReplicatorAndListenerOnSameDatabase() throws {
-        if !self.keyChainAccessAllowed { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let exp1 = expectation(description: "replicator#1 stop")
         let exp2 = expectation(description: "replicator#2 stop")
@@ -565,7 +545,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testCloseWithActiveListener() throws {
-        if !self.keyChainAccessAllowed { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         try listen()
         
@@ -579,7 +559,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testEmptyNetworkInterface() throws {
-        if !self.keyChainAccessAllowed { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         try listen()
         let urls = self.listener!.urls!
@@ -619,7 +599,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testMultipleReplicatorsToListener() throws {
-        if !self.keyChainAccessAllowed { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         try listen()
         
@@ -634,7 +614,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     
     // TODO: https://issues.couchbase.com/browse/CBL-954
     func _testReadOnlyListener() throws {
-        if !self.keyChainAccessAllowed { return }
+        try XCTSkipUnless(keyChainAccessAllowed, "Skipping, keychain is not allowed in this config")
         
         let config = URLEndpointListenerConfiguration(database: self.oDB)
         config.readOnly = true


### PR DESCRIPTION
* keeps forgetting, whether the test skips or really passing. 
* XCTSkip can be really helpful in detecting this case