### PR TITLE
CBLDatabase.getCookies: should have nullable result

### DIFF
--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 // method of the PredictiveModel.
 - (instancetype) initWithC4Database: (C4Database*)c4db;
 
-- (NSString*) getCookies: (NSURL*)url;
+- (nullable NSString*) getCookies: (NSURL*)url;
 - (BOOL) saveCookie: (NSString*)cookie url: (NSURL*)url;
 
 @end


### PR DESCRIPTION
This method returns nil when the db has no saved cookies, so its
return value should be nullable. (I hit an undefined-behavior
sanitizer warning on this today.)