### PR TITLE
Remove the CE schemes from Jenkins validation

### DIFF
--- a/Scripts/pull_request_build.sh
+++ b/Scripts/pull_request_build.sh
@@ -2,7 +2,7 @@
 
 cd couchbase-lite-ios
 
-SCHEMES=("CBL_EE_ObjC" "CBL_EE_Swift" "CBL_ObjC" "CBL_Swift")
+SCHEMES=("CBL_EE_ObjC" "CBL_EE_Swift")
 for SCHEME in "${SCHEMES[@]}"
 do
   xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone SE (2nd generation)"


### PR DESCRIPTION
* Remove the CE scheme, since that's already tested via GH Actions
* Not much value with it, we are already checking CE combination for Mac/iOS/catalyst