### PR TITLE
CBL-1991: atan2(y,x) instead of atan2(x,y)

### DIFF
--- a/Objective-C/CBLQueryFunction.h
+++ b/Objective-C/CBLQueryFunction.h
@@ -113,11 +113,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (CBLQueryExpression*) atan: (CBLQueryExpression*)expression;
 
 /** 
- Creates an ATAN2(X, Y) function that returns the arctangent of y/x.
+ Creates an ATAN2(Y, X) function that returns the arctangent of y/x.
  
  @param x The expression to evaluate as the X coordinate.
  @param y The expression to evaluate as the Y coordinate.
- @return The ATAN2(X, Y) function.
+ @return The ATAN2(Y, X) function.
  */
 + (CBLQueryExpression*) atan2: (CBLQueryExpression*)x y: (CBLQueryExpression*)y;
 

--- a/Objective-C/Tests/QueryTest+Main.m
+++ b/Objective-C/Tests/QueryTest+Main.m
@@ -992,7 +992,7 @@
                            [CBLQueryFunction acos: p],
                            [CBLQueryFunction asin: p],
                            [CBLQueryFunction atan: p],
-                           [CBLQueryFunction atan2: p y: [CBLQueryExpression integer: 90]],
+                           [CBLQueryFunction atan2: [CBLQueryExpression integer: 90] y: p],
                            [CBLQueryFunction ceil: p],
                            [CBLQueryFunction cos: p],
                            [CBLQueryFunction degrees: p],

--- a/Swift/Function.swift
+++ b/Swift/Function.swift
@@ -107,12 +107,12 @@ public final class Function {
         return QueryExpression(CBLQueryFunction.atan(expression.toImpl()))
     }
     
-    /// Creates an ATAN2(X, Y) function that returns the arctangent of y/x.
+    /// Creates an ATAN2(Y, X) function that returns the arctangent of y/x.
     ///
     /// - Parameters:
     ///   - x: The expression to evaluate as the X coordinate.
     ///   - y: The expression to evaluate as the Y coordinate.
-    /// - Returns: The ATAN2(X, Y) function.
+    /// - Returns: The ATAN2(Y, X) function.
     public static func atan2(x: ExpressionProtocol, y: ExpressionProtocol) -> ExpressionProtocol {
         return QueryExpression(CBLQueryFunction.atan2(x.toImpl(), y: y.toImpl()))
     }

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -899,7 +899,7 @@ class QueryTest: CBLTestCase {
                          Function.acos(p),
                          Function.asin(p),
                          Function.atan(p),
-                         Function.atan2(x: p, y: Expression.int(90)),
+                         Function.atan2(x: Expression.int(90), y: p),
                          Function.ceil(p),
                          Function.cos(p),
                          Function.degrees(p),
@@ -927,7 +927,7 @@ class QueryTest: CBLTestCase {
                 .from(DataSource.database(db))
             let numRow = try verifyQuery(q, block: { (n, r) in
                 let expected = expectedValues[index]
-                XCTAssertEqual(r.double(at: 0), expected)
+                XCTAssertEqual(r.double(at: 0), expected, "Failure with \(f)")
             })
             XCTAssertEqual(numRow, 1)
             index = index + 1


### PR DESCRIPTION
* latest litecore changes with atan2 function, updated documentation and unit tests
* https://github.com/couchbase/couchbase-lite-core/commit/356453cb37ac91be227e0d827fe7c1e51af2a1a9