### PR TITLE
disable concurrent build in Jenkinsfile in case multiple PR kicks off at the same time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 pipeline {
+    options {
+        disableConcurrentBuilds() 
+    }
     agent { label 'mobile-builder-ios-pull-request'  }
     stages {
         stage('Checkout'){


### PR DESCRIPTION
Jenkins slave is configured with 2 executors now to allow official build & test running in parallel.
Hence, we need to disable concurrent build option in Jenkinsfile to ensure 2 PR build don't kick simultaneously.

-Ming Ho