### PR TITLE
CBL-2621: Replace deprecated APIs

### DIFF
--- a/Objective-C/Internal/Replicator/CBLTrustCheck.mm
+++ b/Objective-C/Internal/Replicator/CBLTrustCheck.mm
@@ -186,7 +186,7 @@ static BOOL sOnlyTrustAnchorCerts;
         } else
 #endif
         {
-            cert = SecTrustGetCertificateAtIndex(_trust, 0);
+            SecCertificateRef cert = SecTrustGetCertificateAtIndex(_trust, 0);
             certData = CFBridgingRelease(SecCertificateCopyData(cert));
         }
         

--- a/Objective-C/Internal/Replicator/CBLTrustCheck.mm
+++ b/Objective-C/Internal/Replicator/CBLTrustCheck.mm
@@ -176,8 +176,21 @@ static BOOL sOnlyTrustAnchorCerts;
 
     // If using cert-pinning, accept cert iff it matches the pin:
     if (_pinnedCertData) {
-        SecCertificateRef cert = SecTrustGetCertificateAtIndex(_trust, 0);
-        if ([_pinnedCertData isEqual: CFBridgingRelease(SecCertificateCopyData(cert))]) {
+        NSData* certData = nil;
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
+        if (@available(macOS 12.0, iOS 15.0, *)) {
+            CFArrayRef certs = SecTrustCopyCertificateChain(_trust);
+            SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, 0);
+            certData = CFBridgingRelease(SecCertificateCopyData(cert));
+            CFRelease(certs);
+        } else
+#endif
+        {
+            cert = SecTrustGetCertificateAtIndex(_trust, 0);
+            certData = CFBridgingRelease(SecCertificateCopyData(cert));
+        }
+        
+        if ([_pinnedCertData isEqual: certData]) {
             [self forceTrusted];
             return credential;
         } else {
@@ -204,8 +217,20 @@ static BOOL sOnlyTrustAnchorCerts;
     if (certCount != 1)
         return NO;
     
-    SecCertificateRef certRef = SecTrustGetCertificateAtIndex(_trust, 0);
-    C4Cert* c4cert = toC4Cert(@[(__bridge id) certRef], outError);
+    C4Cert* c4cert = nil;
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
+    if (@available(macOS 12.0, iOS 15.0, *)) {
+        CFArrayRef certs = SecTrustCopyCertificateChain(_trust);
+        SecCertificateRef certRef = (SecCertificateRef)CFArrayGetValueAtIndex(certs, 0);
+        c4cert = toC4Cert(@[(__bridge id) certRef], outError);
+        CFRelease(certs);
+    } else
+#endif
+    {
+        SecCertificateRef certRef = SecTrustGetCertificateAtIndex(_trust, 0);
+        c4cert = toC4Cert(@[(__bridge id) certRef], outError);
+    }
+    
     if (!c4cert)
         return NO;
     

--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -55,13 +55,13 @@ API_AVAILABLE(macos(10.12), ios(10.0))
         if (@available(iOS 10.3, *))
             publicKeyRef = SecCertificateCopyPublicKey(certRef);
         else
-            Assert(false, @"Catalyst:SecCertificateCopyPublicKey is not supported, iOS < 10.3, macOS < 10.3");
+            Assert(false, @"IOS:SecCertificateCopyPublicKey is not supported, iOS < 10.3");
 #elif TARGET_OS_OSX
         if (@available(macOS 10.3, *)) {
             OSStatus status = SecCertificateCopyPublicKey(certRef, &publicKeyRef);
             Assert(status == errSecSuccess);
         } else
-            Assert(false, @"Catalyst:SecCertificateCopyPublicKey is not supported, iOS < 10.3, macOS < 10.3");
+            Assert(false, @"OSX:SecCertificateCopyPublicKey is not supported, macOS < 10.3");
 #endif
     }
     Assert(publicKeyRef);
@@ -70,7 +70,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
         NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(publicKeyRef));
         return [attrs objectForKey: (id)kSecAttrApplicationLabel];
     } else {
-        Assert(false, @"Not Supported by this OS version");
+        Assert(false, @"SecKeyCopyAttributes is not supported, iOS < 10.0, macOS < 10.12");
     }
     return nil;
 }


### PR DESCRIPTION
* SecTrustGetCertificateAtIndex > SecTrustCopyCertificateChain
* More accurate logs