### PR TITLE
Generate XCFramework instead of FAT

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -1881,6 +1881,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A1CEC73291A573E003231EF /* generate_objc_release_zip.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate_objc_release_zip.sh; sourceTree = "<group>"; };
+		1A1CEC7F291A573E003231EF /* generate_swift_release_zip.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate_swift_release_zip.sh; sourceTree = "<group>"; };
 		1A2AB74522BBFD50000B9325 /* CBLConflictResolver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLConflictResolver.m; sourceTree = "<group>"; };
 		1A3470BF266F3E7C0042C6BA /* CBLIndexConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLIndexConfiguration.h; sourceTree = "<group>"; };
 		1A3470C0266F3E7C0042C6BA /* CBLIndexConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLIndexConfiguration.m; sourceTree = "<group>"; };
@@ -3218,6 +3220,8 @@
 				1A5E51D824AAC70E002E0341 /* pull_request_build.sh */,
 				9388CB9521BCDF8B005CA66D /* strip_frameworks.sh */,
 				9388CB9621BCDF8B005CA66D /* generate_release_zip.sh */,
+				1A1CEC73291A573E003231EF /* generate_objc_release_zip.sh */,
+				1A1CEC7F291A573E003231EF /* generate_swift_release_zip.sh */,
 				9367E86E24948C3F00775F97 /* xctest_crash_log.sh */,
 				1A967A5F251BF78400B70945 /* generate_package_manifest.sh */,
 			);

--- a/Scripts/generate_objc_release_zip.sh
+++ b/Scripts/generate_objc_release_zip.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+
+set -e
+
+function usage
+{
+  echo "Usage: ${0} -o <Output Directory> [-v <Version (<Version Number>[-<Build Number>])>]"
+  echo "\nOptions:"
+  echo "  --notest\t create a release package but no tests needs to be run"
+  echo "  --nocov\t create a release package, run tests but no code coverage zip"
+  echo "  --nodocs\t create a release package without API docs"
+}
+
+function checkCrashLogs
+{
+  echo "Check for xctest crash logs ..."
+  sh Scripts/xctest_crash_log.sh
+  exit 1
+}
+
+while [[ $# -gt 0 ]]
+do
+  key=${1}
+  case $key in
+      -v)
+      VERSION=${2}
+      shift
+      ;;
+      -o)
+      OUTPUT_DIR=${2}
+      shift
+      ;;
+      --EE)
+      EE=YES
+      ;;
+      --notest)
+      NO_TEST=YES
+      ;;
+      --nocov)
+      NO_COV=YES
+      ;;
+      --pretty)
+      PRETTY=YES
+      ;;
+      --nodocs)
+      NO_API_DOCS=YES
+      ;;
+      *)
+      usage
+      exit 3
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$OUTPUT_DIR" ]
+then
+  usage
+  exit 4
+fi
+
+if [ -z "$EE" ]
+then
+  SCHEME_PREFIX="CBL"
+  CONFIGURATION="Release"
+  CONFIGURATION_TEST="Debug"
+  COVERAGE_NAME="objc_coverage"
+  EDITION="community"
+else
+  SCHEME_PREFIX="CBL_EE"
+  CONFIGURATION="Release_EE"
+  CONFIGURATION_TEST="Debug_EE"
+  COVERAGE_NAME="objc_coverage-ee"
+  EDITION="enterprise"
+  EXTRA_CMD_OPTIONS="--EE"
+  OPTS="--EE"
+fi
+
+if [ -z "$PRETTY" ]
+then
+  XCPRETTY="cat"
+else
+  # Allow non-ascii text in output:
+  export LC_CTYPE=en_US.UTF-8
+  XCPRETTY="xcpretty"
+fi
+
+# Clean output directory:
+echo "Clean output directory: $OUTPUT_DIR"
+rm -rf "$OUTPUT_DIR"
+
+# Check xcodebuild version:
+echo "Check xcodebuild version ..."
+xcodebuild -version
+
+if [ -z "$NO_TEST" ] || [ -n "$TEST_ONLY" ]
+then
+  echo "Running unit tests ..."
+
+  echo "Check devices ..."
+  xcrun xctrace list devices
+
+  echo "Run ObjC macOS tests ..."
+  sh Scripts/xctest_crash_log.sh --delete-all
+  xcodebuild test \
+    -project CouchbaseLite.xcodeproj \
+    -scheme "${SCHEME_PREFIX}_ObjC" \
+    -configuration "$CONFIGURATION_TEST" \
+    -sdk macosx || checkCrashLogs
+  
+  # get the latest simulator
+  TEST_SIMULATOR=$(xcrun simctl list devicetypes | grep \.iPhone- | tail -1 |  sed  "s/ (com.apple.*//g")
+  
+  echo "Run ObjC iOS tests on ${TEST_SIMULATOR}..."
+  # iOS-App target runs Keychain-Accessing tests
+  sh Scripts/xctest_crash_log.sh --delete-all
+  xcodebuild clean test \
+    -project CouchbaseLite.xcodeproj \
+    -scheme "${SCHEME_PREFIX}_ObjC_Tests_iOS_App" \
+    -configuration "$CONFIGURATION_TEST" \
+    -sdk iphonesimulator \
+    -destination "platform=iOS Simulator,name=$TEST_SIMULATOR" \
+    -enableCodeCoverage YES || checkCrashLogs
+  
+  
+  if [ -z "$NO_COV" ]
+  then
+    # Objective-C:
+    echo "Generate coverage report for ObjC ..."
+    slather coverage --html \
+        --scheme "${SCHEME_PREFIX}_ObjC_Tests_iOS_App" \
+        --binary-basename "CouchbaseLite" \
+        --configuration "$CONFIGURATION_TEST" \
+        --ignore "vendor/*" --ignore "Swift/*" \
+        --ignore "Objective-C/Tests/*" --ignore "../Sources/Swift/*" \
+        --output-directory "$OUTPUT_DIR/$COVERAGE_NAME" \
+        --binary-basename "CouchbaseLite.framework"  \
+        --binary-basename "CBL_EE_Tests" \
+        CouchbaseLite.xcodeproj > /dev/null
+        
+        # Zip reports:
+        pushd "$OUTPUT_DIR" > /dev/null
+        zip -ry $COVERAGE_NAME.zip $COVERAGE_NAME/*
+        popd > /dev/null
+        rm -rf "$OUTPUT_DIR/$COVERAGE_NAME"
+  fi
+fi
+
+VERSION_SUFFIX=""
+if [ -n "$VERSION" ]
+then
+  VERSION_SUFFIX="_$VERSION"
+fi
+
+# Build frameworks:
+echo "Build CouchbaseLite release package..."
+
+BUILD_DIR=$OUTPUT_DIR/build
+
+OUTPUT_OBJC_XC_DIR=$OUTPUT_DIR/objc_xc_$EDITION
+OUTPUT_OBJC_XC_ZIP=../couchbase-lite-objc_xc_$EDITION$VERSION_SUFFIX.zip
+
+OUTPUT_DOCS_DIR=$OUTPUT_DIR/docs
+OUTPUT_OBJC_DOCS_DIR=$OUTPUT_DOCS_DIR/CouchbaseLite
+OUTPUT_OBJC_DOCS_ZIP=../../couchbase-lite-objc-documentation_$EDITION$VERSION_SUFFIX.zip
+
+echo "Building xcframework..."
+set -o pipefail && sh Scripts/build_xcframework.sh -s "${SCHEME_PREFIX}_ObjC" -c "$CONFIGURATION" -o "$BUILD_DIR" -v "$VERSION" $OPTS | $XCPRETTY
+
+echo "Make ObjC XCFramework zip file ..."
+mkdir -p "$OUTPUT_OBJC_XC_DIR"
+cp -R "$BUILD_DIR/xc/${SCHEME_PREFIX}_ObjC"/* "$OUTPUT_OBJC_XC_DIR"
+if [[ -n $WORKSPACE ]]; then
+  cp ${WORKSPACE}/product-texts/mobile/couchbase-lite/license/LICENSE_${EDITION}.txt "$OUTPUT_OBJC_XC_DIR"/LICENSE.txt
+fi
+pushd "$OUTPUT_OBJC_XC_DIR" > /dev/null
+zip -ry "$OUTPUT_OBJC_XC_ZIP" *
+popd > /dev/null
+
+if [[ -z $NO_API_DOCS ]]; then
+  # Generate API docs:
+  echo "Generate API docs ..."
+  OBJC_UMBRELLA_HEADER=`find $OUTPUT_OBJC_XC_DIR -name "CouchbaseLite.h"`
+  jazzy --clean --objc --umbrella-header ${OBJC_UMBRELLA_HEADER} --module CouchbaseLite --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLite
+  
+  # >> Objective-C API
+  pushd "$OUTPUT_OBJC_DOCS_DIR" > /dev/null
+  zip -ry "$OUTPUT_OBJC_DOCS_ZIP" *
+  popd > /dev/null
+fi
+
+# Cleanup
+rm -rf "$BUILD_DIR"
+rm -rf "$OUTPUT_OBJC_XC_DIR"
+rm -rf "$OUTPUT_DOCS_DIR"
+

--- a/Scripts/generate_swift_release_zip.sh
+++ b/Scripts/generate_swift_release_zip.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -e
+
+function usage
+{
+  echo "Usage: ${0} -o <Output Directory> [-v <Version (<Version Number>[-<Build Number>])>]"
+  echo "\nOptions:"
+  echo "  --notest\t create a release package but no tests needs to be run"
+  echo "  --nocov\t create a release package, run tests but no code coverage zip"
+  echo "  --nodocs\t create a release package without API docs"
+}
+
+function checkCrashLogs
+{
+  echo "Check for xctest crash logs ..."
+  sh Scripts/xctest_crash_log.sh
+  exit 1
+}
+
+while [[ $# -gt 0 ]]
+do
+  key=${1}
+  case $key in
+      -v)
+      VERSION=${2}
+      shift
+      ;;
+      -o)
+      OUTPUT_DIR=${2}
+      shift
+      ;;
+      --EE)
+      EE=YES
+      ;;
+      --notest)
+      NO_TEST=YES
+      ;;
+      --nocov)
+      NO_COV=YES
+      ;;
+      --pretty)
+      PRETTY=YES
+      ;;
+      --nodocs)
+      NO_API_DOCS=YES
+      ;;
+      *)
+      usage
+      exit 3
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$OUTPUT_DIR" ]
+then
+  usage
+  exit 4
+fi
+
+if [ -z "$EE" ]
+then
+  SCHEME_PREFIX="CBL"
+  CONFIGURATION="Release"
+  CONFIGURATION_TEST="Debug"
+  COVERAGE_NAME="swift_coverage"
+  EDITION="community"
+else
+  SCHEME_PREFIX="CBL_EE"
+  CONFIGURATION="Release_EE"
+  CONFIGURATION_TEST="Debug_EE"
+  COVERAGE_NAME="swift_coverage-ee"
+  EDITION="enterprise"
+  OPTS="--EE"
+fi
+
+if [ -z "$PRETTY" ]
+then
+  XCPRETTY="cat"
+else
+  # Allow non-ascii text in output:
+  export LC_CTYPE=en_US.UTF-8
+  XCPRETTY="xcpretty"
+fi
+
+# Clean output directory:
+echo "Clean output directory: $OUTPUT_DIR"
+rm -rf "$OUTPUT_DIR"
+
+# Check xcodebuild version:
+echo "Check xcodebuild version ..."
+xcodebuild -version
+
+if [ -z "$NO_TEST" ]
+then
+  echo "Running unit tests ..."
+
+  echo "Check devices ..."
+  xcrun xctrace list devices
+
+  echo "Run macOS tests ..."
+  xcodebuild test \
+    -project CouchbaseLite.xcodeproj \
+    -scheme "${SCHEME_PREFIX}_Swift" \
+    -configuration "$CONFIGURATION_TEST" \
+    -sdk macosx
+
+  # get the latest simulator
+  TEST_SIMULATOR=$(xcrun simctl list devicetypes | grep \.iPhone- | tail -1 |  sed  "s/ (com.apple.*//g")
+  echo "Run Swift iOS tests on ${TEST_SIMULATOR}..."
+  
+  xcodebuild clean test \
+    -project CouchbaseLite.xcodeproj \
+    -scheme "${SCHEME_PREFIX}_Swift_Tests_iOS_App" \
+    -configuration "$CONFIGURATION_TEST" \
+    -sdk iphonesimulator \
+    -destination "platform=iOS Simulator,name=$TEST_SIMULATOR" \
+    -enableCodeCoverage YES
+  
+  # Generage Code Coverage Reports:
+  if [ -z "$NO_COV" ]
+  then
+    # Swift:
+    echo "Generate coverage report for Swift ..."
+    slather coverage --html \
+        --scheme "${SCHEME_PREFIX}_Swift_Tests_iOS_App" \
+        --binary-basename "CouchbaseLiteSwift" \
+        --configuration "$CONFIGURATION_TEST"  \
+        --ignore "vendor/*" --ignore "Objective-C/*" \
+        --ignore "Swift/Tests/*" --ignore "../Sources/Objective-C/*" \
+        --output-directory "$OUTPUT_DIR/$COVERAGE_NAME" \
+        CouchbaseLite.xcodeproj > /dev/null
+    
+    # Zip reports:
+    pushd "$OUTPUT_DIR" > /dev/null
+    zip -ry $COVERAGE_NAME.zip $COVERAGE_NAME/*
+    popd > /dev/null
+    rm -rf "$OUTPUT_DIR/$COVERAGE_NAME"
+  fi
+fi
+
+VERSION_SUFFIX=""
+if [ -n "$VERSION" ]
+then
+  VERSION_SUFFIX="_$VERSION"
+fi
+
+# Build frameworks:
+echo "Build CouchbaseLite release package..."
+
+BUILD_DIR=$OUTPUT_DIR/build
+
+OUTPUT_SWIFT_XC_DIR=$OUTPUT_DIR/swift_xc_$EDITION
+OUTPUT_SWIFT_XC_ZIP=../couchbase-lite-swift_xc_$EDITION$VERSION_SUFFIX.zip
+
+OUTPUT_DOCS_DIR=$OUTPUT_DIR/docs
+OUTPUT_SWIFT_DOCS_DIR=$OUTPUT_DOCS_DIR/CouchbaseLiteSwift
+OUTPUT_SWIFT_DOCS_ZIP=../../couchbase-lite-swift-documentation_$EDITION$VERSION_SUFFIX.zip
+
+echo "Building xcframework..."
+set -o pipefail && sh Scripts/build_xcframework.sh -s "${SCHEME_PREFIX}_Swift" -c "$CONFIGURATION" -o "$BUILD_DIR" -v "$VERSION" $OPTS | $XCPRETTY
+
+echo "Make Swift xcframework zip file ..."
+mkdir -p "$OUTPUT_SWIFT_XC_DIR"
+cp -R "$BUILD_DIR/xc/${SCHEME_PREFIX}_Swift"/* "$OUTPUT_SWIFT_XC_DIR"
+if [[ -n $WORKSPACE ]]; then
+  cp ${WORKSPACE}/product-texts/mobile/couchbase-lite/license/LICENSE_${EDITION}.txt "$OUTPUT_SWIFT_XC_DIR"/LICENSE.txt
+fi
+pushd "$OUTPUT_SWIFT_XC_DIR" > /dev/null
+zip -ry "$OUTPUT_SWIFT_XC_ZIP" *
+popd > /dev/null
+
+# Generate swift checksum file:
+echo "Generate swift package checksum..."
+sh Scripts/generate_package_manifest.sh -zip-path "$OUTPUT_DIR/couchbase-lite-swift_xc_$EDITION$VERSION_SUFFIX.zip" -o $OUTPUT_DIR $OPTS
+
+if [[ -z $NO_API_DOCS ]]; then
+  # Generate API docs:
+  echo "Generate API docs ..."
+  jazzy --clean --xcodebuild-arguments "clean,build,-scheme,${SCHEME_PREFIX}_Swift,-sdk,iphonesimulator,-destination,generic/platform=iOS Simulator" --module CouchbaseLiteSwift --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLiteSwift
+  
+  # >> Swift API docs
+  pushd "$OUTPUT_SWIFT_DOCS_DIR" > /dev/null
+  zip -ry "$OUTPUT_SWIFT_DOCS_ZIP" *
+  popd > /dev/null
+fi
+
+# Cleanup
+rm -rf "$BUILD_DIR"
+rm -rf "$OUTPUT_SWIFT_XC_DIR"
+rm -rf "$OUTPUT_DOCS_DIR"
+


### PR DESCRIPTION
* Generate XCFramework instead of FAT binary
* Pointed the Helium scripts 
  1. Scripts/build_xcframework.sh 
  2. Scripts/generate_objc_release_zip.sh 
  3. Scripts/generate_swift_release_zip.sh
* Updated the generate_release_script to use the above 2nd & 3rd. 