### PR TITLE
Fix addrinfo error to NSError conversion

### DIFF
--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -490,7 +490,7 @@ static inline NSError* posixError(int errNo, NSString* msg) {
 
 static inline NSError* addrInfoError(int res, NSString* msg) {
     return [NSError errorWithDomain: (id)kCFErrorDomainCFNetwork
-                               code: res
+                               code: kCFHostErrorUnknown
                            userInfo: @{NSLocalizedDescriptionKey: msg,
                                        (id)kCFGetAddrInfoFailureKey: $sprintf(@"%d", res)}];
 }


### PR DESCRIPTION
The error code should be kCFHostErrorUnknown to match the logic in CBLStatus.mm.