### PR TITLE
[test] [swift] collection/scope/db deleted scenario

### DIFF
--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -753,10 +753,14 @@ class CollectionTest: CBLTestCase {
     
     func testGetScopesOrCollectionsWhenDatabaseIsClosed() throws {
         try self.db.close()
+        
+        try getScopesOrCollectionsTest()
     }
     
     func testGetScopesOrCollectionsWhenDatabaseIsDeleted() throws {
         try self.db.delete()
+        
+        try getScopesOrCollectionsTest()
     }
     
     func getScopesOrCollectionsTest() throws {


### PR DESCRIPTION
* Add unit test about deleted scenario
* `testUseDatabaseAPIWhenDefaultCollectionIsDeleted`: Not added, since fatalError, we can't test from unit test. 