### PR TITLE
.framework skip arm64 for simulator

### DIFF
--- a/Scripts/build_framework.sh
+++ b/Scripts/build_framework.sh
@@ -120,8 +120,15 @@ for SDK in "${SDKS[@]}"
         BUILD_VERSION="CBL_VERSION_STRING=${VERSION}"
       fi
     fi
+    
+    # override and only x86 and i386 architecture, for .framework
+    ARCH=""
+    if [[ "${SDK}" == "iphonesimulator" ]]
+    then
+      ARCH="-arch x86_64 -arch i386"
+    fi
 
-    xcodebuild -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -sdk ${SDK} ${BUILD_VERSION} ${BUILD_NUMBER} "ONLY_ACTIVE_ARCH=NO" "BITCODE_GENERATION_MODE=bitcode" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGN_IDENTITY=" ${ACTION} ${QUIET}
+    xcodebuild -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -sdk ${SDK} ${ARCH} ${BUILD_VERSION} ${BUILD_NUMBER} "ONLY_ACTIVE_ARCH=NO" "BITCODE_GENERATION_MODE=bitcode" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGN_IDENTITY=" ${ACTION} ${QUIET}
 
     # Get the XCode built framework and dsym file path:
     PRODUCTS_DIR=`xcodebuild -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -sdk "${SDK}" -showBuildSettings|grep -w BUILT_PRODUCTS_DIR|head -n 1|awk '{ print $3 }'`

--- a/Scripts/generate_release_zip.sh
+++ b/Scripts/generate_release_zip.sh
@@ -68,7 +68,7 @@ then
 fi
 
 # TODO: refactor for Lithium - only create xcframeworks binaries
-XCFRAMEWORK=YES
+COMBINED=YES
 
 if [ -z "$EE" ]
 then
@@ -301,4 +301,5 @@ rm -rf "$BUILD_DIR"
 rm -rf "$OUTPUT_OBJC_DIR"
 rm -rf "$OUTPUT_SWIFT_DIR"
 rm -rf "$OUTPUT_SWIFT_XC_DIR"
+rm -rf "$OUTPUT_OBJC_XC_DIR"
 rm -rf "$OUTPUT_DOCS_DIR"


### PR DESCRIPTION
* to avoid failure with .framework build, skip arm64 for simulator build.
* XCFramework alone build changed to building combined binary build.
* remove objc directory once the build is done.