### PR TITLE
test: fix unit tests 

### DIFF
--- a/Objective-C/Internal/CBLFullTextMatchExpression.m
+++ b/Objective-C/Internal/CBLFullTextMatchExpression.m
@@ -36,7 +36,7 @@
 }
 
 - (id) asJSON {
-    return @[@"MATCH", _indexName, _query];
+    return @[@"MATCH()", _indexName, _query];
 }
 
 @end

--- a/Objective-C/Tests/ReplicatorTest.h
+++ b/Objective-C/Tests/ReplicatorTest.h
@@ -78,6 +78,13 @@ NS_ASSUME_NONNULL_BEGIN
                                    authenticator: (nullable CBLAuthenticator*)authenticator
                                       serverCert: (nullable SecCertificateRef)serverCert;
 
+- (CBLReplicatorConfiguration*) configWithTarget: (id<CBLEndpoint>)target
+                                            type: (CBLReplicatorType)type
+                                      continuous: (BOOL)continuous
+                                   authenticator: (nullable CBLAuthenticator*)authenticator
+                                      serverCert: (nullable SecCertificateRef)serverCert
+                                      maxRetries: (NSInteger)maxRetries;
+
 #ifdef COUCHBASE_ENTERPRISE
 - (CBLReplicatorConfiguration*) configWithTarget: (id<CBLEndpoint>)target
                                             type: (CBLReplicatorType)type
@@ -109,6 +116,15 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady;
             continuous: (BOOL)continuous
          authenticator: (nullable CBLAuthenticator*)authenticator
             serverCert: (nullable SecCertificateRef)serverCert
+             errorCode: (NSInteger)errorCode
+           errorDomain: (nullable NSString*)errorDomain;
+
+- (BOOL) runWithTarget: (id<CBLEndpoint>)target
+                  type: (CBLReplicatorType)type
+            continuous: (BOOL)continuous
+         authenticator: (nullable CBLAuthenticator*)authenticator
+            serverCert: (nullable SecCertificateRef)serverCert
+            maxRetries: (NSInteger)maxRetries
              errorCode: (NSInteger)errorCode
            errorDomain: (nullable NSString*)errorDomain;
 

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -238,11 +238,28 @@
                                       continuous: (BOOL)continuous
                                    authenticator: (nullable CBLAuthenticator*)authenticator
                                       serverCert: (nullable SecCertificateRef)serverCert {
+    return [self configWithTarget: target
+                             type: type
+                       continuous: continuous
+                    authenticator: authenticator
+                       serverCert: serverCert
+                       maxRetries: -1];
+}
+
+- (CBLReplicatorConfiguration*) configWithTarget: (id<CBLEndpoint>)target
+                                            type: (CBLReplicatorType)type
+                                      continuous: (BOOL)continuous
+                                   authenticator: (nullable CBLAuthenticator*)authenticator
+                                      serverCert: (nullable SecCertificateRef)serverCert
+                                      maxRetries: (NSInteger)maxRetries /* for default, set -1 */ {
     CBLReplicatorConfiguration* c = [[CBLReplicatorConfiguration alloc] initWithDatabase: self.db
                                                                                   target: target];
     c.replicatorType = type;
     c.continuous = continuous;
     c.authenticator = authenticator;
+    
+    if (maxRetries >= 0)
+        c.maxRetries = maxRetries;
     
     if ([$castIf(CBLURLEndpoint, target).url.scheme isEqualToString: @"wss"]) {
         if (serverCert)
@@ -320,11 +337,30 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady {
             serverCert: (nullable SecCertificateRef)serverCert
              errorCode: (NSInteger)errorCode
            errorDomain: (nullable NSString*)errorDomain {
+    return [self runWithTarget: target
+                          type: type
+                    continuous: continuous
+                 authenticator: authenticator
+                    serverCert: serverCert
+                    maxRetries: -1
+                     errorCode: errorCode
+                   errorDomain: errorDomain];
+}
+
+- (BOOL) runWithTarget: (id<CBLEndpoint>)target
+                  type: (CBLReplicatorType)type
+            continuous: (BOOL)continuous
+         authenticator: (nullable CBLAuthenticator*)authenticator
+            serverCert: (nullable SecCertificateRef)serverCert
+            maxRetries: (NSInteger)maxRetries // set to -1 for default maxRetry
+             errorCode: (NSInteger)errorCode
+           errorDomain: (nullable NSString*)errorDomain {
     id config = [self configWithTarget: target
                                   type: type
                             continuous: continuous
                          authenticator: authenticator
-                            serverCert: serverCert];
+                            serverCert: serverCert
+                            maxRetries: maxRetries];
     return [self run: config errorCode: errorCode errorDomain: errorDomain];
 }
 

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1445,7 +1445,6 @@ typedef CBLURLEndpointListener Listener;
     AssertNil(err);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-1664
 - (void) testStopListener {
     XCTestExpectation* x1 = [self expectationWithDescription: @"idle"];
     XCTestExpectation* x2 = [self expectationWithDescription: @"stopped"];

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -1446,7 +1446,7 @@ typedef CBLURLEndpointListener Listener;
 }
 
 // TODO: https://issues.couchbase.com/browse/CBL-1664
-- (void) _testStopListener {
+- (void) testStopListener {
     XCTestExpectation* x1 = [self expectationWithDescription: @"idle"];
     XCTestExpectation* x2 = [self expectationWithDescription: @"stopped"];
     
@@ -1486,6 +1486,7 @@ typedef CBLURLEndpointListener Listener;
              continuous: NO
           authenticator: nil
              serverCert: nil
+             maxRetries: 2 // to make fail(stop) early
               errorCode: ECONNREFUSED
             errorDomain: NSPOSIXErrorDomain];
 }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -42,12 +42,16 @@ class ReplicatorTest: CBLTestCase {
     }
     
     func config(target: Endpoint, type: ReplicatorType = .pushAndPull, continuous: Bool = false,
-                auth: Authenticator? = nil, serverCert: SecCertificate? = nil) -> ReplicatorConfiguration {
+                auth: Authenticator? = nil, serverCert: SecCertificate? = nil,
+                maxRetries: Int? = 9) -> ReplicatorConfiguration {
         let config = ReplicatorConfiguration(database: self.db, target: target)
         config.replicatorType = type
         config.continuous = continuous
         config.authenticator = auth
         config.pinnedServerCertificate = serverCert
+        if let maxRetries = maxRetries {
+            config.maxRetries = maxRetries
+        }
         return config
     }
 
@@ -55,9 +59,9 @@ class ReplicatorTest: CBLTestCase {
     func config(target: Endpoint, type: ReplicatorType = .pushAndPull,
                 continuous: Bool = false, auth: Authenticator? = nil,
                 acceptSelfSignedOnly: Bool = false,
-                serverCert: SecCertificate? = nil) -> ReplicatorConfiguration {
+                serverCert: SecCertificate? = nil, maxRetries: Int? = 9) -> ReplicatorConfiguration {
         let config = self.config(target: target, type: type, continuous: continuous,
-                                 auth: auth, serverCert: serverCert)
+                                 auth: auth, serverCert: serverCert, maxRetries: maxRetries)
         config.acceptOnlySelfSignedServerCertificate = acceptSelfSignedOnly
         return config
     }
@@ -92,9 +96,11 @@ class ReplicatorTest: CBLTestCase {
              continuous: Bool = false, auth: Authenticator? = nil,
              acceptSelfSignedOnly: Bool = false,
              serverCert: SecCertificate? = nil,
+             maxRetries: Int? = 9,
              expectedError: Int? = nil) {
         let config = self.config(target: target, type: type, continuous: continuous, auth: auth,
-                                 acceptSelfSignedOnly: acceptSelfSignedOnly, serverCert: serverCert)
+                                 acceptSelfSignedOnly: acceptSelfSignedOnly, serverCert: serverCert,
+                                 maxRetries: maxRetries)
         run(config: config, reset: false, expectedError: expectedError)
     }
     #endif
@@ -1027,7 +1033,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertEqual(config.maxRetries, 9)
         
         // continous
-        config = self.config(target: kConnRefusedTarget, type: .pushAndPull, continuous: true)
+        config = self.config(target: kConnRefusedTarget, type: .pushAndPull, continuous: true, maxRetries: nil)
         XCTAssertEqual(config.maxRetries, NSInteger.max)
     }
     

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -1060,7 +1060,7 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     // TODO: https://issues.couchbase.com/browse/CBL-1664
-    func _testStopListener() throws {
+    func testStopListener() throws {
         let x1 = expectation(description: "idle")
         let x2 = expectation(description: "stopped")
         
@@ -1097,7 +1097,7 @@ class URLEndpontListenerTest: ReplicatorTest {
         
         // Check to ensure that the replicator is not accessible:
         run(target: target, type: .pushAndPull, continuous: false, auth: nil, serverCert: nil,
-            expectedError: Int(ECONNREFUSED))
+            maxRetries: 2, expectedError: Int(ECONNREFUSED))
     }
     
     func testTLSPasswordListenerAuthenticator() throws {

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -1059,7 +1059,6 @@ class URLEndpontListenerTest: ReplicatorTest {
         XCTAssertNil(listener!.tlsIdentity)
     }
     
-    // TODO: https://issues.couchbase.com/browse/CBL-1664
     func testStopListener() throws {
         let x1 = expectation(description: "idle")
         let x2 = expectation(description: "stopped")


### PR DESCRIPTION
1. testStopListener test: CBL-1664
* Since the default retry count was 3 for single shot, it was stopping before 10secs, and now the max-retry count changed to 9, it was in offline state which resulted in the failure of the test. Now we will include the maxRetry with the unit test run-replicator function.
* enabled the test 

2. testWhereMatch: CBL-1839
* corrected the MATCH()