### PR TITLE
CBL-815: test: add replicator goes offline scenario

### DIFF
--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -507,12 +507,12 @@
     [self waitForExpectations: @[busy] timeout: 5.0];
     
     // background during the data transfer!
-    [r setSuspended: YES];
+    [replicator setSuspended: YES];
     [self waitForExpectations: @[offline] timeout: 5.0];
     
     // forground after 0.2 secs
     [NSThread sleepForTimeInterval: 0.2];
-    [r setSuspended: NO];
+    [replicator setSuspended: NO];
     
     [self waitForExpectations: @[stop] timeout: 5.0];
     [replicator removeChangeListenerWithToken: token];

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -464,7 +464,6 @@
 }
 
 - (void) testBackgroundingDuringDataTransfer {
-    CBLDatabase.log.console.level = kCBLLogLevelInfo;
     XCTestExpectation* idle = [self allowOverfillExpectationWithDescription: @"idle-nd-ready"];
     XCTestExpectation* busy = [self allowOverfillExpectationWithDescription: @"transferring data"];
     XCTestExpectation* offline = [self expectationWithDescription: @"app-in-background"];

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -464,7 +464,7 @@
 }
 
 - (void) testBackgroundingDuringDataTransfer {
-    XCTestExpectation* idle = [self allowOverfillExpectationWithDescription: @"idle-nd-ready"];
+    XCTestExpectation* idle = [self allowOverfillExpectationWithDescription: @"idle-and-ready"];
     XCTestExpectation* busy = [self allowOverfillExpectationWithDescription: @"transferring data"];
     XCTestExpectation* offline = [self expectationWithDescription: @"app-in-background"];
     XCTestExpectation* stop = [self allowOverfillExpectationWithDescription: @"finish-transfer"];
@@ -507,12 +507,13 @@
     [self waitForExpectations: @[busy] timeout: 5.0];
     
     // background during the data transfer!
-    [replicator appBackgrounding];
+    [r setSuspended: YES];
     [self waitForExpectations: @[offline] timeout: 5.0];
     
     // forground after 0.2 secs
     [NSThread sleepForTimeInterval: 0.2];
-    [replicator appForegrounding];
+    [r setSuspended: NO];
+    
     [self waitForExpectations: @[stop] timeout: 5.0];
     [replicator removeChangeListenerWithToken: token];
     


### PR DESCRIPTION
* most common scenario will be app goes background while data is transferring. make sure it will resume the transfer when it becomes online and continue