### PR TITLE
Fix Swift Warnings

### DIFF
--- a/Swift/ArrayObject.swift
+++ b/Swift/ArrayObject.swift
@@ -244,8 +244,8 @@ public class ArrayObject: ArrayProtocol, Equatable, Hashable, Sequence {
     
     // MARK: Hashable
     
-    public var hashValue: Int {
-        return _impl.hash;
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_impl.hash)
     }
     
     // MARK: Internal

--- a/Swift/Blob.swift
+++ b/Swift/Blob.swift
@@ -96,8 +96,8 @@ public final class Blob: Equatable, Hashable {
     
     // MARK: Hashable
     
-    public var hashValue: Int {
-        return _impl.hash;
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_impl.hash)
     }
     
     // MARK: Internal

--- a/Swift/DictionaryObject.swift
+++ b/Swift/DictionaryObject.swift
@@ -265,8 +265,8 @@ public class DictionaryObject: DictionaryProtocol, Equatable, Hashable, Sequence
     
     // MARK: Hashable
     
-    public var hashValue: Int {
-        return _impl.hash;
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_impl.hash)
     }
     
     // MARK: Internal

--- a/Swift/Document.swift
+++ b/Swift/Document.swift
@@ -240,8 +240,8 @@ public class Document : DictionaryProtocol, Equatable, Hashable, Sequence {
     
     // MARK: Hashable
     
-    public var hashValue: Int {
-        return _impl.hash;
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_impl.hash)
     }
     
     // MARK: Internal

--- a/Swift/Tests/ArrayTest.swift
+++ b/Swift/Tests/ArrayTest.swift
@@ -227,7 +227,6 @@ class ArrayTest: CBLTestCase {
                        MutableArrayObject(data: data[6] as! [String]))
         let b = obj.blob(at: 10)
         XCTAssertEqual(b?.content, (data[7] as! Blob).content)
-        XCTAssert(obj.value(at: 11) as! NSNull == (data[8] as? NSNull))
+        XCTAssert(obj.value(at: 11) as! NSNull == (data[8] as! NSNull))
     }
 }
-

--- a/Swift/Tests/MessageEndpointTest.swift
+++ b/Swift/Tests/MessageEndpointTest.swift
@@ -220,17 +220,19 @@ MultipeerConnectionDelegate {
     
     func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
         switch state {
-        case .connecting:
-            print("*** Connecting: \(peerID.displayName)")
-        case .connected:
-            print("*** Connected: \(peerID.displayName)")
-            if session === serverSession {
-                serverConnected!.fulfill()
-            } else {
-                clientConnected!.fulfill()
-            }
-        case .notConnected:
-            print("*** Not Connected: \(peerID.displayName)")
+            case .connecting:
+                print("*** Connecting: \(peerID.displayName)")
+            case .connected:
+                print("*** Connected: \(peerID.displayName)")
+                if session === serverSession {
+                    serverConnected!.fulfill()
+                } else {
+                    clientConnected!.fulfill()
+                }
+            case .notConnected:
+                print("*** Not Connected: \(peerID.displayName)")
+            default:
+                print("*** Unhandled State: \(state)")
         }
     }
     


### PR DESCRIPTION
* Fixed warning about hashValue deprecated
* Fixed warning about casting
* Fixed warning about default switch case