### PR TITLE
test: cleanup 

### DIFF
--- a/Swift/Tests/TLSIdentityTest.swift
+++ b/Swift/Tests/TLSIdentityTest.swift
@@ -19,7 +19,7 @@
 import XCTest
 import CouchbaseLiteSwift
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 class TLSIdentityTest: CBLTestCase {
     let serverCertLabel = "CBL-Swift-Server-Cert"
     let clientCertLabel = "CBL-Swift-Client-Cert"

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -1256,32 +1256,8 @@ class URLEndpontListenerTest: ReplicatorTest {
             serverCert: nil,
             expectedError: CBLErrorTLSCertUntrusted)
         
-        try stopListen()
+        try stopListener()
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
-    }
-    
-    func testAcceptOnlySelfSignedServerCertificate() throws {
-        if !self.keyChainAccessAllowed { return }
-        
-        // Listener:
-        let listener = try listen(tls: true)
-        XCTAssertNotNil(listener.tlsIdentity)
-        XCTAssertEqual(listener.tlsIdentity!.certs.count, 1)
-        
-        // Replicator - TLS Error:
-        self.ignoreException {
-            self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
-                     acceptSelfSignedOnly: false, serverCert: nil, expectedError: CBLErrorTLSCertUnknownRoot)
-        }
-        
-        // Replicator - Success:
-        self.ignoreException {
-            self.run(target: listener.localURLEndpoint, type: .pushAndPull, continuous: false,
-                     acceptSelfSignedOnly: true, serverCert: nil)
-        }
-        
-        // Cleanup
-        try stopListen()
     }
     
     func testAcceptOnlySelfSignedCertificateWithPinnedCertificate() throws {
@@ -1314,7 +1290,7 @@ class URLEndpontListenerTest: ReplicatorTest {
         }
         
         // Cleanup
-        try stopListen()
+        try stopListener()
         try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
     }
     

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -400,7 +400,7 @@ class URLEndpontListenerTest: ReplicatorTest {
         
         try stopListener(listener: listener)
         XCTAssertNil(listener.tlsIdentity)
-        try cleanupTLSIdentity(true) // cleanup the server tlsIdentity
+        try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
     }
     
     func testTLSListenerUserIdentity() throws {
@@ -1135,7 +1135,7 @@ class URLEndpontListenerTest: ReplicatorTest {
             expectedError: CBLErrorHTTPAuthRequired)
         
         // cleanup client cert authenticator identity
-        try cleanupTLSIdentity(false)
+        try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
         
         // Replicator - Success:
         run(target: self.listener!.localURLEndpoint,

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import CouchbaseLiteSwift
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 class URLEndpontListenerTest: ReplicatorTest {
     let wsPort: UInt16 = 4984
     let wssPort: UInt16 = 4985
@@ -164,15 +164,13 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func checkEqual(cert cert1: SecCertificate, andCert cert2: SecCertificate) {
-        if #available(iOS 11, *) {
-            var cn1: CFString?
-            XCTAssertEqual(SecCertificateCopyCommonName(cert1, &cn1), errSecSuccess)
-            
-            var cn2: CFString?
-            XCTAssertEqual(SecCertificateCopyCommonName(cert2, &cn2), errSecSuccess)
-            
-            XCTAssertEqual(cn1! as String, cn2! as String)
-        }
+        var cn1: CFString?
+        XCTAssertEqual(SecCertificateCopyCommonName(cert1, &cn1), errSecSuccess)
+        
+        var cn2: CFString?
+        XCTAssertEqual(SecCertificateCopyCommonName(cert2, &cn2), errSecSuccess)
+        
+        XCTAssertEqual(cn1! as String, cn2! as String)
     }
     
     func validateActiveReplicationsAndURLEndpointListener(isDeleteDBs: Bool) throws {
@@ -463,7 +461,6 @@ class URLEndpontListenerTest: ReplicatorTest {
         try stopListener()
     }
     
-    @available(macOS 10.12, iOS 10.3, *)
     func testClientCertAuthWithCallback() throws {
         if !self.keyChainAccessAllowed { return }
         
@@ -491,7 +488,6 @@ class URLEndpontListenerTest: ReplicatorTest {
         try stopListener()
     }
     
-    @available(macOS 10.12, iOS 10.3, *)
     func testClientCertAuthWithCallbackError() throws {
         if !self.keyChainAccessAllowed { return }
         
@@ -1067,7 +1063,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
 }
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.3, *)
 extension URLEndpointListener {
     var localURL: URL {
         assert(self.port != nil && self.port! > UInt16(0))


### PR DESCRIPTION
* remove unnecessary function and use the single line deleteIdentity. 
* remove stopListen and make stopListener with default empty param.
* keeps the 10.3 instead of 10.0 in the tests file, so we can skip the enclosed check. 