### PR TITLE
testing-only: disable .framework and only create xcframework

### DIFF
--- a/Scripts/generate_release_zip.sh
+++ b/Scripts/generate_release_zip.sh
@@ -67,8 +67,8 @@ then
   exit 4
 fi
 
-# As long as we support `.framework`, we will create .framework as well as .xcframework zips.
-COMBINED=YES
+# TODO: refactor for Lithium - only create xcframeworks binaries
+XCFRAMEWORK=YES
 
 if [ -z "$EE" ]
 then

--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -36,7 +36,7 @@ TARGETED_DEVICE_FAMILY             = 1,2
 VALID_ARCHS                        = x86_64 arm64 armv7 armv7s  i386
 VALID_ARCHS[sdk=macosx*]           = x86_64 arm64
 VALID_ARCHS[sdk=iphonesimulator*]  = x86_64 arm64               i386
-VALID_ARCHS[sdk=appletvsimulator*] = x86_64                     i386
+VALID_ARCHS[sdk=appletvsimulator*] = x86_64 arm64               i386
 VALID_ARCHS[sdk=iphoneos*]         =        arm64 armv7 armv7s
 VALID_ARCHS[sdk=appletvos*]        =        arm64
 


### PR DESCRIPTION
* this is temporary fix and only for testing purpose.
* will validate the xcframework from Apple M1 with this PR. 