### PR TITLE
Add experiment option to use bind function

### DIFF
--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -83,6 +83,13 @@ typedef BOOL (^CBLReplicationFilter) (CBLDocument* document, CBLDocumentFlags fl
  */
 @property (nonatomic, nullable) NSString* networkInterface;
 
+/*
+ (Volatile API : Will be removed in the release version)
+ Experiment to use bind() function to bind socket to the specified network interface
+ instead of setting the socket option.
+ */
+@property (nonatomic) bool experimentNetworkInterfaceUseBindFunction;
+
 /**
  A set of Sync Gateway channel names to pull from. Ignored for push replication.
  The default value is nil, meaning that all accessible channels will be pulled.

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -39,6 +39,7 @@
 @synthesize pinnedServerCertificate=_pinnedServerCertificate;
 @synthesize headers=_headers;
 @synthesize networkInterface=_networkInterface;
+@synthesize experimentNetworkInterfaceUseBindFunction=_experimentNetworkInterfaceUseBindFunction;
 @synthesize documentIDs=_documentIDs, channels=_channels;
 @synthesize pushFilter=_pushFilter, pullFilter=_pullFilter;
 @synthesize checkpointInterval=_checkpointInterval, heartbeat=_heartbeat;
@@ -123,6 +124,11 @@
     _networkInterface = networkInterface;
 }
 
+- (void) setexperimentNetworkInterfaceUseBindFunction: (BOOL)experimentNetworkInterfaceUseBindFunction {
+    [self checkReadonly];
+    _experimentNetworkInterfaceUseBindFunction = experimentNetworkInterfaceUseBindFunction;
+}
+
 - (void) setDocumentIDs: (NSArray<NSString *>*)documentIDs {
     [self checkReadonly];
     _documentIDs = documentIDs;
@@ -194,6 +200,7 @@
         _pinnedServerCertificate = config.pinnedServerCertificate;
         cfretain(_pinnedServerCertificate);
         _networkInterface = config.networkInterface;
+        _experimentNetworkInterfaceUseBindFunction = config.experimentNetworkInterfaceUseBindFunction;
         _headers = config.headers;
         _documentIDs = config.documentIDs;
         _channels = config.channels;

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -87,6 +87,11 @@ public struct ReplicatorConfiguration {
     /// Specific network interface for connecting to the remote target.
     public var networkInterface: String?
     
+    /// (Volatile API : Will be removed in the release version)
+    /// Experiment to use bind() function to bind socket to the specified network interface
+    /// instead of setting the socket option.
+    public var experimentNetworkInterfaceUseBindFunction: Bool = false
+    
     /// A set of Sync Gateway channel names to pull from. Ignored for push
     /// replication. If unset, all accessible channels will be pulled.
     /// Note: channels that are not accessible to the user will be ignored by
@@ -214,6 +219,7 @@ public struct ReplicatorConfiguration {
         self.pinnedServerCertificate = config.pinnedServerCertificate
         self.headers = config.headers
         self.networkInterface = config.networkInterface
+        self.experimentNetworkInterfaceUseBindFunction = config.experimentNetworkInterfaceUseBindFunction
         self.channels = config.channels
         self.documentIDs = config.documentIDs
         self.conflictResolver = config.conflictResolver
@@ -244,6 +250,7 @@ public struct ReplicatorConfiguration {
         c.pinnedServerCertificate = self.pinnedServerCertificate
         c.headers = self.headers
         c.networkInterface = self.networkInterface;
+        c.experimentNetworkInterfaceUseBindFunction = self.experimentNetworkInterfaceUseBindFunction;
         c.channels = self.channels
         c.documentIDs = self.documentIDs
         c.pushFilter = self.filter(push: true)


### PR DESCRIPTION
* Added experimentNetworkInterfaceUseBindFunction option to the replicator configuration.

* In CBLWebSocket, use bind() function to bind network interface when experimentNetworkInterfaceUseBindFunction is enabled.