### PR TITLE
test: race condition clenaup 

### DIFF
--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -366,16 +366,24 @@ typedef CBLURLEndpointListener Listener;
     
     [self generateDocumentWithID: @"doc-1"];
     
+    XCTestExpectation* x = [self expectationWithDescription: @"Replicator Stopped"];
     id rConfig = [self configWithTarget: _listener.localEndpoint type: kCBLReplicatorTypePush continuous: NO];
+    CBLReplicator* replicator = [[CBLReplicator alloc] initWithConfig: rConfig];
+    
     __block Listener* weakListener = _listener;
     __block uint64_t maxConnectionCount = 0, maxActiveCount = 0;
-    [self run: rConfig reset: NO errorCode: 0 errorDomain: nil onReplicatorReady:^(CBLReplicator * r) {
+    id token = [replicator addChangeListener: ^(CBLReplicatorChange* change) {
         Listener* strongListener = weakListener;
-        [r addChangeListener:^(CBLReplicatorChange * change) {
-            maxConnectionCount = MAX(strongListener.status.connectionCount, maxConnectionCount);
-            maxActiveCount = MAX(strongListener.status.activeConnectionCount, maxActiveCount);
-        }];
+        maxConnectionCount = MAX(strongListener.status.connectionCount, maxConnectionCount);
+        maxActiveCount = MAX(strongListener.status.activeConnectionCount, maxActiveCount);
+        if (change.status.activity == kCBLReplicatorStopped)
+            [x fulfill];
     }];
+    
+    [replicator start];
+    [self waitForExpectations: @[x] timeout: timeout];
+    [replicator removeChangeListenerWithToken: token];
+    
     AssertEqual(maxActiveCount, 1);
     AssertEqual(maxConnectionCount, 1);
     AssertEqual(self.otherDB.count, 1);
@@ -384,8 +392,6 @@ typedef CBLURLEndpointListener Listener;
     [self stopListener: _listener];
     AssertEqual(_listener.status.connectionCount, 0);
     AssertEqual(_listener.status.activeConnectionCount, 0);
-    repl = nil;
-    _listener = nil;
 }
 
 - (void) testTLSIdentity {

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -384,6 +384,8 @@ typedef CBLURLEndpointListener Listener;
     [self stopListener: _listener];
     AssertEqual(_listener.status.connectionCount, 0);
     AssertEqual(_listener.status.activeConnectionCount, 0);
+    repl = nil;
+    _listener = nil;
 }
 
 - (void) testTLSIdentity {


### PR DESCRIPTION
Cleaning up the replicator and listener at the end of test