### PR TITLE
[fix] ios simulator to use iPhone 11

### DIFF
--- a/Scripts/generate_objc_release_zip.sh
+++ b/Scripts/generate_objc_release_zip.sh
@@ -66,7 +66,7 @@ then
   CONFIGURATION_TEST="Debug"
   COVERAGE_NAME="coverage"
   EDITION="community"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
 else
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
@@ -74,7 +74,7 @@ else
   COVERAGE_NAME="coverage-ee"
   EDITION="enterprise"
   EXTRA_CMD_OPTIONS="--EE"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
   OPTS="--EE"
 fi
 

--- a/Scripts/generate_swift_release_zip.sh
+++ b/Scripts/generate_swift_release_zip.sh
@@ -66,14 +66,14 @@ then
   CONFIGURATION_TEST="Debug"
   COVERAGE_NAME="coverage"
   EDITION="community"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
 else
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
   CONFIGURATION_TEST="Debug_EE"
   COVERAGE_NAME="coverage-ee"
   EDITION="enterprise"
-  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 14"
+  TEST_SIMULATOR="platform=iOS Simulator,name=iPhone 11"
   OPTS="--EE"
 fi
 


### PR DESCRIPTION
* While testing on Xcode 14, it got updated, and since the Jenkins has Xcode 13.x, we will revert it to iPhone 11