### PR TITLE
fix: issue with n1ql query instance

### DIFF
--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -176,8 +176,12 @@ using namespace fleece;
 }
 
 - (NSString*) description {
-    NSString* desc = [[NSString alloc] initWithData: _json encoding: NSUTF8StringEncoding];
-    return [NSString stringWithFormat: @"%@[json=%@]", self.class, desc];
+    if (_language == kC4JSONQuery) {
+        NSString* desc = [[NSString alloc] initWithData: _json encoding: NSUTF8StringEncoding];
+        return [NSString stringWithFormat: @"%@[json=%@]", self.class, desc];
+    } else {
+        return [NSString stringWithFormat: @"%@[n1ql=%@]", self.class, _expressions];
+    }
 }
 
 #pragma mark - Parameters

--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -112,7 +112,7 @@ public class Query {
         })
         
         if tokens.count == 0 {
-            database!.addQuery(self)
+            database.addQuery(self)
         }
         
         let listenerToken = ListenerToken(token)
@@ -130,7 +130,7 @@ public class Query {
         tokens.remove(token)
         
         if tokens.count == 0 {
-            database!.removeQuery(self)
+            database.removeQuery(self)
         }
         lock.unlock()
     }
@@ -173,7 +173,7 @@ public class Query {
     
     var joinsImpl: [CBLQueryJoin]?
     
-    var database: Database?
+    var database: Database!
     
     var whereImpl: CBLQueryExpression?
     
@@ -204,7 +204,7 @@ public class Query {
         }
         
         precondition(fromImpl != nil, "From statement is required.")
-        assert(selectImpl != nil && database != nil)
+        assert(selectImpl != nil)
         if self.distinct {
             queryImpl = CBLQueryBuilder.selectDistinct(
                 selectImpl!,
@@ -237,7 +237,7 @@ public class Query {
     
     func stop() {
         lock.lock()
-        database!.removeQuery(self)
+        database.removeQuery(self)
         tokens.removeAllObjects()
         lock.unlock()
     }

--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -148,6 +148,7 @@ public class Query {
     ///   - json: JSON data encoding the query. This can be obtained from a Query object's
     //            JSONRepresentation property.
     init(database: Database, JSONRepresentation json: Data) {
+        self.database = database
         queryImpl = CBLQuery(database: database._impl, jsonRepresentation: json)
     }
     
@@ -156,6 +157,7 @@ public class Query {
     ///     - database  The database to query.
     ///     - expressions  String representing the query expression.
     init(database: Database, expressions: String) {
+        self.database = database
         queryImpl = CBLQuery(database: database._impl, expressions: expressions)
     }
 

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1286,18 +1286,26 @@ class QueryTest: CBLTestCase {
         }
     }
     
-    func testLiveQuery() throws {
-        try loadNumbers(100)
-        var count = 0;
+    func testJSONLiveQuery() throws {
         let q = QueryBuilder
             .select()
             .from(DataSource.database(db))
             .where(Expression.property("number1").lessThan(Expression.int(10)))
             .orderBy(Ordering.property("number1"))
-        
+        try testLiveQuery(query: q)
+    }
+    
+    func testN1QLLiveQuery() throws {
+        let q = db.createQuery(query: "SELECT * FROM testdb WHERE number1 < 10")
+        try testLiveQuery(query: q)
+    }
+    
+    func testLiveQuery(query: Query) throws {
+        try loadNumbers(100)
+        var count = 0;
         let x = expectation(description: "changes")
         
-        let token = q.addChangeListener { (change) in
+        let token = query.addChangeListener { (change) in
             count = count + 1
             XCTAssertNotNil(change.query)
             XCTAssertNil(change.error)
@@ -1316,7 +1324,7 @@ class QueryTest: CBLTestCase {
         
         waitForExpectations(timeout: 2.0) { (error) in }
         
-        q.removeChangeListener(withToken: token)
+        query.removeChangeListener(withToken: token)
     }
     
     func testLiveQueryNoUpdate() throws {


### PR DESCRIPTION
* query instance is not save with database.
* add a unit test with validating the n1ql query crash
* description updated with n1ql as well as json string