### PR TITLE
Add network interface option in the replicator config

### DIFF
--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -78,6 +78,11 @@ typedef BOOL (^CBLReplicationFilter) (CBLDocument* document, CBLDocumentFlags fl
  */
 @property (nonatomic, nullable) NSDictionary<NSString*, NSString*>* headers;
 
+/*
+ Specific network interface (e.g. en0 and pdp_ip0) for connecting to the remote target.
+ */
+@property (nonatomic, nullable) NSString* networkInterface;
+
 /**
  A set of Sync Gateway channel names to pull from. Ignored for push replication.
  The default value is nil, meaning that all accessible channels will be pulled.

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -38,6 +38,7 @@
 @synthesize authenticator=_authenticator;
 @synthesize pinnedServerCertificate=_pinnedServerCertificate;
 @synthesize headers=_headers;
+@synthesize networkInterface=_networkInterface;
 @synthesize documentIDs=_documentIDs, channels=_channels;
 @synthesize pushFilter=_pushFilter, pullFilter=_pullFilter;
 @synthesize checkpointInterval=_checkpointInterval, heartbeat=_heartbeat;
@@ -117,6 +118,11 @@
     _headers = headers;
 }
 
+- (void) setNetworkInterface: (NSString*)networkInterface {
+    [self checkReadonly];
+    _networkInterface = networkInterface;
+}
+
 - (void) setDocumentIDs: (NSArray<NSString *>*)documentIDs {
     [self checkReadonly];
     _documentIDs = documentIDs;
@@ -187,6 +193,7 @@
 #endif
         _pinnedServerCertificate = config.pinnedServerCertificate;
         cfretain(_pinnedServerCertificate);
+        _networkInterface = config.networkInterface;
         _headers = config.headers;
         _documentIDs = config.documentIDs;
         _channels = config.channels;

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -37,7 +37,6 @@
 #import "CollectionUtils.h"
 #import "CBLURLEndpoint.h"
 #import "CBLStringBytes.h"
-#import "c4.h"
 
 #ifdef COUCHBASE_ENTERPRISE
 #import "CBLCert.h"

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -205,7 +205,7 @@ static void doDispose(C4Socket* s) {
         _sockfd = -1;
         _networkInterface = _replicator.config.networkInterface;
         if (_networkInterface) {
-            queueName = [NSString stringWithFormat: @"%@-Connecting", queueName];
+            queueName = [NSString stringWithFormat: @"%@-SocketConnect", queueName];
             _socketConnectQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
         }
     }

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -410,7 +410,7 @@ static void doDispose(C4Socket* s) {
                 result = setsockopt(_sockfd, IPPROTO_IP, IP_BOUND_IF, &index, sizeof(index));
                 break;
             case AF_INET6:
-                result = setsockopt(_sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &index, sizeof(index));
+                result = setsockopt(_sockfd, IPPROTO_IPV6, IPV6_BOUND_IF, &index, sizeof(index));
                 break;
             default:
                 CBLWarnError(WebSocket, @"%@: Address family %d is not supported", self, addr->ai_family);

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -366,17 +366,13 @@ static void doDispose(C4Socket* s) {
     if (res) {
         NSString* msg = [NSString stringWithFormat: @"failed(%d) to get address info: %s", res,
                          gai_strerror(res)];
-        if (res == EAI_NONAME) {
-            CBLWarnError(WebSocket, @"%@: %@", self, msg);
-            if (error) {
-                *error = [NSError errorWithDomain: (id)kCFErrorDomainCFNetwork
-                                             code: kCFHostErrorUnknown
-                                         userInfo: @{NSLocalizedDescriptionKey : msg,
-                                                     (id)kCFGetAddrInfoFailureKey: @EAI_NONAME}];
-            }
-        } else
-            [self populateError: error errNo: res msg: msg];
-        
+        CBLWarnError(WebSocket, @"%@: %@", self, msg);
+        if (error) {
+            *error = [NSError errorWithDomain: (id)kCFErrorDomainCFNetwork
+                                         code: res
+                                     userInfo: @{NSLocalizedDescriptionKey : msg,
+                                                 (id)kCFGetAddrInfoFailureKey: $sprintf(@"%d", res)}];
+        }
         return false;
     }
     CBLLogVerbose(WebSocket, @"%@: %@:%ld(%@) got address info - (%d %d %d)", self, hostname,

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -84,6 +84,9 @@ public struct ReplicatorConfiguration {
     /// Extra HTTP headers to send in all requests to the remote target.
     public var headers: Dictionary<String, String>?
     
+    /// Specific network interface for connecting to the remote target.
+    public var networkInterface: String?
+    
     /// A set of Sync Gateway channel names to pull from. Ignored for push
     /// replication. If unset, all accessible channels will be pulled.
     /// Note: channels that are not accessible to the user will be ignored by
@@ -210,6 +213,7 @@ public struct ReplicatorConfiguration {
         self.authenticator = config.authenticator
         self.pinnedServerCertificate = config.pinnedServerCertificate
         self.headers = config.headers
+        self.networkInterface = config.networkInterface
         self.channels = config.channels
         self.documentIDs = config.documentIDs
         self.conflictResolver = config.conflictResolver
@@ -239,6 +243,7 @@ public struct ReplicatorConfiguration {
         c.authenticator = (self.authenticator as? IAuthenticator)?.toImpl()
         c.pinnedServerCertificate = self.pinnedServerCertificate
         c.headers = self.headers
+        c.networkInterface = self.networkInterface;
         c.channels = self.channels
         c.documentIDs = self.documentIDs
         c.pushFilter = self.filter(push: true)


### PR DESCRIPTION
* Add network interface option in the replicator config
* cherry-pick - d71b4428d73756ef4f0d7e5ee4640aa09d8b71ae
* We should have a functional test for this feature. 
* tested and is connecting. 
  * localhost + en0
  * 127.0.0.1 + lo0 
  * IPv4 + en0
  * IPv6 + en0
  
* from the logs only difference is setting the network interface. 
```
CouchbaseLite Network Info: <CBLWebSocket: **> connecting thru network interface en0
```