### PR TITLE
Disable Version Vector by Default

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -84,7 +84,7 @@ typedef enum {
 @synthesize c4db=_c4db, sharedKeys=_sharedKeys;
 
 static const C4DatabaseConfig2 kDBConfig = {
-    .flags = (kC4DB_Create | kC4DB_AutoCompact | kC4DB_VersionVectors),
+    .flags = (kC4DB_Create | kC4DB_AutoCompact),
 };
 
 static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
@@ -839,6 +839,10 @@ static BOOL setupDatabaseDirectory(NSString *dir, NSError **outError)
 
 static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
     C4DatabaseConfig2 c4config = kDBConfig;
+    
+    if (config.enableVersionVector)
+        c4config.flags |= kC4DB_VersionVectors;
+    
 #ifdef COUCHBASE_ENTERPRISE
     if (config.encryptionKey)
         c4config.encryptionKey = [CBLDatabase c4EncryptionKey: config.encryptionKey];

--- a/Objective-C/CBLDatabaseConfiguration.h
+++ b/Objective-C/CBLDatabaseConfiguration.h
@@ -30,6 +30,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy) NSString* directory;
 
+/**
+ Experiment API. Enable version vector.
+ 
+ If the enableVersionVector is set to true, the database will use version vector instead of
+ using revision tree. When enabling version vector on an existing database, the database
+ will be upgraded to use the revision tree while the database is opened.
+ 
+ NOTE:
+ 1. The database that uses version vector cannot be downgraded back to use revision tree.
+ 2. The current version of Sync Gateway doesn't support version vector so the syncronization
+ with Sync Gateway will not be working.
+ */
+@property (nonatomic) BOOL enableVersionVector;
 
 /**
  Initializes the CBLDatabaseConfiguration object.

--- a/Objective-C/CBLDatabaseConfiguration.m
+++ b/Objective-C/CBLDatabaseConfiguration.m
@@ -24,7 +24,7 @@
     BOOL _readonly;
 }
 
-@synthesize directory=_directory;
+@synthesize directory=_directory, enableVersionVector=enableVersionVector;
 
 #ifdef COUCHBASE_ENTERPRISE
 @synthesize encryptionKey=_encryptionKey;

--- a/Swift/DatabaseConfiguration.swift
+++ b/Swift/DatabaseConfiguration.swift
@@ -30,6 +30,22 @@ public class DatabaseConfiguration {
         }
     }
     
+    ///  Experiment API. Enable version vector.
+    
+    /// If the enableVersionVector is set to true, the database will use version vector instead of
+    /// using revision tree. When enabling version vector on an existing database, the database
+    /// will be upgraded to use the revision tree while the database is opened.
+    ///
+    /// NOTE:
+    /// 1. The database that uses version vector cannot be downgraded back to use revision tree.
+    /// 2. The current version of Sync Gateway doesn't support version vector so the syncronization
+    /// with Sync Gateway will not be working.
+    public var enableVersionVector: Bool = false {
+        willSet(newValue) {
+            checkReadOnly()
+        }
+    }
+    
     #if COUCHBASE_ENTERPRISE
     /// The key to encrypt the database with.
     public var encryptionKey: EncryptionKey? {
@@ -56,6 +72,7 @@ public class DatabaseConfiguration {
     init(config: DatabaseConfiguration?, readonly: Bool) {
         if let c = config {
             self.directory = c.directory
+            self.enableVersionVector = c.enableVersionVector
             #if COUCHBASE_ENTERPRISE
             self.encryptionKey = c.encryptionKey
             #endif
@@ -72,6 +89,7 @@ public class DatabaseConfiguration {
     func toImpl() -> CBLDatabaseConfiguration {
         let config = CBLDatabaseConfiguration()
         config.directory = self.directory
+        config.enableVersionVector = self.enableVersionVector
         #if COUCHBASE_ENTERPRISE
         config.encryptionKey = self.encryptionKey?.impl
         #endif


### PR DESCRIPTION
* Until SG supports version vector, disable version vector by default until ready.
* Add enableVersionVector flag to DatabaseConfiguration for enabling version vector. The enableVersionVector is temporary until we enable version vector from CBL to SGW.