### PR TITLE
fix: stack memory usage after release

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -493,6 +493,9 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     slice fromPath(path.fileSystemRepresentation);
     CBLStringBytes destinationName(name);
     C4DatabaseConfig2 c4Config = c4DatabaseConfig2(config ?: [CBLDatabaseConfiguration new]);
+    CBLStringBytes dir(config.directory);
+    c4config.parentDirectory = dir;
+    
     if (!(c4db_copyNamed(fromPath, destinationName, &c4Config, &err) || err.code==0 || convertError(err, outError))) {
         NSString* toPathStr = databasePath(name, dir);
         NSError* removeError;
@@ -772,6 +775,9 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     CBLLogInfo(Database, @"Opening %@ at path %@", self, path);
     
     C4DatabaseConfig2 c4config = c4DatabaseConfig2(_config);
+    CBLStringBytes dir(_config.directory);
+    c4config.parentDirectory = dir;
+    
     C4Error err;
     CBLStringBytes n(_name);
     _c4db = c4db_openNamed(n, &c4config, &err);
@@ -816,8 +822,6 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
     if (config.encryptionKey)
         c4config.encryptionKey = [CBLDatabase c4EncryptionKey: config.encryptionKey];
 #endif
-    CBLStringBytes dir(config.directory);
-    c4config.parentDirectory = dir;
     return c4config;
 }
 

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -493,8 +493,8 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     slice fromPath(path.fileSystemRepresentation);
     CBLStringBytes destinationName(name);
     C4DatabaseConfig2 c4Config = c4DatabaseConfig2(config ?: [CBLDatabaseConfiguration new]);
-    CBLStringBytes dir(config.directory);
-    c4config.parentDirectory = dir;
+    CBLStringBytes d(config.directory);
+    c4config.parentDirectory = d;
     
     if (!(c4db_copyNamed(fromPath, destinationName, &c4Config, &err) || err.code==0 || convertError(err, outError))) {
         NSString* toPathStr = databasePath(name, dir);
@@ -775,8 +775,8 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     CBLLogInfo(Database, @"Opening %@ at path %@", self, path);
     
     C4DatabaseConfig2 c4config = c4DatabaseConfig2(_config);
-    CBLStringBytes dir(_config.directory);
-    c4config.parentDirectory = dir;
+    CBLStringBytes d(_config.directory);
+    c4config.parentDirectory = d;
     
     C4Error err;
     CBLStringBytes n(_name);

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -494,7 +494,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     CBLStringBytes destinationName(name);
     C4DatabaseConfig2 c4Config = c4DatabaseConfig2(config ?: [CBLDatabaseConfiguration new]);
     CBLStringBytes d(config.directory);
-    c4config.parentDirectory = d;
+    c4Config.parentDirectory = d;
     
     if (!(c4db_copyNamed(fromPath, destinationName, &c4Config, &err) || err.code==0 || convertError(err, outError))) {
         NSString* toPathStr = databasePath(name, dir);


### PR DESCRIPTION
* config directory setting inside the static was causing the already released directory string to be used when c4config is used second time

* more details of the error : CBL-1395