### PR TITLE
CBL-1888: FROM clause is mandatory

### DIFF
--- a/Objective-C/CBLQueryDataSource.m
+++ b/Objective-C/CBLQueryDataSource.m
@@ -32,7 +32,8 @@
 }
 
 - (id) asJSON {
-    return _alias ?  @{@"AS": _alias} : @{ };
+    NSString* columnName = [self columnName];
+    return columnName ? @{ @"AS" : columnName } : @{ };
 }
 
 - (nullable NSString*) columnName {

--- a/Objective-C/CBLQueryDataSource.m
+++ b/Objective-C/CBLQueryDataSource.m
@@ -33,7 +33,8 @@
 
 - (id) asJSON {
     NSString* columnName = [self columnName];
-    return columnName ? @{ @"AS" : columnName } : @{ };
+    assert(columnName);
+    return @{ @"AS" : columnName };
 }
 
 - (nullable NSString*) columnName {

--- a/Objective-C/Tests/QueryTest+Main.m
+++ b/Objective-C/Tests/QueryTest+Main.m
@@ -333,8 +333,7 @@
     AssertEqual(numRows, 2u);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-1888
-- (void) _testSelectAll {
+- (void) testSelectAll {
     [self loadNumbers: 100];
     
     CBLQueryExpression* NUMBER1 = [CBLQueryExpression property: @"number1"];

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1035,8 +1035,7 @@ class QueryTest: CBLTestCase {
         XCTAssertEqual(numRow, 0)
     }
     
-    // TODO: https://issues.couchbase.com/browse/CBL-1888
-    func _testSelectAll() throws {
+    func testSelectAll() throws {
         try loadNumbers(100)
         
         let NUMBER1 = Expression.property("number1")


### PR DESCRIPTION
* Litecore decided that the "FROM" clause would be required in the query. Hence manually, '*' transformed to default database-name. 
* CBL-1923, CBL-1888
* More details comments in the CBL-1888