### PR TITLE
cbl-1094: update the server verfication mode

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -726,7 +726,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
         [url c4Address: &addr];
         C4SliceResult cookies = c4db_getCookies(_c4db, addr, &err);
         if (!cookies.buf) {
-            CBLWarnError(WebSocket, @"Error getting cookies %d/%d", err.domain, err.code);
+            CBLWarn(WebSocket, @"Error getting cookies %d/%d", err.domain, err.code);
         }
         return sliceResult2string(cookies);
     }

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -44,7 +44,7 @@
 @synthesize conflictResolver=_conflictResolver;
 
 #ifdef COUCHBASE_ENTERPRISE
-@synthesize serverCertificateVerificationMode=_serverCertificateVerificationMode;
+@synthesize acceptOnlySelfSignedServerCertificate=_acceptOnlySelfSignedServerCertificate;
 #endif
 
 #if TARGET_OS_IPHONE
@@ -63,7 +63,7 @@
         _target = target;
         _replicatorType = kCBLReplicatorTypePushAndPull;
 #ifdef COUCHBASE_ENTERPRISE
-        _serverCertificateVerificationMode = kCBLServerCertVerificationModeCACert;
+        _acceptOnlySelfSignedServerCertificate = NO;
 #endif
     }
     return self;
@@ -91,9 +91,9 @@
 }
 
 #ifdef COUCHBASE_ENTERPRISE
-- (void) setServerCertificateVerificationMode: (CBLServerCertificateVerificationMode)serverCertificateVerificationMode {
+- (void) setAcceptOnlySelfSignedServerCertificate: (BOOL)acceptOnlySelfSignedServerCertificate {
     [self checkReadonly];
-    _serverCertificateVerificationMode = serverCertificateVerificationMode;
+    _acceptOnlySelfSignedServerCertificate = acceptOnlySelfSignedServerCertificate;
 }
 #endif
 
@@ -146,7 +146,7 @@
         _continuous = config.continuous;
         _authenticator = config.authenticator;
 #ifdef COUCHBASE_ENTERPRISE
-        _serverCertificateVerificationMode = config.serverCertificateVerificationMode;
+        _acceptOnlySelfSignedServerCertificate = config.acceptOnlySelfSignedServerCertificate;
 #endif
         _pinnedServerCertificate = config.pinnedServerCertificate;
         cfretain(_pinnedServerCertificate);

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -205,6 +205,8 @@
     NSString* uniqueID = $castIf(CBLMessageEndpoint, _target).uid;
     if (uniqueID)
         options[@kC4ReplicatorOptionRemoteDBUniqueID] = uniqueID;
+    
+    options[@kC4ReplicatorOptionOnlySelfSignedServerCert] = @(_acceptOnlySelfSignedServerCertificate);
 #endif
     
     return options;

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSTimeInterval heartbeatInterval;
 
 #ifdef COUCHBASE_ENTERPRISE
-@property (nonatomic) CBLServerCertificateVerificationMode serverCertificateVerificationMode;
+@property (nonatomic) BOOL acceptOnlySelfSignedServerCertificate;
 #endif
 
 - (instancetype) initWithConfig: (CBLReplicatorConfiguration*)config

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -170,7 +170,7 @@ static void doDispose(C4Socket* s) {
         _remoteURL = $castIf(CBLURLEndpoint, _replicator.config.target).url;
 #ifdef COUCHBASE_ENTERPRISE
         // Workaround for CBL-1003:
-        if (_replicator.config.serverCertificateVerificationMode == kCBLServerCertVerificationModeSelfSignedCert)
+        if (_replicator.config.acceptOnlySelfSignedServerCertificate)
             _acceptOnlySelfSignedCert = YES;
 #endif
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL: url];

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -340,7 +340,7 @@ static void doDispose(C4Socket* s) {
                          forKey: (__bridge id)kCFStreamSSLValidatesCertificateChain];
       
 #ifdef COUCHBASE_ENTERPRISE
-        if (_options[kC4ReplicatorOptionOnlySelfSignedServerCert])
+        if (_options[kC4ReplicatorOptionOnlySelfSignedServerCert].asBool())
             [settings setObject: @NO
                          forKey: (__bridge id)kCFStreamSSLValidatesCertificateChain];
 #endif

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -672,7 +672,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
     
     NSError* error;
 #ifdef COUCHBASE_ENTERPRISE
-    NSURLCredential* credentials = _acceptOnlySelfSignedCert ?
+    NSURLCredential* credentials = !pin && _acceptOnlySelfSignedCert ?
         [check acceptOnlySelfSignedCert: &error] :
         [check checkTrust: &error];
 #else

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -30,7 +30,7 @@
 
 #ifdef COUCHBASE_ENTERPRISE
 
-- (void)testEmptyPush {
+- (void) testEmptyPush {
     id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: NO];
     [self run: config errorCode: 0 errorDomain: nil];

--- a/Objective-C/Tests/ReplicatorTest.h
+++ b/Objective-C/Tests/ReplicatorTest.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
                                             type: (CBLReplicatorType)type
                                       continuous: (BOOL)continuous
                                    authenticator: (nullable CBLAuthenticator*)authenticator
-                            serverCertVerifyMode: (CBLServerCertificateVerificationMode)serverCertVerifyMode
+                            acceptSelfSignedOnly: (BOOL)acceptSelfSignedOnly
                                       serverCert: (nullable SecCertificateRef)serverCert;
 #endif
 
@@ -117,7 +117,7 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady;
                   type: (CBLReplicatorType)type
             continuous: (BOOL)continuous
          authenticator: (nullable CBLAuthenticator*)authenticator
-  serverCertVerifyMode: (CBLServerCertificateVerificationMode)serverCertVerifyMode
+  acceptSelfSignedOnly: (BOOL)acceptSelfSignedOnly
             serverCert: (nullable SecCertificateRef)serverCert
              errorCode: (NSInteger)errorCode
            errorDomain: (nullable NSString*)errorDomain;

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -262,14 +262,14 @@
                                             type: (CBLReplicatorType)type
                                       continuous: (BOOL)continuous
                                    authenticator: (nullable CBLAuthenticator*)authenticator
-                            serverCertVerifyMode: (CBLServerCertificateVerificationMode)serverCertVerifyMode
+                            acceptSelfSignedOnly: (BOOL)acceptSelfSignedOnly
                                       serverCert: (nullable SecCertificateRef)serverCert {
     CBLReplicatorConfiguration* c = [self configWithTarget: target
                                                       type: type
                                                 continuous: continuous
                                              authenticator: authenticator
                                                 serverCert: serverCert];
-    c.serverCertificateVerificationMode = serverCertVerifyMode;
+    c.acceptOnlySelfSignedServerCertificate = acceptSelfSignedOnly;
     return c;
 }
 #endif
@@ -333,7 +333,7 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady {
                   type: (CBLReplicatorType)type
             continuous: (BOOL)continuous
          authenticator: (nullable CBLAuthenticator*)authenticator
-  serverCertVerifyMode: (CBLServerCertificateVerificationMode)serverCertVerifyMode
+  acceptSelfSignedOnly: (BOOL)acceptSelfSignedOnly
             serverCert: (nullable SecCertificateRef)serverCert
              errorCode: (NSInteger)errorCode
            errorDomain: (nullable NSString*)errorDomain {
@@ -341,7 +341,7 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady {
                                   type: type
                             continuous: continuous
                          authenticator: authenticator
-                  serverCertVerifyMode: serverCertVerifyMode
+                  acceptSelfSignedOnly: acceptSelfSignedOnly
                             serverCert: serverCert];
     return [self run: config errorCode: errorCode errorDomain: errorDomain];
 }

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -550,7 +550,37 @@ typedef CBLURLEndpointListener Listener;
     [self stopListener: listener];
 }
 
-- (void) testServerCertVerificationModeSelfSignedCert {
+- (void) testAcceptSelfSignedCertWithPinnedCertificate {
+    if (!self.keyChainAccessAllowed) return;
+    
+    // Listener:
+    Listener* listener = [self listenWithTLS: YES];
+    AssertNotNil(listener);
+    AssertEqual(listener.tlsIdentity.certs.count, 1);
+    
+    // should fail this scenario
+    [self runWithTarget: listener.localEndpoint
+                   type: kCBLReplicatorTypePushAndPull
+             continuous: NO
+          authenticator: nil
+   acceptSelfSignedOnly: YES
+             serverCert: self.defaultServerCert
+              errorCode: CBLErrorTLSCertUnknownRoot
+            errorDomain: CBLErrorDomain];
+    
+    [self runWithTarget: listener.localEndpoint
+                   type: kCBLReplicatorTypePushAndPull
+             continuous: NO
+          authenticator: nil
+   acceptSelfSignedOnly: NO
+             serverCert: (__bridge SecCertificateRef) listener.tlsIdentity.certs[0]
+              errorCode: 0
+            errorDomain: nil];
+    
+    [self stopListener: listener];
+}
+
+- (void) testAcceptOnlySelfSignedCertMode {
     if (!self.keyChainAccessAllowed) return;
     
     // Listener:
@@ -587,7 +617,7 @@ typedef CBLURLEndpointListener Listener;
     [self stopListener: listener];
 }
 
-- (void) testServerCertVerificationModeCACert {
+- (void) testDoNotAcceptSelfSignedMode {
     if (!self.keyChainAccessAllowed) return;
     
     // Listener:

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -566,7 +566,7 @@ typedef CBLURLEndpointListener Listener;
                        type: kCBLReplicatorTypePushAndPull
                  continuous: NO
               authenticator: nil
-       serverCertVerifyMode: kCBLServerCertVerificationModeCACert
+       acceptSelfSignedOnly: NO
                  serverCert: nil
                   errorCode: CBLErrorTLSCertUnknownRoot
                 errorDomain: CBLErrorDomain];
@@ -578,7 +578,7 @@ typedef CBLURLEndpointListener Listener;
                        type: kCBLReplicatorTypePushAndPull
                  continuous: NO
               authenticator: nil
-       serverCertVerifyMode: kCBLServerCertVerificationModeSelfSignedCert
+       acceptSelfSignedOnly: YES
                  serverCert: nil
                   errorCode: 0
                 errorDomain: nil];
@@ -603,7 +603,7 @@ typedef CBLURLEndpointListener Listener;
                        type: kCBLReplicatorTypePushAndPull
                  continuous: NO
               authenticator: nil
-       serverCertVerifyMode: kCBLServerCertVerificationModeCACert
+       acceptSelfSignedOnly: NO
                  serverCert: nil
                   errorCode: CBLErrorTLSCertUnknownRoot
                 errorDomain: CBLErrorDomain];
@@ -615,7 +615,7 @@ typedef CBLURLEndpointListener Listener;
                        type: kCBLReplicatorTypePushAndPull
                  continuous: NO
               authenticator: nil
-       serverCertVerifyMode: kCBLServerCertVerificationModeCACert
+       acceptSelfSignedOnly: NO
                  serverCert: (__bridge SecCertificateRef) listener.tlsIdentity.certs[0]
                   errorCode: 0
                 errorDomain: nil];

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -558,7 +558,7 @@ typedef CBLURLEndpointListener Listener;
     AssertNotNil(listener);
     AssertEqual(listener.tlsIdentity.certs.count, 1);
     
-    // should fail this scenario
+    // listener = cert1; replicator.pin = cert2; acceptSelfSigned = true => fail
     [self runWithTarget: listener.localEndpoint
                    type: kCBLReplicatorTypePushAndPull
              continuous: NO
@@ -568,6 +568,7 @@ typedef CBLURLEndpointListener Listener;
               errorCode: CBLErrorTLSCertUnknownRoot
             errorDomain: CBLErrorDomain];
     
+    // listener = cert1; replicator.pin = cert1; acceptSelfSigned = false => pass
     [self runWithTarget: listener.localEndpoint
                    type: kCBLReplicatorTypePushAndPull
              continuous: NO

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -30,15 +30,6 @@ public enum ReplicatorType: UInt8 {
     case pull
 }
 
-///  Server Certificate Verification Mode.
-///
-/// - caCert: Verify by using trusted anchor CA certs or by using the configured pinned server certs (Default Mode).
-/// - selfSignedCert: Verify by accepting any and only self-signed certs. Any non-self-signed certs will be rejected.
-public enum ServerCertificateVerificationMode: UInt8 {
-    case caCert = 0
-    case selfSignedCert
-}
-
 /// Document flags describing a replicated document.
 public struct DocumentFlags: OptionSet {
     
@@ -102,7 +93,7 @@ public class ReplicatorConfiguration {
     
     #if COUCHBASE_ENTERPRISE
     /// Specify how the replicator verifies TLS server certificates. The default mode is .caCert.
-    public var serverCertificateVerificationMode: ServerCertificateVerificationMode = .caCert {
+    public var acceptOnlySelfSignedServerCertificate: Bool = false {
         willSet(newValue) {
             checkReadOnly()
         }
@@ -229,7 +220,7 @@ public class ReplicatorConfiguration {
         #endif
         
         #if COUCHBASE_ENTERPRISE
-        self.serverCertificateVerificationMode = config.serverCertificateVerificationMode
+        self.acceptOnlySelfSignedServerCertificate = config.acceptOnlySelfSignedServerCertificate
         #endif
     }
     
@@ -263,8 +254,7 @@ public class ReplicatorConfiguration {
         #endif
         
         #if COUCHBASE_ENTERPRISE
-        c.serverCertificateVerificationMode = CBLServerCertificateVerificationMode(rawValue:
-            UInt(self.serverCertificateVerificationMode.rawValue))!
+        c.acceptOnlySelfSignedServerCertificate = self.acceptOnlySelfSignedServerCertificate
         #endif
         return c
     }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -50,11 +50,11 @@ class ReplicatorTest: CBLTestCase {
     #if COUCHBASE_ENTERPRISE
     func config(target: Endpoint, type: ReplicatorType = .pushAndPull,
                 continuous: Bool = false, auth: Authenticator? = nil,
-                serverCertVerifyMode: ServerCertificateVerificationMode = .caCert,
+                acceptSelfSignedOnly: Bool = false,
                 serverCert: SecCertificate? = nil) -> ReplicatorConfiguration {
         let config = self.config(target: target, type: type, continuous: continuous,
                                  auth: auth, serverCert: serverCert)
-        config.serverCertificateVerificationMode = serverCertVerifyMode
+        config.acceptOnlySelfSignedServerCertificate = acceptSelfSignedOnly
         return config
     }
     #endif
@@ -86,11 +86,11 @@ class ReplicatorTest: CBLTestCase {
     #if COUCHBASE_ENTERPRISE
     func run(target: Endpoint, type: ReplicatorType = .pushAndPull,
              continuous: Bool = false, auth: Authenticator? = nil,
-             serverCertVerifyMode: ServerCertificateVerificationMode = .caCert,
+             acceptSelfSignedOnly: Bool = false,
              serverCert: SecCertificate? = nil,
              expectedError: Int? = nil) {
         let config = self.config(target: target, type: type, continuous: continuous, auth: auth,
-                                 serverCertVerifyMode: serverCertVerifyMode, serverCert: serverCert)
+                                 acceptSelfSignedOnly: acceptSelfSignedOnly, serverCert: serverCert)
         run(config: config, reset: false, expectedError: expectedError)
     }
     #endif

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -333,13 +333,13 @@ class URLEndpontListenerTest: ReplicatorTest {
         // Replicator - TLS Error:
         self.ignoreException {
             self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
-                     serverCertVerifyMode: .caCert, serverCert: nil, expectedError: CBLErrorTLSCertUnknownRoot)
+                     acceptSelfSignedOnly: false, serverCert: nil, expectedError: CBLErrorTLSCertUnknownRoot)
         }
         
         // Replicator - Success:
         self.ignoreException {
             self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
-                     serverCertVerifyMode: .selfSignedCert, serverCert: nil)
+                     acceptSelfSignedOnly: true, serverCert: nil)
         }
         
         // Cleanup
@@ -359,14 +359,14 @@ class URLEndpontListenerTest: ReplicatorTest {
         // Replicator - TLS Error:
         self.ignoreException {
             self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
-                     serverCertVerifyMode: .caCert, serverCert: nil, expectedError: CBLErrorTLSCertUnknownRoot)
+                     acceptSelfSignedOnly: false, serverCert: nil, expectedError: CBLErrorTLSCertUnknownRoot)
         }
         
         // Replicator - Success:
         self.ignoreException {
             let serverCert = listener.tlsIdentity!.certs[0]
             self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
-                     serverCertVerifyMode: .caCert, serverCert: serverCert)
+                     acceptSelfSignedOnly: false, serverCert: serverCert)
         }
         
         // Cleanup
@@ -462,7 +462,7 @@ class URLEndpontListenerTest: ReplicatorTest {
         try generateDocument(withID: "doc-1")
         let rConfig = self.config(target: self.listener!.localURLEndpoint,
                                  type: .pushAndPull, continuous: false, auth: nil,
-                                 serverCertVerifyMode: .caCert, serverCert: nil)
+                                 acceptSelfSignedOnly: false, serverCert: nil)
         var maxConnectionCount: UInt64 = 0, maxActiveCount:UInt64 = 0
         run(config: rConfig, reset: false, expectedError: nil) { (replicator) in
             replicator.addChangeListener { (change) in


### PR DESCRIPTION
* remove the enum and use a bool indicating whether only self-signed is accepted
* for every blip request, we look for cookies, if no cookies saved, we only print warning and not an error. 