### PR TITLE
[test] [swift] 8.1 default collection/scope & 8.2 collections

### DIFF
--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -512,7 +512,8 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
  
  @param name Scope name, if empty, it will use default scope name.
  @param error On return, the error if any. CBLErrorNotOpen code will be returned
-        if the database is closed.
+        if the database is closed. CBLErrorNotFound code will be returned if the
+        scope doesn't exist.
  @return Scope object, or nil if an error occurred.
  */
 - (nullable CBLScope*) scopeWithName: (nullable NSString*)name
@@ -549,7 +550,8 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
  @param name Name of the collection to be fetched.
  @param scope Name of the scope the collection resides, if not specified uses the default scope.
  @param error On return, the error if any. CBLErrorNotOpen code will be returned
-        if the database is closed.
+        if the database is closed. CBLErrorNotFound code will be returned if the
+        scope doesn't exist.
  @return collection instance or If the collection doesn't exist, a nil value will be returned.
  */
 - (nullable CBLCollection*) collectionWithName: (NSString*)name
@@ -583,7 +585,8 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
 /**
  Get the default collection. If the default collection is deleted, nil will be returned.
  
- @param error On return, the error if any.
+ @param error On return, the error if any. CBLErrorNotFound code will be returned if the
+        default collection is deleted.
  @return Default collection, or nil if an error occurred.
  */
 - (nullable CBLCollection*) defaultCollection: (NSError**)error;

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -681,12 +681,12 @@ static const C4DatabaseConfig2 kDBConfig = {
 
 - (nullable CBLCollection*) defaultCollection: (NSError**)error {
     CBL_LOCK(_mutex) {
-        // db closed or deleted
+        // db closed
         if (![self mustBeOpen: error])
             return nil;
         
-        // collection removed
-        BOOL isValid = _defaultCollection.isValid;
+        // if collection is invalid (deleted or LC marked as invalid)
+        BOOL isValid = [_defaultCollection collectionIsValid: error];
         if (!isValid) {
             _defaultCollection = nil;
             convertError({LiteCoreDomain, kC4ErrorNotFound}, error);

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -686,7 +686,7 @@ static const C4DatabaseConfig2 kDBConfig = {
             return nil;
         
         // if collection is invalid (deleted or LC marked as invalid)
-        BOOL isValid = [_defaultCollection collectionIsValid: error];
+        BOOL isValid = _defaultCollection.isValid;
         if (!isValid) {
             _defaultCollection = nil;
             convertError({LiteCoreDomain, kC4ErrorNotFound}, error);

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -668,8 +668,10 @@ static const C4DatabaseConfig2 kDBConfig = {
         
         CBLStringBytes sname(scopeName);
         BOOL exists = c4db_hasScope(_c4db, sname);
-        if (!exists)
+        if (!exists) {
+            convertError({LiteCoreDomain, kC4ErrorNotFound}, error);
             return nil;
+        }
         
         return [[CBLScope alloc] initWithDB: self name: scopeName];
     }
@@ -679,12 +681,16 @@ static const C4DatabaseConfig2 kDBConfig = {
 
 - (nullable CBLCollection*) defaultCollection: (NSError**)error {
     CBL_LOCK(_mutex) {
+        // db closed or deleted
         if (![self mustBeOpen: error])
             return nil;
         
+        // collection removed
         BOOL isValid = _defaultCollection.isValid;
-        if (!isValid)
+        if (!isValid) {
             _defaultCollection = nil;
+            convertError({LiteCoreDomain, kC4ErrorNotFound}, error);
+        }
         
         return _defaultCollection;
     }
@@ -802,8 +808,10 @@ static void throwIfNotOpenError(NSError* error) {
             return nil;
         }
         
-        if (!c)
+        if (!c) {
+            convertError({LiteCoreDomain, kC4ErrorNotFound}, error);
             return nil;
+        }
         
         return [[CBLCollection alloc] initWithDB: self c4collection: c];
     }

--- a/Objective-C/Internal/CBLCollection+Internal.h
+++ b/Objective-C/Internal/CBLCollection+Internal.h
@@ -57,6 +57,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (bool) resolveConflictInDocument: (NSString*)docID
               withConflictResolver: (nullable id<CBLConflictResolver>)conflictResolver
                              error: (NSError**)outError;
+
+- (BOOL) collectionIsValid: (NSError**)error;
+
 @end
 
 @interface CBLCollectionChange ()

--- a/Objective-C/Internal/CBLCollection+Internal.h
+++ b/Objective-C/Internal/CBLCollection+Internal.h
@@ -58,8 +58,6 @@ NS_ASSUME_NONNULL_BEGIN
               withConflictResolver: (nullable id<CBLConflictResolver>)conflictResolver
                              error: (NSError**)outError;
 
-- (BOOL) collectionIsValid: (NSError**)error;
-
 @end
 
 @interface CBLCollectionChange ()

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2507,13 +2507,15 @@
 - (void) testEmptyCollection {
     NSError* error = nil;
     AssertNil([self.db collectionWithName: @"dummy" scope: nil error: &error]);
-    AssertNil(error);
+    AssertEqual(error.code, CBLErrorNotFound);
     
+    error = nil;
     AssertNil([self.db collectionWithName: @"dummy" scope: kCBLDefaultScopeName error: &error]);
-    AssertNil(error);
+    AssertEqual(error.code, CBLErrorNotFound);
     
+    error = nil;
     AssertNil([self.db collectionWithName: @"dummy" scope: @"scope1" error: &error]);
-    AssertNil(error);
+    AssertEqual(error.code, CBLErrorNotFound);
 }
 
 #pragma mark - Collection Indexable

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -52,7 +52,7 @@ import Foundation
 /// collection-aware code should avoid them and use the new Collection API instead.
 /// These legacy functions are deprecated and will be removed eventually.
 ///
-public final class Collection : CollectionChangeObservable, Indexable {
+public final class Collection : CollectionChangeObservable, Indexable, Equatable {
     
     /// The default scope name constant
     public static let defaultCollectionName: String = kCBLDefaultCollectionName
@@ -281,6 +281,11 @@ public final class Collection : CollectionChangeObservable, Indexable {
         try _impl.deleteIndex(withName: name)
     }
     
+    // MARK: Equatable
+    
+    public static func == (lhs: Collection, rhs: Collection) -> Bool {
+        return lhs._impl == rhs._impl
+    }
     
     // MARK: Internal
     

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -472,18 +472,32 @@ public final class Database {
     /// value will be returned if there are no collections under the given scope’s name.
     /// Note: The default scope is exceptional, and it will always be returned.
     public func scope(name: String) throws -> Scope? {
-        // Note: Swift cannot detect nullable when objective-c return nullable value with out error
-        let s: CBLScope? = try _impl.scope(withName: name)
-        return s != nil ? Scope(s!, db: self) : nil
+        do {
+            let s = try _impl.scope(withName: name)
+            return Scope(s, db: self)
+        } catch let err as NSError {
+            if err.code == CBLErrorNotFound {
+                return nil
+            }
+            
+            throw err
+        }
     }
     
     // MARK: Collections
     
     /// Get the default collection. If the default collection is deleted, nil will be returned.
     public func defaultCollection() throws  -> Collection? {
-        // Note: Swift cannot detect nullable when objective-c return nullable value with out error
-        let c: CBLCollection? = try _impl.defaultCollection()
-        return c != nil ? Collection(c!, db: self) : nil
+        do {
+            let c = try _impl.defaultCollection()
+            return Collection(c, db: self)
+        } catch let err as NSError {
+            if err.code == CBLErrorNotFound {
+                return nil
+            }
+            
+            throw err
+        }
     }
     
     /// Get all collections in the specified scope.
@@ -507,9 +521,16 @@ public final class Database {
     /// Get a collection in the specified scope by name.
     /// If the collection doesn't exist, a nil value will be returned.
     public func collection(name: String, scope: String? = defaultScopeName) throws -> Collection? {
-        // Note: Swift cannot detect nullable when objective-c return nullable value with out error
-        let c: CBLCollection? = try _impl.collection(withName: name, scope: scope)
-        return c != nil ? Collection(c!, db: self) : nil
+        do {
+            let c = try _impl.collection(withName: name, scope: scope)
+            return Collection(c, db: self)
+        } catch let err as NSError {
+            if err.code == CBLErrorNotFound {
+                return nil
+            }
+            
+            throw err
+        }
     }
     
     /// Delete a collection by name  in the specified scope. If the collection doesn't exist, the operation

--- a/Swift/Scope.swift
+++ b/Swift/Scope.swift
@@ -42,12 +42,12 @@ public final class Scope {
     
     /// Get all collections in the scope.
     public func collections() throws -> [Collection] {
-        return try _db.collections()
+        return try _db.collections(scope: _impl.name)
     }
     
     /// Get a collection in the scope by name. If the collection doesn't exist, a nil value will be returned.
     public func collection(name: String) throws -> Collection? {
-        return try _db.collection(name: name)
+        return try _db.collection(name: name, scope: _impl.name)
     }
     
     init(_ scope: CBLScope, db: Database) {

--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -73,7 +73,7 @@ class CollectionTest: CBLTestCase {
         XCTAssertNil(collection)
         
         self.expectError(domain: CBLErrorDomain, code: CBLError.invalidParameter) {
-            let _ = try? self.db.createCollection(name: Database.defaultCollectionName)
+            let _ = try self.db.createCollection(name: Database.defaultCollectionName)
         }
         
         collection = try self.db.defaultCollection()
@@ -288,7 +288,7 @@ class CollectionTest: CBLTestCase {
         var name = ""
         for i in 0..<251 {
             name.append("a")
-            if i%4 == 0 {
+            if i%4 == 0 { // without this, test might take ~20secs to finish
                 names.append(name)
             }
         }
@@ -319,7 +319,7 @@ class CollectionTest: CBLTestCase {
         XCTAssertEqual(col1a.name, "COLLECTION1")
         XCTAssertEqual(col1b.name, "collection1")
         
-        let cols = self.db.collections(scope: "scopeA")
+        let cols = try self.db.collections(scope: "scopeA")
         XCTAssertEqual(cols.count, 2)
         XCTAssert(cols.contains(where: { $0.name == "COLLECTION1" }))
         XCTAssert(cols.contains(where: { $0.name == "collection1" }))
@@ -332,7 +332,7 @@ class CollectionTest: CBLTestCase {
         XCTAssertEqual(col1a.scope.name, "scopeA")
         XCTAssertEqual(col1b.scope.name, "SCOPEa")
         
-        let scopes = self.db.scopes()
+        let scopes = try self.db.scopes()
         XCTAssertEqual(scopes.count, 2)
         XCTAssert(scopes.contains(where: { $0.name == "scopeA" }))
         XCTAssert(scopes.contains(where: { $0.name == "SCOPEa" }))


### PR DESCRIPTION
* Add unit tests for 8.1 & 8.2
* CBL-3477

Update the code to return nil with CBLErrorNotFound, in case of collection/scope is missing. So that,  swift can check and return nil. 

If not we might end up using a hack to check for 
```
if nsError.code == 0, nsError.domain == "Foundation._GenericObjCError" {
        // handle empty error code! 
}