### PR TITLE
skip local network in unit test

### DIFF
--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -659,7 +659,7 @@ typedef CBLURLEndpointListener Listener;
     NSArray* urls = _listener.urls;
     
     /** Link local addresses cannot be assigned via network interface because they don't map to any given interface.  */
-    NSPredicate* p = [NSPredicate predicateWithFormat: @"NOT(SELF.host BEGINSWITH 'fe80::')"];
+    NSPredicate* p = [NSPredicate predicateWithFormat: @"NOT(SELF.host CONTAINS 'fe80::') AND NOT(SELF.host CONTAINS '.local')"];
     NSArray* notLinkLocal = [urls filteredArrayUsingPredicate: p];
     
     NSError* err = nil;

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -589,7 +589,7 @@ class URLEndpontListenerTest: ReplicatorTest {
         let urls = self.listener!.urls!
         
         /// Link local addresses cannot be assigned via network interface because they don't map to any given interface.
-        let notLinkLocal: [URL] = urls.filter { !$0.host!.starts(with: "fe80::") }
+        let notLinkLocal: [URL] = urls.filter { !$0.host!.contains("fe80::") && !$0.host!.contains(".local")}
         
         for (i, url) in notLinkLocal.enumerated() {
             // separate db instance!


### PR DESCRIPTION
* update test to ignore the local network, since the iphone simulator might pick up hostname instead of the localhost name