### PR TITLE
CBL-1972: Add enableAutoPurge property to replicatorConfig

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -233,6 +233,7 @@ typedef enum {
     }
     socketFactory.context = (__bridge void*)self;
 
+    // FIXME: Set-AutoPurge: https://issues.couchbase.com/browse/CBL-1976
     // Parameters:
     alloc_slice optionsFleece = self._encodedOptions;
     C4ReplicatorParameters params = {

--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -151,6 +151,17 @@ typedef BOOL (^CBLReplicationFilter) (CBLDocument* document, CBLDocumentFlags fl
  */
 @property (nonatomic) NSTimeInterval maxAttemptWaitTime;
 
+/**
+ To enable/disable the auto purge feature
+ 
+ The default value is true which means that the document will be automatically purged by the
+ pull replicator when the user loses access to the document from both removed and revoked scenarios.
+ 
+ When the property is set to false, the document will not be purged when the user
+ loses access to the document.
+ */
+@property (nonatomic) BOOL enableAutoPurge;
+
 /** Not available */
 - (instancetype) init NS_UNAVAILABLE;
 

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -43,6 +43,7 @@
 @synthesize checkpointInterval=_checkpointInterval, heartbeat=_heartbeat;
 @synthesize conflictResolver=_conflictResolver;
 @synthesize maxAttempts=_maxAttempts, maxAttemptWaitTime=_maxAttemptWaitTime;
+@synthesize enableAutoPurge=_enableAutoPurge;
 
 #ifdef COUCHBASE_ENTERPRISE
 @synthesize acceptOnlySelfSignedServerCertificate=_acceptOnlySelfSignedServerCertificate;
@@ -69,6 +70,7 @@
         _heartbeat = 0;
         _maxAttempts = 0;
         _maxAttemptWaitTime = 0;
+        _enableAutoPurge = YES;
     }
     return self;
 }
@@ -163,6 +165,11 @@
     _maxAttemptWaitTime = maxAttemptWaitTime;
 }
 
+- (void) setEnableAutoPurge: (BOOL)enableAutoPurge {
+    [self checkReadonly];
+    _enableAutoPurge = enableAutoPurge;
+}
+
 #pragma mark - Internal
 
 - (instancetype) initWithConfig: (CBLReplicatorConfiguration*)config
@@ -190,6 +197,7 @@
         _conflictResolver = config.conflictResolver;
         _maxAttempts = config.maxAttempts;
         _maxAttemptWaitTime = config.maxAttemptWaitTime;
+        _enableAutoPurge = config.enableAutoPurge;
 #if TARGET_OS_IPHONE
         _allowReplicatingInBackground = config.allowReplicatingInBackground;
 #endif

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -176,6 +176,15 @@ public struct ReplicatorConfiguration {
         }
     }
     
+    /// To enable/disable the auto purge feature
+    
+    /// The default value is true which means that the document will be automatically purged by the
+    /// pull replicator when the user loses access to the document from both removed and revoked scenarios.
+    
+    /// When the property is set to false, the document will not be purged when the user
+    /// loses access to the document.
+    public var enableAutoPurge: Bool = true
+    
     /// Initializes a ReplicatorConfiguration's builder with the given
     /// local database and the replication target.
     ///
@@ -207,6 +216,7 @@ public struct ReplicatorConfiguration {
         self.maxAttemptWaitTime = config.maxAttemptWaitTime
         self.pullFilter = config.pullFilter
         self.pushFilter = config.pushFilter
+        self.enableAutoPurge = config.enableAutoPurge
         
         #if os(iOS)
         self.allowReplicatingInBackground = config.allowReplicatingInBackground
@@ -234,6 +244,7 @@ public struct ReplicatorConfiguration {
         c.heartbeat = self.heartbeat
         c.maxAttempts = self.maxAttempts
         c.maxAttemptWaitTime = self.maxAttemptWaitTime
+        c.enableAutoPurge = self.enableAutoPurge
         
         if let resolver = self.conflictResolver {
             c.setConflictResolverUsing { (conflict) -> CBLDocument? in


### PR DESCRIPTION
* property value is not set to the lite core, property is added to the class.
* linked the Jira ticket to track the set to lite core task - CBL-1976