### PR TITLE
Stabilising unit test

### DIFF
--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1930,7 +1930,7 @@ class QueryTest: CBLTestCase {
                 x1.fulfill()
             }
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             try! self.db.purgeDocument(withID: "doc1")
         }
         wait(for: [x1], timeout: 10.0)


### PR DESCRIPTION
* avoid the change listener is firing immedietly in case of faster device/machine. Making the purge happen after 0.5 wil be enough time to receive both change sets.