### PR TITLE
CBL-1247: Correct the cookie logic

### DIFF
--- a/Objective-C/Internal/Replicator/CBLWebSocket.h
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSString*) webSocketAcceptHeaderForKey: (NSString*)key;
 
 // for testing purpose only:
-+ (NSArray*) parseCookie: (NSString*) cookie;
++ (NSArray*) parseCookies: (NSString*) cookie;
 
 @end
 

--- a/Objective-C/Internal/Replicator/CBLWebSocket.h
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.h
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSString*) webSocketAcceptHeaderForKey: (NSString*)key;
 
+// for testing purpose only:
++ (NSArray*) parseCookie: (NSString*) cookie;
+
 @end
 
 

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -453,7 +453,7 @@ static void doDispose(C4Socket* s) {
     if (cookie.length > 0) {
         NSArray* cookies = [CBLWebSocket parseCookie: cookie];
         
-        // Save to LiteCore 
+        // Save to LiteCore
         for (NSString* cookieStr in cookies) {
             [_db saveCookie: cookieStr url: _remoteURL];
         }
@@ -784,7 +784,9 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
     _out = nil;
 }
 
-+ (NSArray*) parseCookie: (NSString*) cookieStr {
+#pragma mark - Helper
+
++ (NSArray*) parseCookies: (NSString*) cookieStr {
     Assert(cookieStr.length > 0, @"Trtying to parse empty cookie string");
     
     NSArray* rawAttrs = [cookieStr componentsSeparatedByString: @";"];

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -22,6 +22,7 @@
 #import "CBLDocumentReplication+Internal.h"
 #import "CBLReplicator+Backgrounding.h"
 #import "CBLReplicator+Internal.h"
+#import "CBLWebSocket.h"
 
 @interface ReplicatorTest_Main : ReplicatorTest
 @end
@@ -1480,6 +1481,21 @@
     
     AssertEqual(pushDocIds.count, 1u);
     Assert([pushDocIds containsObject: @"doc1"]);
+}
+
+- (void) testWebSocketParseCookie {
+    NSArray* inputs = @[
+        @[@"a1=b1", @[@"a1=b1"]],
+        @[@"a1=b1;a2=b2", @[@"a1=b1;a2=b2"]],
+        @[@"a1=b1;expires=b2,3", @[@"a1=b1;expires=b2,3"]],
+        @[@"a1=b1;a2=b2,a3=b3;a4=b4", @[@"a1=b1;a2=b2", @"a3=b3;a4=b4"]],
+        @[@"a1=b1;Expires=Mon, 29 Feb 2021 20:21:12 GMT;Path=/", @[@"a1=b1;Expires=Mon, 29 Feb 2021 20:21:12 GMT;Path=/"]],
+        @[@"a1=b1;expires=b2,3,a2=b2", @[@"a1=b1;expires=b2,3", @"a2=b2"]],
+    ];
+    
+    for (NSArray* input in inputs) {
+        AssertEqualObjects([CBLWebSocket parseCookie: input[0]], input[1]);
+    }
 }
 
 #endif // COUCHBASE_ENTERPRISE

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -1491,10 +1491,11 @@
         @[@"a1=b1;a2=b2,a3=b3;a4=b4", @[@"a1=b1;a2=b2", @"a3=b3;a4=b4"]],
         @[@"a1=b1;Expires=Mon, 29 Feb 2021 20:21:12 GMT;Path=/", @[@"a1=b1;Expires=Mon, 29 Feb 2021 20:21:12 GMT;Path=/"]],
         @[@"a1=b1;expires=b2,3,a2=b2", @[@"a1=b1;expires=b2,3", @"a2=b2"]],
+        @[@"a1=b1;expires=b1,2,a3=b3;Expires=b3,4", @[@"a1=b1;expires=b1,2", @"a3=b3;Expires=b3,4"]],
     ];
     
     for (NSArray* input in inputs) {
-        AssertEqualObjects([CBLWebSocket parseCookie: input[0]], input[1]);
+        AssertEqualObjects([CBLWebSocket parseCookies: input[0]], input[1]);
     }
 }
 


### PR DESCRIPTION
* previous parsing logic was wrong, corrected
* include a unit test to validate the parse method
* as per the documentation, https://tools.ietf.org/html/rfc6265#section-4.1.1, any ASCII except control characters can become cookie value, so I have used bell(^G) character 