### PR TITLE
Some collection fixes in Swift

### DIFF
--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -55,7 +55,7 @@ import Foundation
 public final class Collection : CollectionChangeObservable, Indexable {
     
     /// The default scope name constant
-    public static let defaultCollectionName: String = "_default"
+    public static let defaultCollectionName: String = kCBLDefaultCollectionName
     
     /// Collection name.
     public var name: String { _impl.name }

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -323,8 +323,7 @@ public struct ReplicatorConfiguration {
         if let resolver = self.conflictResolver {
             c.setConflictResolverUsing { (conflict) -> CBLDocument? in
                 guard let col = try? self.database.defaultCollection() else {
-                    Database.throwNotOpenEx()
-                    fatalError() // hack to avoid compiler complaining execution continues
+                    Database.throwNotOpenError()
                 }
                 
                 return resolver.resolve(conflict: Conflict(impl: conflict, collection: col))?._impl
@@ -348,8 +347,7 @@ public struct ReplicatorConfiguration {
         
         return { (doc, flags) in
             guard let col = try? self.database.defaultCollection() else {
-                Database.throwNotOpenEx()
-                fatalError() // hack to avoid compiler complaining execution continues
+                Database.throwNotOpenError()
             }
             
             return f(Document(doc, collection: col), DocumentFlags(rawValue: Int(flags.rawValue)))

--- a/Swift/Scope.swift
+++ b/Swift/Scope.swift
@@ -31,7 +31,7 @@ import Foundation
 public final class Scope {
     
     /// The default scope name constant
-    public static let defaultScopeName: String = "_default"
+    public static let defaultScopeName: String = kCBLDefaultScopeName
     
     /// Scope name
     public var name: String {


### PR DESCRIPTION
* Used kCBLDefaultCollectionName and kCBLDefaultScopeName.
* Updated throwNotOpenEx to do fatalError() and return Never to indicate that the function will never return.
* Removes fatalError() hacks as it is not needed anymore after marking throwNotOpenEx as Never return.
* Fixed scope(name: String), defaultCollection(), collection(name: String, scope: String?) to being able to return nil.