### PR TITLE
CBL-2825: Fix: [lithium] Attachment missing when doc updated

### DIFF
--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -230,9 +230,11 @@ using namespace fleece;
     if (!body.buf)
         createError(flErr, [NSString stringWithUTF8String: errMessage], outError);
     
-    FLDoc doc = FLDoc_FromResultData(body, kFLTrusted, self.database.sharedKeys, nullslice);
-    hasAttachment = hasAttachment || c4doc_dictContainsBlobs((FLDict)FLDoc_GetRoot(doc));
-    FLDoc_Release(doc);
+    if (!hasAttachment) {
+        FLDoc doc = FLDoc_FromResultData(body, kFLTrusted, self.database.sharedKeys, nullslice);
+        hasAttachment = c4doc_dictContainsBlobs((FLDict)FLDoc_GetRoot(doc));
+        FLDoc_Release(doc);
+    }
     
     // adds the attachment flag to `outRevFlags`
     if (outRevFlags)

--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -230,6 +230,10 @@ using namespace fleece;
     if (!body.buf)
         createError(flErr, [NSString stringWithUTF8String: errMessage], outError);
     
+    FLDoc doc = FLDoc_FromResultData(body, kFLTrusted, self.database.sharedKeys, nullslice);
+    hasAttachment = hasAttachment || c4doc_dictContainsBlobs((FLDict)FLDoc_GetRoot(doc));
+    FLDoc_Release(doc);
+    
     // adds the attachment flag to `outRevFlags`
     if (outRevFlags)
         *outRevFlags |= hasAttachment ? kRevHasAttachments : 0;

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -1479,7 +1479,7 @@
 
 #pragma mark - Sync Gateway Tests
 
-- (void) testPushPullWithBlobs {
+- (void) testPushPullWithBlobs_SG {
     id target = [self remoteEndpointWithName: @"scratch" secure: NO];
     if (!target)
         return;


### PR DESCRIPTION
* get the attachment present flag check with this call as well c4doc_dictContainsBlobs()
* add a SG unit test, to validate the fix. Its not useful for lithium