### PR TITLE
CBL-1455: Fix flaky test

### DIFF
--- a/Objective-C/CBLErrors.h
+++ b/Objective-C/CBLErrors.h
@@ -24,36 +24,36 @@
 extern NSErrorDomain const CBLErrorDomain;
 
 NS_ERROR_ENUM(CBLErrorDomain) {
-    CBLErrorAssertionFailed = 1,    // Internal assertion failure
-    CBLErrorUnimplemented,          // Oops, an unimplemented API call
-    CBLErrorUnsupportedEncryption,  // Unsupported encryption algorithm
-    CBLErrorBadRevisionID,          // Invalid revision ID syntax
-    CBLErrorCorruptRevisionData,    // Document contains corrupted/unreadable data
-    CBLErrorNotOpen,                // Database/KeyStore/index is not open
-    CBLErrorNotFound,               // Document not found
-    CBLErrorConflict,               // Document update conflict
-    CBLErrorInvalidParameter,       // Invalid function parameter or struct value
-    CBLErrorUnexpectedError,        // Internal unexpected C++ exception
-    CBLErrorCantOpenFile,           // Database file can't be opened; may not exist
-    CBLErrorIOError,                // File I/O error
-    CBLErrorMemoryError,            // Memory allocation failed (out of memory?)
-    CBLErrorNotWriteable,           // File is not writeable
-    CBLErrorCorruptData,            // Data is corrupted
-    CBLErrorBusy,                   // Database is busy/locked
-    CBLErrorNotInTransaction,       // Function must be called while in a transaction
-    CBLErrorTransactionNotClosed,   // Database can't be closed while a transaction is open
-    CBLErrorUnsupported,            // Operation not supported in this database
-    CBLErrorUnreadableDatabase,     // File is not a database, or encryption key is wrong
-    CBLErrorWrongFormat,            // Database exists but not in the format/storage requested
-    CBLErrorCrypto,                 // Encryption/decryption error
-    CBLErrorInvalidQuery,           // Invalid query
-    CBLErrorMissingIndex,           // No such index, or query requires a nonexistent index
-    CBLErrorInvalidQueryParam,      // Unknown query param name, or param number out of range
-    CBLErrorRemoteError,            // Unknown error from remote server
-    CBLErrorDatabaseTooOld,         // Database file format is older than what I can open
-    CBLErrorDatabaseTooNew,         // Database file format is newer than what I can open
-    CBLErrorBadDocID,               // Invalid document ID
-    CBLErrorCantUpgradeDatabase,    // Database can't be upgraded (might be unsupported dev version)
+    CBLErrorAssertionFailed = 1,        // Internal assertion failure
+    CBLErrorUnimplemented,              // Oops, an unimplemented API call
+    CBLErrorUnsupportedEncryption,      // Unsupported encryption algorithm
+    CBLErrorBadRevisionID,              // Invalid revision ID syntax
+    CBLErrorCorruptRevisionData,        // Document contains corrupted/unreadable data
+    CBLErrorNotOpen,                    // Database/KeyStore/index is not open
+    CBLErrorNotFound,                   // Document not found
+    CBLErrorConflict,                   // Document update conflict
+    CBLErrorInvalidParameter,           // Invalid function parameter or struct value
+    CBLErrorUnexpectedError = 10,       // Internal unexpected C++ exception
+    CBLErrorCantOpenFile,               // Database file can't be opened; may not exist
+    CBLErrorIOError,                    // File I/O error
+    CBLErrorMemoryError,                // Memory allocation failed (out of memory?)
+    CBLErrorNotWriteable,               // File is not writeable
+    CBLErrorCorruptData,                // Data is corrupted
+    CBLErrorBusy,                       // Database is busy/locked
+    CBLErrorNotInTransaction,           // Function must be called while in a transaction
+    CBLErrorTransactionNotClosed,       // Database can't be closed while a transaction is open
+    CBLErrorUnsupported,                // Operation not supported in this database
+    CBLErrorUnreadableDatabase = 20,    // File is not a database, or encryption key is wrong
+    CBLErrorWrongFormat,                // Database exists but not in the format/storage requested
+    CBLErrorCrypto,                     // Encryption/decryption error
+    CBLErrorInvalidQuery,               // Invalid query
+    CBLErrorMissingIndex,               // No such index, or query requires a nonexistent index
+    CBLErrorInvalidQueryParam,          // Unknown query param name, or param number out of range
+    CBLErrorRemoteError,                // Unknown error from remote server
+    CBLErrorDatabaseTooOld,             // Database file format is older than what I can open
+    CBLErrorDatabaseTooNew,             // Database file format is newer than what I can open
+    CBLErrorBadDocID,                   // Invalid document ID
+    CBLErrorCantUpgradeDatabase = 30,   // Database can't be upgraded (might be unsupported dev version)
     // Note: These are equivalent to the C4Error codes declared in LiteCore's c4Base.h
 
     CBLErrorNetworkBase                 = 5000,     // ---- Network error codes start here

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -23,7 +23,7 @@ import CouchbaseLiteSwift
 class ReplicatorTest: CBLTestCase {
     var oDB: Database!
     var repl: Replicator!
-    var timeout: TimeInterval = 10
+    var timeout: TimeInterval!
     
     // connect to an unknown-db on same machine, for the connection refused transient error.
     let kConnRefusedTarget: URLEndpoint = URLEndpoint(url: URL(string: "ws://localhost:4984/unknown-db-wXBl5n3fed")!)

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -23,7 +23,7 @@ import CouchbaseLiteSwift
 class ReplicatorTest: CBLTestCase {
     var oDB: Database!
     var repl: Replicator!
-    var timeout: TimeInterval = 10  // At least 10 to cover single-shot replicator's retry logic
+    var timeout: TimeInterval = 10
     
     // connect to an unknown-db on same machine, for the connection refused transient error.
     let kConnRefusedTarget: URLEndpoint = URLEndpoint(url: URL(string: "ws://localhost:4984/unknown-db-wXBl5n3fed")!)
@@ -32,6 +32,7 @@ class ReplicatorTest: CBLTestCase {
         super.setUp()
         try! openOtherDB()
         oDB = otherDB!
+        timeout = 10 // At least 10 to cover single-shot replicator's retry logic
     }
     
     override func tearDown() {

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1144,6 +1144,7 @@ class ReplicatorTest_Main: ReplicatorTest {
     }
     
     func testMaxRetryWaitTimeOfReplicator() {
+        timeout = 12
         let x = self.expectation(description: "repl finish")
         let config: ReplicatorConfiguration = self.config(target: kConnRefusedTarget,
                                                           type: .pushAndPull,

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1144,7 +1144,7 @@ class ReplicatorTest_Main: ReplicatorTest {
     }
     
     func testMaxRetryWaitTimeOfReplicator() {
-        timeout = 12
+        timeout = 12 // already it takes 8 secs of retry, hence 12secs timeout. 
         let x = self.expectation(description: "repl finish")
         let config: ReplicatorConfiguration = self.config(target: kConnRefusedTarget,
                                                           type: .pushAndPull,


### PR DESCRIPTION
* when both replicators ran concurrently and false expectation to finish in similar time.
* now its running separately, and test validation for replicator and listener on same database also done.