### PR TITLE
Fix client cert auth error

### DIFF
--- a/Objective-C/Internal/CBLStatus.mm
+++ b/Objective-C/Internal/CBLStatus.mm
@@ -90,7 +90,9 @@ void convertError(NSError* error, C4Error *outError) {
         }
     } else if ([domain isEqualToString: NSOSStatusErrorDomain]) {
         if (!osStatusToC4Error(code, &c4err)) {
-            if (code >= -9899 && code <= -9800)
+            if (code == errSSLPeerAccessDenied || code == errSSLPeerUnknownCA)
+                c4err = {NetworkDomain, kC4NetErrTLSCertRejectedByPeer};// SecureTransport access denied
+            else if (code >= -9899 && code <= -9800)
                 c4err = {NetworkDomain, kC4NetErrTLSHandshakeFailed};   // SecureTransport errors
         }
     }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -113,7 +113,9 @@ class ReplicatorTest: CBLTestCase {
                 let error = status.error as NSError?
                 if let err = expectedError {
                     XCTAssertNotNil(error)
-                    XCTAssertEqual(error!.code, err)
+                    if let e = error {
+                        XCTAssertEqual(e.code, err)
+                    }
                 } else {
                     XCTAssertNil(error)
                 }


### PR DESCRIPTION
* Fixed the error code for client cert auth error
* Added unit tests for testing failed cases for client cert auth.
* Shorten the test names
* Fixed crash check checking error in test.

CBL-1177