### PR TITLE
Remove query label from Database.createQuery(query:)

### DIFF
--- a/Swift/Database+Query.swift
+++ b/Swift/Database+Query.swift
@@ -21,6 +21,15 @@ import Foundation
 
 extension Database {
     
+    /// Creates a Query object from the given query string.
+    ///
+    /// - Parameters:
+    ///     - query Query string
+    /// - Returns: A query created by the given query string.
+    public func createQuery(_ query: String) -> Query {
+        return Query(database: self, expressions: query)
+    }
+    
     /// All index names.
     public var indexes: Array<String> { return _impl.indexes }
     

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -409,15 +409,6 @@ public final class Database {
     /// Log object used for configuring console, file, and custom logger.
     public static let log = Log()
     
-    /// Creates a Query object from the given query string.
-    ///
-    /// - Parameters:
-    ///     - query Query expression
-    /// - Returns: Query created using the given expression string.
-    public func createQuery(query: String) -> Query {
-        return Query(database: self, expressions: query)
-    }
-    
     // MARK: Internal
     
     func addReplicator(_ replicator: Replicator) {

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -320,13 +320,11 @@ class QueryTest: CBLTestCase {
         XCTAssertEqual(numRows, 1)
         
         // N1QL Query
-        var q2 = db.createQuery(query:
-                                    "SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, 'woman')")
+        var q2 = db.createQuery("SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, 'woman')")
         numRows = try verifyQuery(q2) { (n, r) in }
         XCTAssertEqual(numRows, 1)
         
-        q2 = db.createQuery(query:
-                                    "SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, \"woman\")")
+        q2 = db.createQuery("SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, \"woman\")")
         numRows = try verifyQuery(q2) { (n, r) in }
         XCTAssertEqual(numRows, 1)
     }
@@ -1362,7 +1360,7 @@ class QueryTest: CBLTestCase {
     }
     
     func testN1QLLiveQuery() throws {
-        let q = db.createQuery(query: "SELECT * FROM testdb WHERE number1 < 10")
+        let q = db.createQuery("SELECT * FROM testdb WHERE number1 < 10")
         try testLiveQuery(query: q)
     }
     
@@ -1806,7 +1804,7 @@ class QueryTest: CBLTestCase {
         doc2.setValue("Ice Cream", forKey: "lastName")
         try self.db.saveDocument(doc2)
         
-        let q = self.db.createQuery(query: "SELECT firstName, lastName FROM \(self.db.name)")
+        let q = self.db.createQuery("SELECT firstName, lastName FROM \(self.db.name)")
         let results = try q.execute().allResults()
         XCTAssertEqual(results[0].string(forKey: "firstName"), "Jerry")
         XCTAssertEqual(results[0].string(forKey: "lastName"), "Ice Cream")
@@ -1825,7 +1823,7 @@ class QueryTest: CBLTestCase {
         doc2.setValue("Ice Cream", forKey: "lastName")
         try self.db.saveDocument(doc2)
         
-        let q = self.db.createQuery(query: "SELECT firstName, lastName FROM \(self.db.name) offset 1")
+        let q = self.db.createQuery("SELECT firstName, lastName FROM \(self.db.name) offset 1")
         let results = try q.execute().allResults()
         XCTAssertEqual(results.count, 1)
     }


### PR DESCRIPTION
* Remove query label from Database.createQuery(query:) which is redundant
* Moved createQuery() from Database.swift to Database+Query.swift

CBL-2452