### PR TITLE
test: Add missing unit tests URLEndpointListener

### DIFF
--- a/Objective-C/Internal/Replicator/CBLTrustCheck.mm
+++ b/Objective-C/Internal/Replicator/CBLTrustCheck.mm
@@ -201,6 +201,7 @@ static BOOL sOnlyTrustAnchorCerts;
     if (!isSelfSigned) {
         MYReturnError(outError, NSURLErrorServerCertificateUntrusted, NSURLErrorDomain,
             @"Server SSL certificate is not self-signed");
+        CBLLogVerbose(WebSocket, @"Server SSL certificate is not self-signed, force trusting...");
     }
     
     [self forceTrusted];

--- a/Objective-C/Internal/Replicator/CBLTrustCheck.mm
+++ b/Objective-C/Internal/Replicator/CBLTrustCheck.mm
@@ -201,7 +201,7 @@ static BOOL sOnlyTrustAnchorCerts;
     if (!isSelfSigned) {
         MYReturnError(outError, NSURLErrorServerCertificateUntrusted, NSURLErrorDomain,
             @"Server SSL certificate is not self-signed");
-        CBLLogVerbose(WebSocket, @"Server SSL certificate is not self-signed, force trusting...");
+        return nil;
     }
     
     [self forceTrusted];

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1596,8 +1596,9 @@ typedef CBLURLEndpointListener Listener;
     AssertNil(error);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-1470
-- (void) _testTLSPinnedCertificateListenerAuthenticatorWithMatchingChainClientCredentials {
+// A listener with TLS enabled and a client authenticator pinning certificates
+// should accept a client that presents a cert chain whose root is pinned
+- (void) testTLSPinnedCertificateListenerAuthenticatorWithMatchingChainClientCredentials {
     if (!self.keyChainAccessAllowed) return;
     
     NSData* data = [self dataFromResource: @"identity/certs" ofType: @"p12"];
@@ -1622,6 +1623,7 @@ typedef CBLURLEndpointListener Listener;
     [self generateDocumentWithID: @"doc-1"];
     AssertEqual(self.otherDB.count, 0);
     
+    self.disableDefaultServerCertPinning = YES;
     [self runWithTarget: _listener.localEndpoint
                    type: kCBLReplicatorTypePushAndPull
              continuous: NO

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1489,7 +1489,6 @@ typedef CBLURLEndpointListener Listener;
             errorDomain: NSPOSIXErrorDomain];
 }
 
-// chained cert server + pin root cert instead of leaf cert
 - (void) testChainedCertServerAndCertPinning {
     if (!self.keyChainAccessAllowed) return;
     

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1629,7 +1629,6 @@ typedef CBLURLEndpointListener Listener;
              serverCert: nil
               errorCode: 0
             errorDomain: nil];
-    
 }
 
 #pragma mark - Close & Delete Replicators and Listeners

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1274,7 +1274,6 @@ typedef CBLURLEndpointListener Listener;
     SecCertificateRef serverCert = (__bridge SecCertificateRef) listener.tlsIdentity.certs[0];
     CBLReplicator* replicator = [self replicator: self.otherDB
                                        continous: YES
-                                 
                                           target: listener.localEndpoint
                                       serverCert: nil];
     [replicator addChangeListener: ^(CBLReplicatorChange *change) {

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1557,7 +1557,7 @@ typedef CBLURLEndpointListener Listener;
             errorDomain: NSPOSIXErrorDomain];
 }
 
-- (void) testTLSClientAuthenticatorWithChainedServerCredentials {
+- (void) testTLSPinnedCertClientAuthenticatorWithChainedServerCredentials {
     if (!self.keyChainAccessAllowed) return;
     
     NSData* data = [self dataFromResource: @"identity/certs" ofType: @"p12"];
@@ -1582,23 +1582,11 @@ typedef CBLURLEndpointListener Listener;
         [self listen: config];
     }];
     
-    // A client with `a pinned certificate`
-    // should refuse a server that presents certificate chain (even if the root is the pinned cert)
     [self runWithTarget: _listener.localEndpoint
                    type: kCBLReplicatorTypePushAndPull
              continuous: NO
           authenticator: nil
              serverCert: (__bridge SecCertificateRef) identity.certs[1]
-              errorCode: CBLErrorTLSCertUnknownRoot
-            errorDomain: CBLErrorDomain];
-    
-    // A client with a `acceptSelfSignedOnly` should refuse a server that presents certificate chain
-    [self runWithTarget: _listener.localEndpoint
-                   type: kCBLReplicatorTypePushAndPull
-             continuous: NO
-          authenticator: nil
-   acceptSelfSignedOnly: YES
-             serverCert: nil
               errorCode: CBLErrorTLSCertUnknownRoot
             errorDomain: CBLErrorDomain];
     

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -856,6 +856,8 @@ class URLEndpontListenerTest: ReplicatorTest {
         repl.addChangeListener { (change) in
             let activity = change.status.activity
             if activity == .stopped && change.status.error != nil {
+                // TODO: https://issues.couchbase.com/browse/CBL-1471
+                XCTAssertEqual((change.status.error! as NSError).code, CBLErrorTLSCertUnknownRoot)
                 x1.fulfill()
             }
         }

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -1091,10 +1091,11 @@ class URLEndpontListenerTest: ReplicatorTest {
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
     }
     
-    // TODO: https://issues.couchbase.com/browse/CBL-1470
-    func _testTLSPinnedCertificateListenerAuthenticatorWithMatchingChainClientCredentials() throws {
+    // A listener with TLS enabled and a client authenticator pinning certificates
+    // should accept a client that presents a cert chain whose root is pinned
+    func testTLSPinnedCertificateListenerAuthenticatorWithMatchingChainClientCredentials() throws {
         if !keyChainAccessAllowed { return }
-        
+            
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
         let data = try dataFromResource(name: "identity/certs", ofType: "p12")
         var identity: TLSIdentity!


### PR DESCRIPTION
* add missing unit tests for URLEndpointListener - ObjC & Swift
* fixes: CBL-1477