### PR TITLE
Remove the unnecessary check

### DIFF
--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -318,9 +318,6 @@ using namespace fleece;
         for (unsigned i = 0; i < n; ++i) {
             slice title = c4query_columnTitle(_c4Query, i);
             NSString* titleString = slice2string(title);
-            if ([titleString hasPrefix: @"*"]) {
-                titleString = _from.columnName;
-            }
             cols[titleString] = @(i);
         }
         _columnNames = [cols copy];

--- a/Objective-C/Internal/CBLQuery+Internal.h
+++ b/Objective-C/Internal/CBLQuery+Internal.h
@@ -58,8 +58,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) NSString* alias;
 
-@property (nonatomic, readonly, nullable) NSString* columnName;
-
 - (instancetype) initWithDataSource: (id)source as: (nullable NSString*)alias;
 
 @end


### PR DESCRIPTION
Current lite-core will return the correct columnTitle, no need to hack in platform side.