### PR TITLE
fix: issue with delete event set with wrong value second time

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -387,11 +387,9 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
 }
 
 - (void) setProgressLevel: (CBLReplicatorProgressLevel)level {
-    if (_repl) {
+    _progressLevel = level;
+    if (_repl)
         assert(c4repl_setProgressLevel(_repl, (C4ReplicatorProgressLevel)level, nullptr));
-    } else {
-        _progressLevel = level;
-    }
 }
 
 - (NSSet<NSString*>*) pendingDocumentIDs: (NSError**)error {


### PR DESCRIPTION
- Previously, we were saving the progress level to set in case replicator is stopped or not yet started. 
- But the same enum is causing the value to be reset to default when its set just after the start [here](https://github.com/couchbase/couchbase-lite-ios/blob/master/Objective-C/CBLReplicator.mm#L173)
- Now we are saving the progress level in both case and set second time, just after the start. Which will make the correct level to be set.  