### PR TITLE
[fix] code coverage & doc

### DIFF
--- a/Scripts/generate_objc_release_zip.sh
+++ b/Scripts/generate_objc_release_zip.sh
@@ -66,7 +66,7 @@ then
   CONFIGURATION_TEST="Debug"
   COVERAGE_NAME="coverage"
   EDITION="community"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
 else
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
@@ -74,7 +74,7 @@ else
   COVERAGE_NAME="coverage-ee"
   EDITION="enterprise"
   EXTRA_CMD_OPTIONS="--EE"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
   OPTS="--EE"
 fi
 
@@ -128,6 +128,7 @@ then
     echo "Generate coverage report for ObjC ..."
     slather coverage --html \
         --scheme "${SCHEME_PREFIX}_ObjC_Tests_iOS_App" \
+        --binary-basename "CouchbaseLite" \
         --configuration "$CONFIGURATION_TEST" \
         --ignore "vendor/*" --ignore "Swift/*" \
         --ignore "Objective-C/Tests/*" --ignore "../Sources/Swift/*" \

--- a/Scripts/generate_swift_release_zip.sh
+++ b/Scripts/generate_swift_release_zip.sh
@@ -66,14 +66,14 @@ then
   CONFIGURATION_TEST="Debug"
   COVERAGE_NAME="coverage"
   EDITION="community"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
 else
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
   CONFIGURATION_TEST="Debug_EE"
   COVERAGE_NAME="coverage-ee"
   EDITION="enterprise"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
   OPTS="--EE"
 fi
 
@@ -124,6 +124,7 @@ then
     echo "Generate coverage report for Swift ..."
     slather coverage --html \
         --scheme "${SCHEME_PREFIX}_Swift_Tests_iOS_App" \
+        --binary-basename "CouchbaseLiteSwift" \
         --configuration "$CONFIGURATION_TEST"  \
         --ignore "vendor/*" --ignore "Objective-C/*" \
         --ignore "Swift/Tests/*" --ignore "../Sources/Objective-C/*" \
@@ -176,7 +177,7 @@ sh Scripts/generate_package_manifest.sh -zip-path "$OUTPUT_DIR/couchbase-lite-sw
 if [[ -z $NO_API_DOCS ]]; then
   # Generate API docs:
   echo "Generate API docs ..."
-  jazzy --clean --xcodebuild-arguments "clean,build,-scheme,${SCHEME_PREFIX}_Swift,-sdk,iphonesimulator" --module CouchbaseLiteSwift --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLiteSwift
+  jazzy --clean --xcodebuild-arguments "clean,build,-scheme,${SCHEME_PREFIX}_Swift,-sdk,iphonesimulator,-destination,generic/platform=iOS Simulator" --module CouchbaseLiteSwift --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLiteSwift
   
   # >> Swift API docs
   pushd "$OUTPUT_SWIFT_DOCS_DIR" > /dev/null


### PR DESCRIPTION
* specify the destination in the jazzy to avoid the warnings
* specify the binary-basename in the slather to pick correct binary instead of first among the list. 
    * Assume, this might be the cause of NaN result, it was selecting the CBL_Swift_Tests.app binary instead of CouchbaseLiteSwift binary.