### PR TITLE
Fix podspecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ xcuserdata/
 DerivedData/
 obj/
 derived_src/
+frameworks/
+*-build.log
 
 # CBL files:
 vendor/couchbase-lite-core-EE
@@ -19,3 +21,6 @@ vendor/couchbase-lite-core-EE
 
 # spm 
 .swiftpm/*
+
+# AppCode
+.idea

--- a/CouchbaseLite-Swift.podspec
+++ b/CouchbaseLite-Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'CouchbaseLite-Swift'
-  s.version               = '2.0.0'
+  s.version               = '3.1.0'
   s.license               = 'Apache License, Version 2.0'
   s.homepage              = 'https://github.com/couchbase/couchbase-lite-ios'
   s.summary               = 'An embedded syncable NoSQL database for iOS and MacOS apps.'
@@ -8,14 +8,14 @@ Pod::Spec.new do |s|
   s.source                = { :git => 'https://github.com/couchbase/couchbase-lite-ios.git', :tag => s.version, :submodules => true }
 
   s.prepare_command = <<-CMD
-    sh Scripts/prepare_cocoapods.sh "CBL Swift"
+    sh Scripts/prepare_cocoapods.sh "CBL_Swift"
   CMD
 
-  s.ios.preserve_paths = 'frameworks/CBL Swift/iOS/CouchbaseLiteSwift.framework'
-  s.ios.vendored_frameworks = 'frameworks/CBL Swift/iOS/CouchbaseLiteSwift.framework'
+  s.ios.preserve_paths = 'frameworks/CBL_Swift/iOS/CouchbaseLiteSwift.framework'
+  s.ios.vendored_frameworks = 'frameworks/CBL_Swift/iOS/CouchbaseLiteSwift.framework'
 
-  s.osx.preserve_paths = 'frameworks/CBL Swift/macOS/CouchbaseLiteSwift.framework'
-  s.osx.vendored_frameworks = 'frameworks/CBL Swift/macOS/CouchbaseLiteSwift.framework'
+  s.osx.preserve_paths = 'frameworks/CBL_Swift/macOS/CouchbaseLiteSwift.framework'
+  s.osx.vendored_frameworks = 'frameworks/CBL_Swift/macOS/CouchbaseLiteSwift.framework'
 
   s.ios.deployment_target  = '9.0'
   s.osx.deployment_target  = '10.11'

--- a/CouchbaseLite.podspec
+++ b/CouchbaseLite.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'CouchbaseLite'
-  s.version               = '2.0.0'
+  s.version               = '3.1.0'
   s.license               = 'Apache License, Version 2.0'
   s.homepage              = 'https://github.com/couchbase/couchbase-lite-ios'
   s.summary               = 'An embedded syncable NoSQL database for iOS and MacOS apps.'
@@ -8,14 +8,14 @@ Pod::Spec.new do |s|
   s.source                = { :git => 'https://github.com/couchbase/couchbase-lite-ios.git', :tag => s.version, :submodules => true }
 
   s.prepare_command = <<-CMD
-    sh Scripts/prepare_cocoapods.sh "CBL ObjC"
+    sh Scripts/prepare_cocoapods.sh "CBL_ObjC"
   CMD
 
-  s.ios.preserve_paths = 'frameworks/CBL ObjC/iOS/CouchbaseLite.framework'
-  s.ios.vendored_frameworks = 'frameworks/CBL ObjC/iOS/CouchbaseLite.framework'
+  s.ios.preserve_paths = 'frameworks/CBL_ObjC/iOS/CouchbaseLite.framework'
+  s.ios.vendored_frameworks = 'frameworks/CBL_ObjC/iOS/CouchbaseLite.framework'
 
-  s.osx.preserve_paths = 'frameworks/CBL ObjC/macOS/CouchbaseLite.framework'
-  s.osx.vendored_frameworks = 'frameworks/CBL ObjC/macOS/CouchbaseLite.framework'
+  s.osx.preserve_paths = 'frameworks/CBL_ObjC/macOS/CouchbaseLite.framework'
+  s.osx.vendored_frameworks = 'frameworks/CBL_ObjC/macOS/CouchbaseLite.framework'
 
   s.ios.deployment_target  = '9.0'
   s.osx.deployment_target  = '10.11'


### PR DESCRIPTION
Spaces were changed to underscores in #2654, which broke the local podspec files. This fixes the scheme names and output framework paths.

Also .gitignore the framework builds and logs, as well as the AppCode .idea IDE configuration folder.