### PR TITLE
Cleanup database state variable

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -53,6 +53,13 @@ using namespace fleece;
 // How long to wait after a database opens before expiring docs
 #define kHousekeepingDelayAfterOpening 3.0
 
+// this variable defines the state of database
+typedef enum {
+    kCBLDatabaseStateClosed = 0,
+    kCBLDatabaseStateClosing,
+    kCBLDatabaseStateOpen,
+} CBLDatabaseState;
+
 @implementation CBLDatabase {
     NSString* _name;
     CBLDatabaseConfiguration* _config;
@@ -66,8 +73,9 @@ using namespace fleece;
     
     NSMutableSet<id<CBLStoppable>>* _activeStoppables;
     
-    BOOL _isClosing;
     NSCondition* _closeCondition;
+    
+    CBLDatabaseState _state;
 }
 
 @synthesize name=_name;
@@ -119,6 +127,8 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
         
         qName = $sprintf(@"Database-Query <%@>", name);
         _queryQueue = dispatch_queue_create(qName.UTF8String, DISPATCH_QUEUE_SERIAL);
+        
+        _state = kCBLDatabaseStateOpen;
     }
     return self;
 }
@@ -133,6 +143,8 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     if (self) {
         _shellMode = YES;
         _c4db = c4db;
+        
+        _state = kCBLDatabaseStateOpen;
     }
     return self;
 }
@@ -366,8 +378,8 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
         
         CBLLogInfo(Database, @"Closing %@ at path %@", self, self.path);
         
-        if (!_isClosing) {
-            _isClosing = YES;
+        if (_state != kCBLDatabaseStateClosing) {
+            _state = kCBLDatabaseStateClosing;
             
             if (!_closeCondition)
                 _closeCondition = [[NSCondition alloc] init];
@@ -407,9 +419,6 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
         // Release database:
         if (success)
             [self freeC4DB];
-        
-        // Reset closing flag:
-        _isClosing = NO;
         
         return success;
     }
@@ -671,6 +680,10 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
                     format: @"%@", kCBLErrorMessageDBClosed];
 }
 
+- (BOOL) mustBeOpen: (NSError**)outError {
+    return ![self isClosed] || convertError({LiteCoreDomain, kC4ErrorNotOpen}, outError);
+}
+
 - (void) mustBeOpenLocked {
     CBL_LOCK(self) {
         [self mustBeOpen];
@@ -679,14 +692,20 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 
 // Must be called inside self lock
 - (void) mustBeOpenAndNotClosing {
-    if ([self isClosed] || _isClosing)
+    if (_state < kCBLDatabaseStateOpen)
         [NSException raise: NSInternalInconsistencyException
                     format: @"%@", kCBLErrorMessageDBClosed];
 }
 
 // Must be called inside self lock
 - (BOOL) isClosed {
-    return _c4db == nullptr;
+    if (_state == kCBLDatabaseStateClosed) {
+        assert(_c4db == nullptr);
+        return YES;
+    } else {
+        assert(_c4db != nullptr);
+        return NO;
+    }
 }
 
 - (BOOL) isClosedLocked {
@@ -788,6 +807,8 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     
     [self scheduleDocumentExpiration: kHousekeepingDelayAfterOpening];
     
+    _state = kCBLDatabaseStateOpen;
+    
     return YES;
 }
 
@@ -823,10 +844,6 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
         c4config.encryptionKey = [CBLDatabase c4EncryptionKey: config.encryptionKey];
 #endif
     return c4config;
-}
-
-- (BOOL) mustBeOpen: (NSError**)outError {
-    return _c4db != nullptr || convertError({LiteCoreDomain, kC4ErrorNotOpen}, outError);
 }
 
 - (nullable CBLDocument*) documentWithID: (NSString*)documentID
@@ -952,6 +969,8 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
 - (void) freeC4DB {
     c4db_release(_c4db);
     _c4db = nil;
+    
+    _state = kCBLDatabaseStateClosed;
 }
 
 #pragma mark - DOCUMENT SAVE AND CONFLICT HANDLING

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -57,7 +57,7 @@ using namespace fleece;
 typedef enum {
     kCBLDatabaseStateClosed = 0,
     kCBLDatabaseStateClosing,
-    kCBLDatabaseStateOpen,
+    kCBLDatabaseStateOpened,
 } CBLDatabaseState;
 
 @implementation CBLDatabase {
@@ -128,7 +128,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
         qName = $sprintf(@"Database-Query <%@>", name);
         _queryQueue = dispatch_queue_create(qName.UTF8String, DISPATCH_QUEUE_SERIAL);
         
-        _state = kCBLDatabaseStateOpen;
+        _state = kCBLDatabaseStateOpened;
     }
     return self;
 }
@@ -144,7 +144,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
         _shellMode = YES;
         _c4db = c4db;
         
-        _state = kCBLDatabaseStateOpen;
+        _state = kCBLDatabaseStateOpened;
     }
     return self;
 }
@@ -692,7 +692,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 
 // Must be called inside self lock
 - (void) mustBeOpenAndNotClosing {
-    if (_state < kCBLDatabaseStateOpen)
+    if (_state < kCBLDatabaseStateOpened)
         [NSException raise: NSInternalInconsistencyException
                     format: @"%@", kCBLErrorMessageDBClosed];
 }
@@ -807,7 +807,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     
     [self scheduleDocumentExpiration: kHousekeepingDelayAfterOpening];
     
-    _state = kCBLDatabaseStateOpen;
+    _state = kCBLDatabaseStateOpened;
     
     return YES;
 }


### PR DESCRIPTION
* This is part of CBL-795, clean up of state variables. 
* But this PR only replaces the state bool variables to a state variable CBLDatabaseState(closed, open, closing)
* Since this changes has bigger impact, another PR will include LiveQuery state variable update. 