### PR TITLE
add arm64 arch with the macosx for M1

### DIFF
--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -34,9 +34,9 @@ SUPPORTED_PLATFORMS                = macosx iphoneos iphonesimulator appletvos a
 TARGETED_DEVICE_FAMILY             = 1,2
 
 VALID_ARCHS                        = x86_64 arm64 armv7 armv7s  i386
-VALID_ARCHS[sdk=macosx*]           = x86_64
-VALID_ARCHS[sdk=iphonesimulator*]  = x86_64                     i386
-VALID_ARCHS[sdk=appletvsimulator*] = x86_64                     i386
+VALID_ARCHS[sdk=macosx*]           = x86_64 arm64
+VALID_ARCHS[sdk=iphonesimulator*]  = x86_64 arm64               i386
+VALID_ARCHS[sdk=appletvsimulator*] = x86_64 arm64               i386
 VALID_ARCHS[sdk=iphoneos*]         =        arm64 armv7 armv7s
 VALID_ARCHS[sdk=appletvos*]        =        arm64
 


### PR DESCRIPTION
* make it consistent with LiteCore archs. https://github.com/couchbase/couchbase-lite-core/blob/master/Xcode/xcconfigs/Project.xcconfig#L34-L39
* binary not tested but the xcframework starts including arm64 with the macOS framework. 