### PR TITLE
test: fix race

### DIFF
--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -755,7 +755,7 @@
     
     NSMutableArray* order = [NSMutableArray array];
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
-        int count;
+        NSUInteger count;
         @synchronized (order) {
             [order addObject: con.localDocument.id];
             count = order.count;

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -755,10 +755,12 @@
     
     NSMutableArray* order = [NSMutableArray array];
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
+        int count;
         @synchronized (order) {
             [order addObject: con.localDocument.id];
+            count = order.count;
         }
-        if (order.count == 1) {
+        if (count == 1) {
             [NSThread sleepForTimeInterval: 0.5];
         }
         [order addObject: con.localDocument.id];

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -632,10 +632,16 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         let config = getConfig(.pull)
         var resolver: TestConflictResolver!
         var order = [String]()
+        let lock = NSLock()
         resolver = TestConflictResolver() { (conflict) -> Document? in
-            order.append(conflict.documentID)
             
-            if order.count == 1 {
+            // concurrent conflict resolver queue can cause race here
+            lock.lock()
+            order.append(conflict.documentID)
+            let count = order.count
+            lock.unlock()
+            
+            if count == 1 {
                 Thread.sleep(forTimeInterval: 0.5)
             }
             


### PR DESCRIPTION
* since the concurrent conflict queue is executing the blocks. 'order.count' can change in between which ?might skip the thread sleep