### PR TITLE
more fixes

### DIFF
--- a/Objective-C/Tests/MessageEndpointTest.m
+++ b/Objective-C/Tests/MessageEndpointTest.m
@@ -184,7 +184,8 @@ MCSessionDelegate, CBLMessageEndpointDelegate, MultipeerConnectionDelegate>
     _browser.delegate = self;
     [_browser startBrowsingForPeers];
     
-    [self waitForExpectations: @[_clientConnected, _serverConnected] timeout: 10.0];
+    // cool down period(disconnected to next connected state), is taking around 4-10secs
+    [self waitForExpectations: @[_clientConnected, _serverConnected] timeout: 30.0];
 }
 
 - (void) run: (CBLReplicatorConfiguration*)config

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -842,7 +842,8 @@
     __block int ccrCount = 0;
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
         int c = ccrCount;
-        if (ccrCount++ == 0) {
+        ccrCount++;
+        if (c == 0) {
             // 2
             [expCCR fulfill];
             [self waitForExpectations: @[expFirstDocResolve] timeout: 5.0];

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -267,23 +267,6 @@
     r = nil;
 }
 
-// Runs -testStopContinuousReplicator over and over again indefinitely. (Disabled, obviously)
-- (void) _testStopContinuousReplicatorForever {
-    for (int i = 0; true; i++) {
-        @autoreleasepool {
-            Log(@"**** Begin iteration %d ****", i);
-            @autoreleasepool {
-                [self testStopContinuousReplicator];
-            }
-            Log(@"**** End iteration %d ****", i);
-            fprintf(stderr, "\n\n");
-            [self tearDown];
-            [NSThread sleepForTimeInterval: 1.0];
-            [self setUp];
-        }
-    }
-}
-
 - (void) testPushBlob {
     NSError* error;
     CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -235,7 +235,8 @@
     AssertNil([self.db documentWithID: doc1.id]);
 }
 
-- (void) testStopContinuousReplicator {
+// TODO: https://issues.couchbase.com/browse/CBL-3878
+- (void) _testStopContinuousReplicator {
     id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
     id config = [self configWithTarget: target type: kCBLReplicatorTypePushAndPull continuous: YES];
     CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];

--- a/Swift/Tests/MessageEndpointTest.swift
+++ b/Swift/Tests/MessageEndpointTest.swift
@@ -136,7 +136,8 @@ MultipeerConnectionDelegate {
         browser!.delegate = self
         browser!.startBrowsingForPeers()
         
-        self.wait(for: [clientConnected!, serverConnected!], timeout: 10.0)
+        // cool down period(disconnected to next connected state), is taking around 4-10secs
+        self.wait(for: [clientConnected!, serverConnected!], timeout: 30.0)
     }
     
     func run(config: ReplicatorConfiguration, expectedError: Int?) {


### PR DESCRIPTION
* disable the test
* minor test fix to avoid race with variable ccrCount
* cherry-pick the Helium changes - 30secs timeout for MessageEndpoint tests