### PR TITLE
CBL-2168: Add flag for app extension safe APIs

### DIFF
--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -63,6 +63,9 @@ VERSIONING_SYSTEM                  = apple-generic
 
 SUPPORTS_MACCATALYST               = YES
 
+// background monitor feature will be disabled if its extension project.
+APPLICATION_EXTENSION_API_ONLY     = YES
+
 // Warn about using newer-than-deployment-target APIs without dynamic checks: (Xcode 9+)
 CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE
 


### PR DESCRIPTION
* background monitor methods will be skipped in case of extension
https://github.com/snej/MYUtilities/blob/master/MYBackgroundMonitor.m#L47
https://github.com/snej/MYUtilities/blob/master/MYBackgroundMonitor.m#L67
https://github.com/snej/MYUtilities/blob/master/MYBackgroundMonitor.m#L81
https://github.com/snej/MYUtilities/blob/master/MYBackgroundMonitor.m#L95

* even though we access the UIApplication sharedApplication, its dynamically getting it via performSelector call.
https://github.com/snej/MYUtilities/blob/master/MYBackgroundMonitor.m#L33
