### PR TITLE
[test] [objc] 8.14 Replicator collection tests

### DIFF
--- a/Objective-C/CBLLog.mm
+++ b/Objective-C/CBLLog.mm
@@ -81,7 +81,6 @@ static NSDictionary* domainDictionary = nil;
 static CBLLogDomain toCBLLogDomain(C4LogDomain domain) {
     if (!domainDictionary) {
         domainDictionary = @{ @"DB": @(kCBLLogDomainDatabase),
-                              @"SQL": @(kCBLLogDomainDatabase),
                               @"Query": @(kCBLLogDomainQuery),
                               @"Sync": @(kCBLLogDomainReplicator),
                               @"SyncBusy": @(kCBLLogDomainReplicator),
@@ -173,7 +172,6 @@ static void sendToCallbackLogger(C4LogDomain d, C4LogLevel l, NSString* message)
         setNamedLogDomainLevel("SyncBusy", kC4LogDebug);
         setNamedLogDomainLevel("TLS", kC4LogDebug);
         setNamedLogDomainLevel("Changes", kC4LogDebug);
-        setNamedLogDomainLevel("SQL", kC4LogDebug);
         setNamedLogDomainLevel("Zip", kC4LogDebug);
         setNamedLogDomainLevel("BLIPMessages", kC4LogDebug);
         

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -730,9 +730,11 @@ static void onDocsEnded(C4Replicator* repl,
     CBLCollection* c = [_collectionMap objectForKey: $sprintf(@"%@.%@", doc.scope, doc.collection)];
     Assert(c, @"Collection not found in replicator config when resolving a conflict");
     
+    CBLCollectionConfiguration* colConfig = [_config collectionConfig: c];
+    
     NSError* error = nil;
     if (![c resolveConflictInDocument: doc.id
-                 withConflictResolver: _config.conflictResolver
+                 withConflictResolver: colConfig.conflictResolver
                                 error: &error]) {
         CBLWarn(Sync, @"%@: Conflict resolution of '%@' failed: %@", self, doc.id, error);
     }
@@ -796,13 +798,9 @@ static bool pullFilter(C4CollectionSpec collectionSpec,
     
     if ((flags & kRevPurged) == kRevPurged)
         docFlags |= kCBLDocumentFlagsAccessRemoved;
-
-// TODO: Remove https://issues.couchbase.com/browse/CBL-3206
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return pushing ? _config.pushFilter(doc, docFlags) : _config.pullFilter(doc, docFlags);
-#pragma clang diagnostic pop
-
+    
+    CBLCollectionConfiguration* colConfig = [_config collectionConfig: c];
+    return pushing ? colConfig.pushFilter(doc, docFlags) : colConfig.pullFilter(doc, docFlags);
 }
 
 #pragma mark - BACKGROUNDING SUPPORT:

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -731,6 +731,7 @@ static void onDocsEnded(C4Replicator* repl,
     Assert(c, @"Collection not found in replicator config when resolving a conflict");
     
     CBLCollectionConfiguration* colConfig = [_config collectionConfig: c];
+    Assert(colConfig, @"Collection config not found in replicator config when resolving a conflict");
     
     NSError* error = nil;
     if (![c resolveConflictInDocument: doc.id
@@ -800,6 +801,8 @@ static bool pullFilter(C4CollectionSpec collectionSpec,
         docFlags |= kCBLDocumentFlagsAccessRemoved;
     
     CBLCollectionConfiguration* colConfig = [_config collectionConfig: c];
+    Assert(colConfig, @"Collection config is not found in the replicator config when " \
+           "calling the filter function.");
     return pushing ? colConfig.pushFilter(doc, docFlags) : colConfig.pullFilter(doc, docFlags);
 }
 

--- a/Objective-C/Tests/ReplicatorTest+Collection.m
+++ b/Objective-C/Tests/ReplicatorTest+Collection.m
@@ -405,6 +405,7 @@
 }
 
 // exception causiung the memory leak!
+// TODO: https://issues.couchbase.com/browse/CBL-3576
 - (void) _testAddCollectionsFromDifferentDatabaseInstances {
     NSError* error = nil;
     CBLCollection* col1a = [self.db createCollectionWithName: @"colA"
@@ -439,6 +440,7 @@
 }
 
 // memory leak with NSException
+// TODO: https://issues.couchbase.com/browse/CBL-3576
 - (void) _testAddDeletedCollections {
     NSError* error = nil;
     CBLCollection* col1a = [self.db createCollectionWithName: @"colA"
@@ -675,7 +677,7 @@
     AssertEqual(col1a.count, 10);
 }
 
-// memory leak!
+// TODO: https://issues.couchbase.com/browse/CBL-3576
 - (void) _testMismatchedCollectionReplication {
     NSError* error = nil;
     CBLCollection* cola = [self.db createCollectionWithName: @"colA"
@@ -1022,8 +1024,7 @@
     AssertEqual(col2b.count, 5);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-3524
-- (void) _testCollectionGetPendingDocumentIDs {
+- (void) testCollectionGetPendingDocumentIDs {
     NSError* error = nil;
     CBLCollection* col1a = [self.db createCollectionWithName: @"colA"
                                                        scope: @"scopeA" error: &error];
@@ -1058,6 +1059,7 @@
     CBLReplicatorConfiguration* config = [self configWithTarget: target
                                                            type: kCBLReplicatorTypePush
                                                      continuous: NO];
+    [config addCollections: @[col1a, col1b] config: nil];
     CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
     
     NSSet* docIds1a = [r pendingDocumentIDsForCollection: col1a error: &error];
@@ -1089,17 +1091,16 @@
     AssertEqual(docIds1a.count, 1);
     Assert([docIds1a containsObject: @"doc1"]);
     
-    CBLDocument* doc = [col1b documentWithID: @"doc2" error: &error];
+    CBLDocument* doc = [col1b documentWithID: @"doc12" error: &error];
     [col1b deleteDocument: doc error: &error];
     AssertNil(error);
     docIds1b = [r pendingDocumentIDsForCollection: col1b error: &error];
     AssertNil(error);
     AssertEqual(docIds1b.count, 1);
-    Assert([docIds1b containsObject: @"doc2"]);
+    Assert([docIds1b containsObject: @"doc12"]);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-3524
-- (void) _testCollectionIsDocumentPending {
+- (void) testCollectionIsDocumentPending {
     NSError* error = nil;
     CBLCollection* col1a = [self.db createCollectionWithName: @"colA"
                                                        scope: @"scopeA" error: &error];
@@ -1130,6 +1131,7 @@
     CBLReplicatorConfiguration* config = [self configWithTarget: target
                                                            type: kCBLReplicatorTypePush
                                                      continuous: NO];
+    [config addCollections: @[col1a, col1b] config: nil];
     CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
     
     for (NSUInteger i = 0; i < 10; i++) {
@@ -1167,11 +1169,11 @@
     AssertNil(error);
     
     // Delete a document in colB.
-    CBLDocument* doc = [col1b documentWithID: @"doc2" error: &error];
+    CBLDocument* doc = [col1b documentWithID: @"doc12" error: &error];
     [col1b deleteDocument: doc error: &error];
     AssertNil(error);
     
-    Assert([r isDocumentPending: @"doc2" collection: col1b error: &error]);
+    Assert([r isDocumentPending: @"doc12" collection: col1b error: &error]);
     AssertNil(error);
 }
 


### PR DESCRIPTION
* Add unit tests for replicator+collection support
* Use filter & conflict resolver from the collection config. 
* Not included - testCollectionDocumentReplicationEvents - CBL-3569