### PR TITLE
CBL-1879: Add unit tests to validate the Config API

### DIFF
--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -219,6 +219,8 @@ public struct ReplicatorConfiguration {
         self.heartbeat = config.heartbeat
         self.maxRetries = config.maxRetries
         self.maxRetryWaitTime = config.maxRetryWaitTime
+        self.pullFilter = config.pullFilter
+        self.pushFilter = config.pushFilter
         
         #if os(iOS)
         self.allowReplicatingInBackground = config.allowReplicatingInBackground

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -1347,34 +1347,58 @@ class DatabaseTest: CBLTestCase {
     
     #endif
     
+    // MARK: DatabaseConfig
+    
+    func testSetDatabaseConfigurationProperties() throws {
+        var config = DatabaseConfiguration()
+        config.directory = NSTemporaryDirectory().appending("/temp")
+        config.enableVersionVector = true
+        #if COUCHBASE_ENTERPRISE
+        config.encryptionKey = EncryptionKey.password("somePassword")
+        #endif
+        
+        let db = try Database(name: "dbName", config: config)
+        XCTAssertEqual(db.config.directory, NSTemporaryDirectory().appending("/temp"))
+        XCTAssert(db.config.enableVersionVector)
+        
+        #if COUCHBASE_ENTERPRISE
+        XCTAssertNotNil(db.config.encryptionKey)
+        #endif
+    }
+    
     func testDefaultDatabaseConfiguration() {
         let config = DatabaseConfiguration()
         XCTAssertEqual(config.directory, CBLDatabaseConfiguration().directory)
         XCTAssertEqual(config.enableVersionVector, false)
         
-#if COUCHBASE_ENTERPRISE
+        #if COUCHBASE_ENTERPRISE
         XCTAssertNil(config.encryptionKey)
-#endif
+        #endif
     }
     
     func testCopyingDatabaseConfiguration() throws {
         var config = DatabaseConfiguration()
         config.directory = self.directory
         config.enableVersionVector = true
-#if COUCHBASE_ENTERPRISE
+        #if COUCHBASE_ENTERPRISE
         config.encryptionKey  = EncryptionKey.password("somePassword")
-#endif
+        #endif
         db = try Database(name: "someName", config: config)
+        let copiedConfig = DatabaseConfiguration(config: config)
         
         config.directory = "\(self.directory)/updatedURL"
         config.enableVersionVector = false
-#if COUCHBASE_ENTERPRISE
+        #if COUCHBASE_ENTERPRISE
         config.encryptionKey = nil
-#endif
+        #endif
+        
         XCTAssertEqual(db.config.directory, self.directory)
+        XCTAssertEqual(copiedConfig.directory, self.directory)
         XCTAssert(db.config.enableVersionVector)
-#if COUCHBASE_ENTERPRISE
+        XCTAssert(copiedConfig.enableVersionVector)
+        #if COUCHBASE_ENTERPRISE
         XCTAssertNotNil(db.config.encryptionKey)
-#endif
+        XCTAssertNotNil(copiedConfig.encryptionKey)
+        #endif
     }
 }

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -1383,22 +1383,38 @@ class DatabaseTest: CBLTestCase {
         #if COUCHBASE_ENTERPRISE
         config.encryptionKey  = EncryptionKey.password("somePassword")
         #endif
-        db = try Database(name: "someName", config: config)
-        let copiedConfig = DatabaseConfiguration(config: config)
         
+        db = try Database(name: "someName", config: config)
+        let config1 = DatabaseConfiguration(config: config)
+        
+        // update the config, after passing to constructor;
         config.directory = "\(self.directory)/updatedURL"
         config.enableVersionVector = false
         #if COUCHBASE_ENTERPRISE
         config.encryptionKey = nil
         #endif
-        
+        // validate no impact on original passed in config.
         XCTAssertEqual(db.config.directory, self.directory)
-        XCTAssertEqual(copiedConfig.directory, self.directory)
+        XCTAssertEqual(config1.directory, self.directory)
         XCTAssert(db.config.enableVersionVector)
-        XCTAssert(copiedConfig.enableVersionVector)
+        XCTAssert(config1.enableVersionVector)
         #if COUCHBASE_ENTERPRISE
         XCTAssertNotNil(db.config.encryptionKey)
-        XCTAssertNotNil(copiedConfig.encryptionKey)
+        XCTAssertNotNil(config1.encryptionKey)
+        #endif
+        
+        // update the copied config.
+        var config2 = db.config
+        config2.directory = "\(self.directory)/updatedURL"
+        config2.enableVersionVector = false
+        #if COUCHBASE_ENTERPRISE
+        config2.encryptionKey = nil
+        #endif
+        // validate no impact on original passed in config.
+        XCTAssertEqual(db.config.directory, self.directory)
+        XCTAssert(db.config.enableVersionVector)
+        #if COUCHBASE_ENTERPRISE
+        XCTAssertNotNil(db.config.encryptionKey)
         #endif
     }
 }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1117,26 +1117,26 @@ class ReplicatorTest_Main: ReplicatorTest {
     
     // MARK: ReplicatorConfig
     
-    func testReplicationConfigCopying() throws {
+    func testCopyingReplicatorConfiguration() throws {
         let basic = BasicAuthenticator(username: "abcd", password: "1234")
         let target = URLEndpoint(url: URL(string: "ws://foo.couchbase.com/db")!)
-        var temp = ReplicatorConfiguration(database: oDB, target: target)
+        var config1 = ReplicatorConfiguration(database: oDB, target: target)
         #if COUCHBASE_ENTERPRISE
-        temp.acceptOnlySelfSignedServerCertificate = true
+        config1.acceptOnlySelfSignedServerCertificate = true
         #endif
-        temp.continuous = true
-        temp.authenticator = basic
-        temp.channels = ["c1", "c2"]
-        temp.documentIDs = ["d1", "d2"]
-        temp.headers = ["a": "aa", "b": "bb"]
-        temp.replicatorType = .pull
-        temp.heartbeat = 211
-        temp.maxRetries = 223
-        temp.maxRetryWaitTime = 227
+        config1.continuous = true
+        config1.authenticator = basic
+        config1.channels = ["c1", "c2"]
+        config1.documentIDs = ["d1", "d2"]
+        config1.headers = ["a": "aa", "b": "bb"]
+        config1.replicatorType = .pull
+        config1.heartbeat = 211
+        config1.maxRetries = 223
+        config1.maxRetryWaitTime = 227
         
         let certData = try dataFromResource(name: "SelfSigned", ofType: "cer")
         let cert = SecCertificateCreateWithData(kCFAllocatorDefault, certData as CFData)!
-        temp.pinnedServerCertificate = cert
+        config1.pinnedServerCertificate = cert
         
         let filter = { (doc: Document, flags: DocumentFlags) -> Bool in
             guard doc.boolean(forKey: "sync") else {
@@ -1145,28 +1145,28 @@ class ReplicatorTest_Main: ReplicatorTest {
             
             return !flags.contains(.deleted)
         }
-        temp.pullFilter = filter
-        temp.pushFilter = filter
+        config1.pullFilter = filter
+        config1.pushFilter = filter
         
         // copying
-        let config = ReplicatorConfiguration(config: temp)
+        let config = ReplicatorConfiguration(config: config1)
         
-        // update temp after passing to configuration’s constructor
+        // update config1 after passing to configuration’s constructor
         #if COUCHBASE_ENTERPRISE
-        temp.acceptOnlySelfSignedServerCertificate = false
+        config1.acceptOnlySelfSignedServerCertificate = false
         #endif
-        temp.continuous = false
-        temp.authenticator = nil
-        temp.channels = nil
-        temp.documentIDs = nil
-        temp.headers = nil
-        temp.replicatorType = .push
-        temp.heartbeat = 11
-        temp.maxRetries = 13
-        temp.maxRetryWaitTime = 17
-        temp.pinnedServerCertificate = nil
-        temp.pullFilter = nil
-        temp.pushFilter = nil
+        config1.continuous = false
+        config1.authenticator = nil
+        config1.channels = nil
+        config1.documentIDs = nil
+        config1.headers = nil
+        config1.replicatorType = .push
+        config1.heartbeat = 11
+        config1.maxRetries = 13
+        config1.maxRetryWaitTime = 17
+        config1.pinnedServerCertificate = nil
+        config1.pullFilter = nil
+        config1.pushFilter = nil
         
         #if COUCHBASE_ENTERPRISE
         XCTAssert(config.acceptOnlySelfSignedServerCertificate)
@@ -1220,7 +1220,8 @@ class ReplicatorTest_Main: ReplicatorTest {
         // set correctly on replicator
         repl = Replicator(config:  config)
         
-        // update after passed to the target's constructor
+        // -------------
+        // update config, after passed to the target's constructor
         #if COUCHBASE_ENTERPRISE
         config.acceptOnlySelfSignedServerCertificate = false
         #endif
@@ -1237,6 +1238,25 @@ class ReplicatorTest_Main: ReplicatorTest {
         config.pullFilter = nil
         config.pushFilter = nil
         
+        // update returned configuration.
+        var config2 = repl.config
+        #if COUCHBASE_ENTERPRISE
+        config2.acceptOnlySelfSignedServerCertificate = false
+        #endif
+        config2.continuous = false
+        config2.authenticator = nil
+        config2.channels = nil
+        config2.documentIDs = nil
+        config2.headers = nil
+        config2.replicatorType = .push
+        config2.heartbeat = 11
+        config2.maxRetries = 13
+        config2.maxRetryWaitTime = 17
+        config2.pinnedServerCertificate = nil
+        config2.pullFilter = nil
+        config2.pushFilter = nil
+        
+        // validate no impact on above updates.
         #if COUCHBASE_ENTERPRISE
         XCTAssert(repl.config.acceptOnlySelfSignedServerCertificate)
         #endif

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1121,7 +1121,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         let basic = BasicAuthenticator(username: "abcd", password: "1234")
         let target = URLEndpoint(url: URL(string: "ws://foo.couchbase.com/db")!)
         var temp = ReplicatorConfiguration(database: oDB, target: target)
+        #if COUCHBASE_ENTERPRISE
         temp.acceptOnlySelfSignedServerCertificate = true
+        #endif
         temp.continuous = true
         temp.authenticator = basic
         temp.channels = ["c1", "c2"]
@@ -1150,7 +1152,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         let config = ReplicatorConfiguration(config: temp)
         
         // update temp after passing to configuration’s constructor
+        #if COUCHBASE_ENTERPRISE
         temp.acceptOnlySelfSignedServerCertificate = false
+        #endif
         temp.continuous = false
         temp.authenticator = nil
         temp.channels = nil
@@ -1164,7 +1168,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         temp.pullFilter = nil
         temp.pushFilter = nil
         
+        #if COUCHBASE_ENTERPRISE
         XCTAssert(config.acceptOnlySelfSignedServerCertificate)
+        #endif
         XCTAssert(config.continuous)
         XCTAssertEqual((config.authenticator as! BasicAuthenticator).username, basic.username)
         XCTAssertEqual((config.authenticator as! BasicAuthenticator).password, basic.password)
@@ -1184,7 +1190,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         let basic = BasicAuthenticator(username: "abcd", password: "1234")
         let target = URLEndpoint(url: URL(string: "ws://foo.couchbase.com/db")!)
         var config = ReplicatorConfiguration(database: oDB, target: target)
+        #if COUCHBASE_ENTERPRISE
         config.acceptOnlySelfSignedServerCertificate = true
+        #endif
         config.continuous = true
         config.authenticator = basic
         config.channels = ["c1", "c2"]
@@ -1213,7 +1221,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         repl = Replicator(config:  config)
         
         // update after passed to the target's constructor
+        #if COUCHBASE_ENTERPRISE
         config.acceptOnlySelfSignedServerCertificate = false
+        #endif
         config.continuous = false
         config.authenticator = nil
         config.channels = nil
@@ -1227,7 +1237,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         config.pullFilter = nil
         config.pushFilter = nil
         
+        #if COUCHBASE_ENTERPRISE
         XCTAssert(repl.config.acceptOnlySelfSignedServerCertificate)
+        #endif
         XCTAssert(repl.config.continuous)
         XCTAssertEqual((repl.config.authenticator as! BasicAuthenticator).username, basic.username)
         XCTAssertEqual((repl.config.authenticator as! BasicAuthenticator).password, basic.password)
@@ -1247,7 +1259,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         let target = URLEndpoint(url: URL(string: "ws://foo.couchbase.com/db")!)
         let config = ReplicatorConfiguration(database: oDB, target: target)
         
+        #if COUCHBASE_ENTERPRISE
         XCTAssertFalse(config.acceptOnlySelfSignedServerCertificate)
+        #endif
         XCTAssertNil(config.authenticator)
         XCTAssertNil(config.channels)
         XCTAssertNil(config.conflictResolver)

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -1323,7 +1323,6 @@ class URLEndpontListenerTest: ReplicatorTest {
     
     func testSetListenerConfigurationProperties() throws {
         var config = URLEndpointListenerConfiguration(database: oDB)
-    
         let basic = ListenerPasswordAuthenticator { (uname, pswd) -> Bool in
             return uname == "username" && pswd == "secret"
         }
@@ -1333,15 +1332,14 @@ class URLEndpontListenerTest: ReplicatorTest {
         config.networkInterface = "awesomeinterface.com"
         config.port = 3121
         config.readOnly = true
-        
         if self.keyChainAccessAllowed {
             try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
             let tls = try tlsIdentity(true)
             config.tlsIdentity = tls
         }
-        
         let listener = URLEndpointListener(config: config)
         
+        // ----------
         // update config after passing to configuration’s constructor
         config.authenticator = nil
         config.disableTLS = false
@@ -1350,6 +1348,16 @@ class URLEndpontListenerTest: ReplicatorTest {
         config.port = 3123
         config.readOnly = false
         
+        // update the returned config from listener
+        var config2 = listener.config
+        config2.authenticator = nil
+        config2.disableTLS = false
+        config2.enableDeltaSync = false
+        config2.networkInterface = "0.0.0.0"
+        config2.port = 3123
+        config2.readOnly = false
+        
+        // validate no impact with above updates to configs
         XCTAssertNotNil(listener.config.authenticator)
         XCTAssert(listener.config.disableTLS)
         XCTAssert(listener.config.enableDeltaSync)
@@ -1378,33 +1386,33 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func testCopyingListenerConfiguration() throws {
-        var temp = URLEndpointListenerConfiguration(database: oDB)
+        var config1 = URLEndpointListenerConfiguration(database: oDB)
     
         let basic = ListenerPasswordAuthenticator { (uname, pswd) -> Bool in
             return uname == "username" && pswd == "secret"
         }
-        temp.authenticator = basic
-        temp.disableTLS = true
-        temp.enableDeltaSync = true
-        temp.networkInterface = "awesomeinterface.com"
-        temp.port = 3121
-        temp.readOnly = true
+        config1.authenticator = basic
+        config1.disableTLS = true
+        config1.enableDeltaSync = true
+        config1.networkInterface = "awesomeinterface.com"
+        config1.port = 3121
+        config1.readOnly = true
         
         if self.keyChainAccessAllowed {
             try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
             let tls = try tlsIdentity(true)
-            temp.tlsIdentity = tls
+            config1.tlsIdentity = tls
         }
+        let config = URLEndpointListenerConfiguration(config: config1)
         
-        let config = URLEndpointListenerConfiguration(config: temp)
-        
-        // update config after passing to configuration’s constructor
-        temp.authenticator = nil
-        temp.disableTLS = false
-        temp.enableDeltaSync = false
-        temp.networkInterface = "0.0.0.0"
-        temp.port = 3123
-        temp.readOnly = false
+        // ------
+        // update config1 after passing to configuration’s constructor
+        config1.authenticator = nil
+        config1.disableTLS = false
+        config1.enableDeltaSync = false
+        config1.networkInterface = "0.0.0.0"
+        config1.port = 3123
+        config1.readOnly = false
         
         XCTAssertNotNil(config.authenticator)
         XCTAssert(config.disableTLS)


### PR DESCRIPTION
## DatabaseConfiguration
1. Ensure that all of the properties will be initialized correctly when using the new Configuration API.
    - testSetDatabaseConfigurationProperties
2. Ensure that all non required properties are initialized with their default value correctly when they are not set.
    -  testDefaultDatabaseConfiguration
3. Ensure that the configuration object specified to the target object’s constructor is copied and subsequent changes to the original configuration object will not affect the target object’s configuration.
    -  testSetDatabaseConfigurationProperties
4. Ensure that the configuration object specified to the configuration’s constructor is copied and subsequent changes to the original configuration object will not affect the new configuration’s object.
    - testCopyingDatabaseConfiguration**

## ReplicatorConfiguration
1. Ensure that all of the properties will be initialized correctly when using the new Configuration API.
    - testReplicationConfigSetterMethods
2. Ensure that all non required properties are initialized with their default value correctly when they are not set.
    - testDefaultReplicatorConfiguration
3. Ensure that the configuration object specified to the target object’s constructor is copied and subsequent changes to the original configuration object will not affect the target object’s configuration.
    - testReplicationConfigSetterMethods
4. Ensure that the configuration object specified to the configuration’s constructor is copied and subsequent changes to the original configuration object will not affect the new configuration’s object.
    - testReplicationConfigCopying

## ListenerConfiguration
1. Ensure that all of the properties will be initialized correctly when using the new Configuration API.
    - testSetListenerConfigurationProperties
2. Ensure that all non required properties are initialized with their default value correctly when they are not set.
    - testDefaultListenerConfiguration
3. Ensure that the configuration object specified to the target object’s constructor is copied and subsequent changes to the original configuration object will not affect the target object’s configuration.
    - testSetListenerConfigurationProperties
4. Ensure that the configuration object specified to the configuration’s constructor is copied and subsequent changes to the original configuration object will not affect the new configuration’s object.
    - testCopyingListenerConfiguration