### PR TITLE
stabilize unit test

### DIFF
--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -57,15 +57,10 @@ class URLEndpontListenerTest: ReplicatorTest {
     }
     
     func stopListener(listener: URLEndpointListener? = nil) throws {
-        var l: URLEndpointListener!
-        if let listener = listener {
-            l = listener
-        } else {
-            l = self.listener
-        }
+        let l = listener ?? self.listener
         
-        l.stop()
-        if let id = l.tlsIdentity {
+        l?.stop()
+        if let id = l?.tlsIdentity {
             try id.deleteFromKeyChain()
         }
     }


### PR DESCRIPTION
* JAK found flaky test issues with the pushAndPull replicator. Causing a race with replicators to pull/push before other one pushes it. Which end up in wrong DB.count.
* We are now validating the push and pull separately