### PR TITLE
Add isValued/isNotValued APIs in Swift

### DIFF
--- a/Swift/Expression.swift
+++ b/Swift/Expression.swift
@@ -148,6 +148,18 @@ public protocol ExpressionProtocol {
     @available(*, deprecated, message: "Use isValued() instead.")
     func notNullOrMissing() -> ExpressionProtocol
     
+    /// Creates an IS VALUED expression that evaluates whether or not the current expression
+    /// is NOT null or missing.
+    ///
+    /// - Returns: The IS VALUED expression.
+    func isValued() -> ExpressionProtocol
+    
+    /// Creates an IS NOT VALUED expression that evaluates whether or not the current expression
+    /// is null or missing.
+    ///
+    /// - Returns: The IS NOT VALUED expression.
+    func isNotValued() ->ExpressionProtocol
+    
     // MARK: Bitwise operators
     
     /// Creates a logical AND expression that performs logical AND operation with the current
@@ -503,6 +515,24 @@ public final class Expression {
     /// - Returns: An IS NOT NULL expression.
     public func notNullOrMissing() -> ExpressionProtocol {
         return QueryExpression(self.impl.notNullOrMissing())
+    }
+    
+    // MARK: isValued() and isNotValued()
+    
+    /// Creates an IS VALUED expression that evaluates whether or not the current expression
+    /// is NOT null or missing.
+    ///
+    /// - Returns: The IS VALUED expression.
+    public func isValued() -> ExpressionProtocol {
+        return QueryExpression(self.impl.isValued())
+    }
+    
+    /// Creates an IS NOT VALUED expression that evaluates whether or not the current expression
+    /// is null or missing.
+    ///
+    /// - Returns: The IS NOT VALUED expression.
+    public func isNotValued() -> ExpressionProtocol {
+        return QueryExpression(self.impl.isNotValued());
     }
     
     // MARK: Bitwise operators

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -147,15 +147,24 @@ class QueryTest: CBLTestCase {
         let age = Expression.property("age")
         let work = Expression.property("work")
         
+        
         let tests: [[Any]] = [
             [name.isNullOrMissing(), []],
+            [name.isNotValued(), []],
             [name.notNullOrMissing(), [doc1, doc2]],
+            [name.isValued(), [doc1, doc2]],
             [address.isNullOrMissing(), [doc1]],
+            [address.isNotValued(), [doc1]],
             [address.notNullOrMissing(), [doc2]],
+            [address.isValued(), [doc2]],
             [age.isNullOrMissing(), [doc1]],
+            [age.isNotValued(), [doc1]],
             [age.notNullOrMissing(), [doc2]],
+            [age.isValued(), [doc2]],
             [work.isNullOrMissing(), [doc1, doc2]],
-            [work.notNullOrMissing(), []]
+            [work.isNotValued(), [doc1, doc2]],
+            [work.notNullOrMissing(), []],
+            [work.isValued(), []]
         ]
         
         for test in tests {


### PR DESCRIPTION
- Add isValued/isNotValued APIs in Swift
- Also add tests to validate the same
- Seems like deprecated warnings cannot be suppressed in swift, which causes deprecation warnings in the test suite. 