### PR TITLE
fix: issue with empty config and empty parent directory 

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -529,7 +529,7 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
     slice fromPath(path.fileSystemRepresentation);
     CBLStringBytes destinationName(name);
     C4DatabaseConfig2 c4Config = c4DatabaseConfig2(config ?: [CBLDatabaseConfiguration new]);
-    CBLStringBytes d(config.directory);
+    CBLStringBytes d(config != nil ? config.directory : CBLDatabaseConfiguration.defaultDirectory);
     c4Config.parentDirectory = d;
     
     if (!(c4db_copyNamed(fromPath, destinationName, &c4Config, &err) || err.code==0 || convertError(err, outError))) {


### PR DESCRIPTION
* when config is empty, parent directory is set to empty which will fail the assertion check for parent. 
* will check for empty config, if so will set the default directory, since the directory will be default. 