### PR TITLE
disable/enable unit test

### DIFF
--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -1514,7 +1514,8 @@
 
 #ifdef COUCHBASE_ENTERPRISE
 
-- (void) testCloseWithActiveReplicators {
+// TODO: https://issues.couchbase.com/browse/CBL-2446
+- (void) _testCloseWithActiveReplicators {
     [self openOtherDB];
     
     CBLDatabaseEndpoint* target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
@@ -1546,7 +1547,8 @@
     Assert([self.db isClosedLocked]);
 }
 
-- (void) testCloseWithActiveLiveQueriesAndReplicators {
+// TODO: https://issues.couchbase.com/browse/CBL-2446
+- (void) _testCloseWithActiveLiveQueriesAndReplicators {
     // Live Queries:
     
     XCTestExpectation* change1 = [self expectationWithDescription: @"changes 1"];
@@ -1736,7 +1738,7 @@
 
 #ifdef COUCHBASE_ENTERPRISE
 
-// TODO: https://issues.couchbase.com/browse/CBL-2364
+// TODO: https://issues.couchbase.com/browse/CBL-2446
 - (void) _testDeleteWithActiveReplicators {
     [self openOtherDB];
     
@@ -1769,7 +1771,8 @@
     Assert([self.db isClosedLocked]);
 }
 
-- (void) testDeleteWithActiveLiveQueriesAndReplicators {
+// TODO: https://issues.couchbase.com/browse/CBL-2446
+- (void) _testDeleteWithActiveLiveQueriesAndReplicators {
     [self openOtherDB];
     
     XCTestExpectation* change1 = [self expectationWithDescription: @"changes 1"];

--- a/Objective-C/Tests/DocumentExpirationTest.m
+++ b/Objective-C/Tests/DocumentExpirationTest.m
@@ -357,8 +357,7 @@
     [self.db removeChangeListenerWithToken: token];
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-2392
-- (void) _testOverrideExpirationWithCloserDate {
+- (void) testOverrideExpirationWithCloserDate {
     XCTestExpectation* expectation = [self expectationWithDescription: @"Document expiry test"];
     
     // Create doc

--- a/Objective-C/Tests/QueryTest+Meta.m
+++ b/Objective-C/Tests/QueryTest+Meta.m
@@ -191,8 +191,7 @@
     AssertEqual([[rs allObjects] count], 0u);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-2392
-- (void) _testExpiryLessThanDate {
+- (void) testExpiryLessThanDate {
     NSError* error;
     CBLMutableDocument* doc = [[CBLMutableDocument alloc] init];
     NSString* docID = doc.id;
@@ -243,8 +242,8 @@
     AssertEqual([[rs allObjects] count], 0u);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-2392
-- (void) _testExpiryGreaterThanDate {
+- (void) testExpiryGreaterThanDate {
+    CBLDatabase.log.console.level = kCBLLogLevelDebug;
     NSError* error;
     CBLMutableDocument* doc = [[CBLMutableDocument alloc] init];
     NSString* docID = doc.id;

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -58,7 +58,11 @@ NS_ASSUME_NONNULL_END
 
 API_AVAILABLE(macos(10.12), ios(10.0))
 @interface URLEndpointListenerTest : ReplicatorTest
+
+API_AVAILABLE(macos(10.12), ios(10.0))
 typedef CBLURLEndpointListenerConfiguration Config;
+
+API_AVAILABLE(macos(10.12), ios(10.0))
 typedef CBLURLEndpointListener Listener;
 @end
 


### PR DESCRIPTION
* Due to CBL-2446, disabling the 4 unit tests. 
* CBL-2364, CBL-2392 are fixed so enabling those tests. 
* Fix for Xcode 13 typedef 