### PR TITLE
CBL-1111 : Fix value type has no subscripts issue when building with XCode12 Beta

### DIFF
--- a/Swift/ArrayObject.swift
+++ b/Swift/ArrayObject.swift
@@ -232,7 +232,7 @@ public class ArrayObject: ArrayProtocol, Equatable, Hashable, Sequence {
     ///
     /// - Parameter index: The Index.
     public subscript(index: Int) -> Fragment {
-        return Fragment(_impl[UInt(index)])
+        return Fragment((_impl as CBLArrayFragment)[UInt(index)])
     }
     
     // MARK: Equality

--- a/Swift/Document.swift
+++ b/Swift/Document.swift
@@ -228,7 +228,7 @@ public class Document : DictionaryProtocol, Equatable, Hashable, Sequence {
     ///
     /// - Parameter key: The key.
     public subscript(key: String) -> Fragment {
-        return Fragment(_impl[key])
+        return Fragment((_impl as CBLDictionaryFragment)[key])
     }
     
     // MARK: Equality

--- a/Swift/DocumentFragment.swift
+++ b/Swift/DocumentFragment.swift
@@ -43,7 +43,7 @@ public final class DocumentFragment: DictionaryFragment {
     ///
     /// - Parameter key: The key.
     public subscript(key: String) -> Fragment {
-        return Fragment(_impl[key])
+        return Fragment((_impl as CBLDictionaryFragment)[key])
     }
     
     // MARK: Internal

--- a/Swift/Fragment.swift
+++ b/Swift/Fragment.swift
@@ -158,14 +158,14 @@ public class Fragment: FragmentProtocol, ArrayFragment, DictionaryFragment {
     ///
     /// - Parameter index: The index
     public subscript(index: Int) -> Fragment {
-        return Fragment(_impl[UInt(index)])
+        return Fragment((_impl as CBLArrayFragment)[UInt(index)])
     }
     
     /// Subscript access to a Fragment object by key.
     ///
     /// - Parameter key: The key.
     public subscript(key: String) -> Fragment {
-        return Fragment(_impl[key])
+        return Fragment((_impl as CBLDictionaryFragment)[key])
     }
     
     // MARK: Internal

--- a/Swift/MutableArrayObject.swift
+++ b/Swift/MutableArrayObject.swift
@@ -532,7 +532,7 @@ public final class MutableArrayObject: ArrayObject, MutableArrayProtocol {
     ///                    the MutableFragment object will represent a nil value.
     /// - Returns: The Fragment object.
     public override subscript(index: Int) -> MutableFragment {
-        return MutableFragment(arrayImpl[UInt(index)])
+        return MutableFragment((arrayImpl as CBLMutableArrayFragment)[UInt(index)])
     }
     
     // MARK: Internal

--- a/Swift/MutableDictionaryObject.swift
+++ b/Swift/MutableDictionaryObject.swift
@@ -266,7 +266,7 @@ public final class MutableDictionaryObject: DictionaryObject, MutableDictionaryP
     /// - Parameter key: The key.
     /// - Returns: The Fragment object.
     public override subscript(key: String) -> MutableFragment {
-        return MutableFragment(dictFragmentImpl[key])
+        return MutableFragment((dictImpl as CBLMutableDictionaryFragment)[key])
     }
     
     // MARK: Internal
@@ -279,10 +279,6 @@ public final class MutableDictionaryObject: DictionaryObject, MutableDictionaryP
     
     private var dictImpl: CBLMutableDictionary {
         return _impl as! CBLMutableDictionary
-    }
-    
-    private var dictFragmentImpl: CBLMutableDictionaryFragment {
-        return _impl as! CBLMutableDictionaryFragment
     }
     
 }

--- a/Swift/MutableDictionaryObject.swift
+++ b/Swift/MutableDictionaryObject.swift
@@ -266,7 +266,7 @@ public final class MutableDictionaryObject: DictionaryObject, MutableDictionaryP
     /// - Parameter key: The key.
     /// - Returns: The Fragment object.
     public override subscript(key: String) -> MutableFragment {
-        return MutableFragment(dictImpl[key])
+        return MutableFragment(dictFragmentImpl[key])
     }
     
     // MARK: Internal
@@ -279,6 +279,10 @@ public final class MutableDictionaryObject: DictionaryObject, MutableDictionaryP
     
     private var dictImpl: CBLMutableDictionary {
         return _impl as! CBLMutableDictionary
+    }
+    
+    private var dictFragmentImpl: CBLMutableDictionaryFragment {
+        return _impl as! CBLMutableDictionaryFragment
     }
     
 }

--- a/Swift/MutableDocument.swift
+++ b/Swift/MutableDocument.swift
@@ -256,7 +256,7 @@ public final class MutableDocument : Document, MutableDictionaryProtocol {
     ///
     /// - Parameter key: The key.
     public override subscript(key: String) -> MutableFragment {
-        return MutableFragment(docImpl[key])
+        return MutableFragment((docImpl as CBLMutableDictionaryFragment)[key])
     }
     
     // MARK: Internal

--- a/Swift/MutableFragment.swift
+++ b/Swift/MutableFragment.swift
@@ -194,14 +194,14 @@ public final class MutableFragment: Fragment, MutableDictionaryFragment, Mutable
     ///
     /// - Parameter index: The index.
     public override subscript(index: Int) -> MutableFragment {
-        return MutableFragment(fragmentImpl[UInt(index)])
+        return MutableFragment((fragmentImpl as CBLMutableArrayFragment)[UInt(index)])
     }
     
     /// Subscript access to a MutableFragment object by key.
     ///
     /// - Parameter key: The key.
     public override subscript(key: String) -> MutableFragment {
-        return MutableFragment(fragmentImpl[key])
+        return MutableFragment((fragmentImpl as CBLMutableDictionaryFragment)[key])
     }
     
     // MARK: Internal

--- a/Swift/Result.swift
+++ b/Swift/Result.swift
@@ -163,7 +163,7 @@ public final class Result : ArrayProtocol, DictionaryProtocol, Sequence {
     ///
     /// - Parameter index: The select result index.
     public subscript(index: Int) -> Fragment {
-        return Fragment(impl[UInt(index)])
+        return Fragment((impl as CBLArrayFragment)[UInt(index)])
     }
     
     // MARK: ReadOnlyDictionaryProtocol
@@ -316,7 +316,7 @@ public final class Result : ArrayProtocol, DictionaryProtocol, Sequence {
     ///
     /// - Parameter key: The select result key.
     public subscript(key: String) -> Fragment {
-        return Fragment(impl[key])
+        return Fragment((impl as CBLDictionaryFragment)[key])
     }
     
     // MARK: Internal


### PR DESCRIPTION
* Cast to the Objective-C Protocol type that defines the subscript method.
* The fix is harmless and works with XCode 11.7.