### PR TITLE
CBL-1290: fix: keychain access denied for Swift_EE target

### DIFF
--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -182,12 +182,16 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 
 - (void) setUp {
     [super setUp];
+    if (!self.keyChainAccessAllowed) return;
+    
     Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: nil]);
     Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: nil]);
 }
 
 - (void) tearDown {
     [super tearDown];
+    if (!self.keyChainAccessAllowed) return;
+    
     Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: nil]);
     Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: nil]);
 }

--- a/Scripts/generate_release_zip.sh
+++ b/Scripts/generate_release_zip.sh
@@ -152,7 +152,7 @@ then
   xcodebuild test -project CouchbaseLite.xcodeproj -scheme "${SCHEME_PREFIX}_Swift" -configuration "$CONFIGURATION_TEST" -sdk macosx
 
   echo "Run Swift iOS tests ..."
-  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "${SCHEME_PREFIX}_Swift" -configuration "$CONFIGURATION_TEST" -sdk iphonesimulator -destination "$TEST_SIMULATOR" -enableCodeCoverage YES
+  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "${SCHEME_PREFIX}_Swift_Tests_iOS_App" -configuration "$CONFIGURATION_TEST" -sdk iphonesimulator -destination "$TEST_SIMULATOR" -enableCodeCoverage YES
   
   # Generage Code Coverage Reports:
   if [ -z "$NO_COV" ]

--- a/Swift/Tests/TLSIdentityTest.swift
+++ b/Swift/Tests/TLSIdentityTest.swift
@@ -138,12 +138,16 @@ class TLSIdentityTest: CBLTestCase {
     
     override func setUp() {
         super.setUp()
+        if (!keyChainAccessAllowed) { return }
+        
         try! TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
         try! TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
     }
     
     override func tearDown() {
         super.tearDown()
+        if (!keyChainAccessAllowed) { return }
+        
         try! TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
         try! TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
     }


### PR DESCRIPTION
* setup and teardown were accessing the keychain, which will return exception.
* fix the generate zip script, to use iOS_App target instead of the Swift target since keychain unit tests also consider for code coverage