### PR TITLE
Change Database’s createQuery() to return error

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -59,10 +59,10 @@
 		1A3471632671C9230042C6BA /* CBLValueIndexConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A34715D2671C9230042C6BA /* CBLValueIndexConfiguration.m */; };
 		1A3471642671C9230042C6BA /* CBLValueIndexConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A34715D2671C9230042C6BA /* CBLValueIndexConfiguration.m */; };
 		1A3471652671C9230042C6BA /* CBLValueIndexConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A34715D2671C9230042C6BA /* CBLValueIndexConfiguration.m */; };
-		1A3471A626736E660042C6BA /* CBLQuery+N.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N.h */; };
-		1A3471B226736E670042C6BA /* CBLQuery+N.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1A3471B326736E680042C6BA /* CBLQuery+N.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N.h */; };
-		1A3471B426736E680042C6BA /* CBLQuery+N.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1A3471A626736E660042C6BA /* CBLQuery+N1QL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N1QL.h */; };
+		1A3471B226736E670042C6BA /* CBLQuery+N1QL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N1QL.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1A3471B326736E680042C6BA /* CBLQuery+N1QL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N1QL.h */; };
+		1A3471B426736E680042C6BA /* CBLQuery+N1QL.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A347189267256290042C6BA /* CBLQuery+N1QL.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A416030227D0AD40061A567 /* Conflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A41602A227D08580061A567 /* Conflict.swift */; };
 		1A416032227D0AD40061A567 /* ConflictResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A41602B227D08580061A567 /* ConflictResolver.swift */; };
 		1A416033227D0AD50061A567 /* Conflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A41602A227D08580061A567 /* Conflict.swift */; };
@@ -1879,7 +1879,7 @@
 		1A3471482671C87F0042C6BA /* CBLFullTextIndexConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLFullTextIndexConfiguration.m; sourceTree = "<group>"; };
 		1A34715C2671C9230042C6BA /* CBLValueIndexConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLValueIndexConfiguration.h; sourceTree = "<group>"; };
 		1A34715D2671C9230042C6BA /* CBLValueIndexConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLValueIndexConfiguration.m; sourceTree = "<group>"; };
-		1A347189267256290042C6BA /* CBLQuery+N.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLQuery+N.h"; sourceTree = "<group>"; };
+		1A347189267256290042C6BA /* CBLQuery+N1QL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLQuery+N1QL.h"; sourceTree = "<group>"; };
 		1A41602A227D08580061A567 /* Conflict.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Conflict.swift; sourceTree = "<group>"; };
 		1A41602B227D08580061A567 /* ConflictResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConflictResolver.swift; sourceTree = "<group>"; };
 		1A4160C52283673E0061A567 /* ReplicatorTest+CustomConflict.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ReplicatorTest+CustomConflict.m"; sourceTree = "<group>"; };
@@ -3561,7 +3561,7 @@
 				937F026E1EFC694900060D64 /* CBLQueryChange+Internal.h */,
 				933208291E774171000D9993 /* CBLQuery+Internal.h */,
 				933BFE1521A3BE960094530D /* CBLQuery+JSON.h */,
-				1A347189267256290042C6BA /* CBLQuery+N.h */,
+				1A347189267256290042C6BA /* CBLQuery+N1QL.h */,
 				93EC42E11FB387AB00D54BB4 /* CBLQueryJSONEncoding.h */,
 				938B3690200745FE004485D8 /* CBLQueryResultArray.h */,
 				938B36A3200745FE004485D8 /* CBLQueryResultArray.m */,
@@ -3918,7 +3918,7 @@
 				9383A5851F1EE7C00083053D /* CBLQueryResultSet.h in Headers */,
 				938196151EC1135F0032CC51 /* CBLDocumentFragment.h in Headers */,
 				93FD614A2020446300E7F6A1 /* CBLQueryBuilder.h in Headers */,
-				1A3471B226736E670042C6BA /* CBLQuery+N.h in Headers */,
+				1A3471B226736E670042C6BA /* CBLQuery+N1QL.h in Headers */,
 				938196141EC113590032CC51 /* CBLMutableArrayFragment.h in Headers */,
 				93E17F0E1ED3BA6E00671CA1 /* CBLDatabaseChange.h in Headers */,
 				9381961B1EC113810032CC51 /* CBLFragment.h in Headers */,
@@ -4130,7 +4130,7 @@
 				9343EFF9207D611600F19A89 /* CBLIndex.h in Headers */,
 				935A58D021AFAD31009A29CB /* CBLDocumentReplication+Internal.h in Headers */,
 				9343EFFB207D611600F19A89 /* CBLData.h in Headers */,
-				1A3471B326736E680042C6BA /* CBLQuery+N.h in Headers */,
+				1A3471B326736E680042C6BA /* CBLQuery+N1QL.h in Headers */,
 				9343EFFC207D611600F19A89 /* CBLValueExpression.h in Headers */,
 				9343EFFD207D611600F19A89 /* CBLParseDate.h in Headers */,
 				9343EFFE207D611600F19A89 /* CBLReplicatorChange+Internal.h in Headers */,
@@ -4219,7 +4219,7 @@
 				93EB264421DF1AE20006FB88 /* CBLDocumentFlags.h in Headers */,
 				9369A699207DB50F009B5B83 /* CBLDatabaseConfiguration+Encryption.h in Headers */,
 				932565BF21ED16BF0092F4E0 /* CBLLogFileConfiguration+Internal.h in Headers */,
-				1A3471B426736E680042C6BA /* CBLQuery+N.h in Headers */,
+				1A3471B426736E680042C6BA /* CBLQuery+N1QL.h in Headers */,
 				9343F0E1207D61AB00F19A89 /* CBLMutableArray.h in Headers */,
 				9369A69F207DBAA9009B5B83 /* CBLDatabase+Encryption.h in Headers */,
 				1A34714C2671C8800042C6BA /* CBLFullTextIndexConfiguration.h in Headers */,
@@ -4381,7 +4381,7 @@
 				939B1B5F2009C0F200FAA3CB /* CBLQueryVariableExpression+Internal.h in Headers */,
 				93B72063205CA6650069F5FC /* CBLException.h in Headers */,
 				93B41D641F0580E700A7F114 /* CBLQueryJoin.h in Headers */,
-				1A3471A626736E660042C6BA /* CBLQuery+N.h in Headers */,
+				1A3471A626736E660042C6BA /* CBLQuery+N1QL.h in Headers */,
 				9388CC3221C18671005CA66D /* CBLLog+Internal.h in Headers */,
 				93EC42EF1FB39DAD00D54BB4 /* CBLLiveQuery.h in Headers */,
 				93DBD0112004BCE00017CA83 /* CBLURLEndpoint.h in Headers */,

--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -478,9 +478,10 @@ typedef NS_ENUM(uint32_t, CBLMaintenanceType) {
  Creates a Query object from the given query string.
  
  @param query Query expression
+ @param error error On return, the given query string is invalid.
  @return query created using the given expression string.
  */
-- (CBLQuery*) createQuery: (NSString*)query;
+- (nullable CBLQuery*) createQuery: (NSString*)query error: (NSError**)error;
 
 @end
 

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -41,7 +41,7 @@
 #import "CBLData.h"
 #import "CBLIndexConfiguration+Internal.h"
 #import "CBLIndexSpec.h"
-#import "CBLQuery+N.h"
+#import "CBLQuery+N1QL.h"
 
 #ifdef COUCHBASE_ENTERPRISE
 #import "CBLDatabase+EncryptionInternal.h"
@@ -687,8 +687,8 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
 
 #pragma mark - Query
 
-- (CBLQuery*) createQuery: (NSString*)query {
-    return [[CBLQuery alloc] initWithDatabase: self expressions: query];
+- (nullable CBLQuery*) createQuery: (NSString*)query error: (NSError**)error {
+    return [[CBLQuery alloc] initWithDatabase: self expressions: query error: error];
 }
 
 #pragma mark - INTERNAL

--- a/Objective-C/Internal/CBLQuery+N1QL.h
+++ b/Objective-C/Internal/CBLQuery+N1QL.h
@@ -1,5 +1,5 @@
 //
-//  CBLQuery+N.h
+//  CBLQuery+N1QL.h
 //  CouchbaseLite
 //
 //  Copyright (c) 2021 Couchbase, Inc All rights reserved.
@@ -35,8 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param database  The database to query.
  @param expressions  String representing the query expression.
  */
-- (instancetype) initWithDatabase: (CBLDatabase*)database
-                      expressions: (NSString*)expressions NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype) initWithDatabase: (CBLDatabase*)database
+                               expressions: (NSString*)expressions
+                                     error: (NSError**)error NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Objective-C/Tests/QueryTest+Main.m
+++ b/Objective-C/Tests/QueryTest+Main.m
@@ -1848,16 +1848,25 @@
     [self validateN1QLQuery: $sprintf(@"SELECT firstName, lastName FROM %@", self.db.name)];
     [self validateN1QLQuery: @"SELECT firstName, lastName FROM _"];
     [self validateN1QLQuery: @"SELECT firstName, lastName FROM _default"];
-    
-    // FIXME: Should throw error!
-    // [self validateN1QLQuery: @"SELECT firstName, lastName"];
+}
+
+- (void) testInvalidN1QLQuery {
+    [self ignoreException: ^{
+        NSError* error;
+        CBLQuery* q = [self.db createQuery: @"SELECT firstName, lastName" error: &error];
+        AssertNil(q);
+        AssertEqual(error.domain, CBLErrorDomain);
+        AssertEqual(error.code, CBLErrorInvalidQuery);
+    }];
 }
 
 - (void) validateN1QLQuery: (NSString*)queryString {
-    CBLQuery* q = [self.db createQuery: queryString];
-    NSError* error = nil;
-    NSArray<CBLQueryResult*>* result = [q execute: &error].allResults;
+    NSError* error;
+    CBLQuery* q = [self.db createQuery: queryString error: &error];
+    AssertNotNil(q);
+    AssertNil(error);
     
+    NSArray<CBLQueryResult*>* result = [q execute: &error].allResults;
     AssertEqual(result.count, 2);
     AssertEqualObjects([result[0] stringForKey: @"firstName"], @"Jerry");
     AssertEqualObjects([result[0] stringForKey: @"lastName"], @"Ice Cream");

--- a/Swift/CouchbaseLiteSwift-EE.modulemap
+++ b/Swift/CouchbaseLiteSwift-EE.modulemap
@@ -64,7 +64,6 @@ framework module CouchbaseLiteSwift {
         header "CBLNewDictionary.h"
         header "CBLQuery.h"
         header "CBLQuery+JSON.h"
-        header "CBLQuery+N.h"
         header "CBLQueryArrayExpression.h"
         header "CBLQueryArrayFunction.h"
         header "CBLQueryBuilder.h"

--- a/Swift/CouchbaseLiteSwift.modulemap
+++ b/Swift/CouchbaseLiteSwift.modulemap
@@ -64,7 +64,6 @@ framework module CouchbaseLiteSwift {
         header "CBLNewDictionary.h"
         header "CBLQuery.h"
         header "CBLQuery+JSON.h"
-        header "CBLQuery+N.h"
         header "CBLQueryArrayExpression.h"
         header "CBLQueryArrayFunction.h"
         header "CBLQueryBuilder.h"

--- a/Swift/Database+Query.swift
+++ b/Swift/Database+Query.swift
@@ -26,8 +26,9 @@ extension Database {
     /// - Parameters:
     ///     - query Query string
     /// - Returns: A query created by the given query string.
-    public func createQuery(_ query: String) -> Query {
-        return Query(database: self, expressions: query)
+    /// - Throws: An error on when the given query string is invalid.
+    public func createQuery(_ query: String) throws -> Query {
+        return try Query(database: self, expressions: query)
     }
     
     /// All index names.

--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -156,9 +156,9 @@ public class Query {
     /// - Parameters:
     ///     - database  The database to query.
     ///     - expressions  String representing the query expression.
-    init(database: Database, expressions: String) {
+    init(database: Database, expressions: String) throws {
         self.database = database
-        queryImpl = CBLQuery(database: database._impl, expressions: expressions)
+        queryImpl = try database._impl.createQuery(expressions)
     }
 
     // MARK: Internal

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -320,11 +320,11 @@ class QueryTest: CBLTestCase {
         XCTAssertEqual(numRows, 1)
         
         // N1QL Query
-        var q2 = db.createQuery("SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, 'woman')")
+        var q2 = try db.createQuery("SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, 'woman')")
         numRows = try verifyQuery(q2) { (n, r) in }
         XCTAssertEqual(numRows, 1)
         
-        q2 = db.createQuery("SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, \"woman\")")
+        q2 = try db.createQuery("SELECT _id FROM `\(db.name)` WHERE MATCH(sentence, \"woman\")")
         numRows = try verifyQuery(q2) { (n, r) in }
         XCTAssertEqual(numRows, 1)
     }
@@ -1360,7 +1360,7 @@ class QueryTest: CBLTestCase {
     }
     
     func testN1QLLiveQuery() throws {
-        let q = db.createQuery("SELECT * FROM testdb WHERE number1 < 10")
+        let q = try db.createQuery("SELECT * FROM testdb WHERE number1 < 10")
         try testLiveQuery(query: q)
     }
     
@@ -1804,12 +1804,18 @@ class QueryTest: CBLTestCase {
         doc2.setValue("Ice Cream", forKey: "lastName")
         try self.db.saveDocument(doc2)
         
-        let q = self.db.createQuery("SELECT firstName, lastName FROM \(self.db.name)")
+        let q = try self.db.createQuery("SELECT firstName, lastName FROM \(self.db.name)")
         let results = try q.execute().allResults()
         XCTAssertEqual(results[0].string(forKey: "firstName"), "Jerry")
         XCTAssertEqual(results[0].string(forKey: "lastName"), "Ice Cream")
         XCTAssertEqual(results[1].string(forKey: "firstName"), "Ben")
         XCTAssertEqual(results[1].string(forKey: "lastName"), "Ice Cream")
+    }
+    
+    func testInvalidN1QL() throws {
+        expectError(domain: CBLErrorDomain, code: CBLErrorInvalidQuery) {
+            _ = try self.db.createQuery("SELECT firstName, lastName")
+        }
     }
     
     func testN1QLQueryOffsetWithoutLimit() throws {
@@ -1823,7 +1829,7 @@ class QueryTest: CBLTestCase {
         doc2.setValue("Ice Cream", forKey: "lastName")
         try self.db.saveDocument(doc2)
         
-        let q = self.db.createQuery("SELECT firstName, lastName FROM \(self.db.name) offset 1")
+        let q = try self.db.createQuery("SELECT firstName, lastName FROM \(self.db.name) offset 1")
         let results = try q.execute().allResults()
         XCTAssertEqual(results.count, 1)
     }


### PR DESCRIPTION
* Changed the signature to return an error or throw exception when the given query string is invalid.
* Changed Swift to call CBLDatabase’s -createQuery:error instead of using internal constructor.
* Renamed CBLQuery's -(BOOL)check: method to -(BOOL)compile:
* Renamed CBLQuery+N.h tp CBLQuery+N1QL.h
* Remove CBLQuery+N.h from Swift’s modulemap file as it’s not used by Swift code (Swift will not call the methods in CBLQuery+N1QL.h directly).

CBL-2483