### PR TITLE
CBL-1114: Fix open connection handshake bug in CBLMockConnection

### DIFF
--- a/Objective-C/Tests/Util/CBLMockConnection.h
+++ b/Objective-C/Tests/Util/CBLMockConnection.h
@@ -50,13 +50,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype) initWithEndpoint: (CBLMessageEndpoint*)endpoint;
 
+- (void) serverConnected;
+
 - (void) serverDisconnected;
 
 @end
 
 @interface CBLMockServerConnection : CBLMockConnection
 
-- (void) clientOpened: (CBLMockClientConnection*)client;
+- (void) clientConnected: (CBLMockClientConnection*)client;
 
 - (void) clientDisconnected: (nullable CBLMessagingError*)error;
 


### PR DESCRIPTION
Ensure that the client reports open connection completion when the server has successfully open the connection.