### PR TITLE
CBL-3912: Use acceptOnlyServerSelfSign from defaults file

### DIFF
--- a/Objective-C/CBLDefaults.h
+++ b/Objective-C/CBLDefaults.h
@@ -64,6 +64,9 @@ extern const NSTimeInterval kCBLDefaultReplicatorMaxAttemptWaitTime;
 /** [YES] Purge documents when a user loses access */
 extern const BOOL kCBLDefaultReplicatorEnableAutoPurge;
 
+/** [NO] Whether or not a replicator only accepts self-signed certificates from the remote */
+extern const BOOL kCBLDefaultReplicatorSelfSignedCertificateOnly;
+
 #pragma mark - CBLURLEndpointListenerConfiguration
 
 /** [0] No port specified, the OS will assign one */

--- a/Objective-C/CBLDefaults.m
+++ b/Objective-C/CBLDefaults.m
@@ -43,6 +43,7 @@ const NSUInteger kCBLDefaultReplicatorMaxAttemptsSingleShot = 10;
 const NSUInteger kCBLDefaultReplicatorMaxAttemptsContinuous = NSUIntegerMax;
 const NSTimeInterval kCBLDefaultReplicatorMaxAttemptWaitTime = 300;
 const BOOL kCBLDefaultReplicatorEnableAutoPurge = YES;
+const BOOL kCBLDefaultReplicatorSelfSignedCertificateOnly = NO;
 
 #pragma mark - CBLURLEndpointListenerConfiguration
 

--- a/Objective-C/CBLReplicatorConfiguration.m
+++ b/Objective-C/CBLReplicatorConfiguration.m
@@ -62,7 +62,7 @@
     if (self) {
         _replicatorType = kCBLDefaultReplicatorType;
     #ifdef COUCHBASE_ENTERPRISE
-        _acceptOnlySelfSignedServerCertificate = NO;
+        _acceptOnlySelfSignedServerCertificate = kCBLDefaultReplicatorSelfSignedCertificateOnly;
     #endif
         _continuous = kCBLDefaultReplicatorContinuous;
         _heartbeat = kCBLDefaultReplicatorHeartbeat;

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -2037,6 +2037,9 @@
                                                          type: kCBLReplicatorTypePush
                                                    continuous: YES];
     AssertEqual(temp.heartbeat, kCBLDefaultReplicatorHeartbeat);
+#ifdef COUCHBASE_ENTERPRISE
+    AssertEqual(temp.acceptOnlySelfSignedServerCertificate, kCBLDefaultReplicatorSelfSignedCertificateOnly);
+#endif
     
     [temp setContinuous: YES];
     [temp setAuthenticator: basic];
@@ -2051,6 +2054,10 @@
                              @"someObject", @"someKey", nil];
     [temp setHeaders: headers];
     
+#ifdef COUCHBASE_ENTERPRISE
+    [temp setAcceptOnlySelfSignedServerCertificate: true];
+#endif
+    
     SecCertificateRef cert = [self defaultServerCert];
     [temp setPinnedServerCertificate: cert];
     CBLReplicatorConfiguration* config = [[CBLReplicatorConfiguration alloc] initWithConfig: temp];
@@ -2064,6 +2071,10 @@
     AssertEqualObjects(docIds, config.documentIDs);
     AssertEqualObjects(channels, config.channels);
     AssertEqual(config.heartbeat, kCBLDefaultReplicatorHeartbeat);
+#ifdef COUCHBASE_ENTERPRISE
+    AssertEqual(temp.acceptOnlySelfSignedServerCertificate, YES);
+#endif
+
 }
 
 - (void) testReplicatorConfigDefaultValues {

--- a/Swift/Defaults.swift
+++ b/Swift/Defaults.swift
@@ -65,6 +65,9 @@ public extension ReplicatorConfiguration {
 	/// [true] Purge documents when a user loses access
 	static let defaultEnableAutoPurge: Bool = kCBLDefaultReplicatorEnableAutoPurge.boolValue
 
+	/// [false] Whether or not a replicator only accepts self-signed certificates from the remote
+	static let defaultSelfSignedCertificateOnly: Bool = kCBLDefaultReplicatorSelfSignedCertificateOnly.boolValue
+
 }
 
 #if COUCHBASE_ENTERPRISE
@@ -84,5 +87,6 @@ public extension URLEndpointListenerConfiguration {
 
 }
 
-#endif 
+#endif
+
 

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -89,7 +89,8 @@ public struct ReplicatorConfiguration {
     #if COUCHBASE_ENTERPRISE
     /// Specify the replicator to accept any and only self-signed certs. Any non-self-signed certs will be rejected
     /// to avoid accidentally using this mode with the non-self-signed certs in production.
-    public var acceptOnlySelfSignedServerCertificate: Bool = false
+    /// Default value is ``ReplicatorConfiguration.defaultSelfSignedCertificateOnly``
+    public var acceptOnlySelfSignedServerCertificate: Bool = ReplicatorConfiguration.defaultSelfSignedCertificateOnly
     #endif
     
     /// The remote target's SSL certificate.

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1304,7 +1304,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertEqual(config.replicatorType, ReplicatorConfiguration.defaultType)
         XCTAssertEqual(config.enableAutoPurge, ReplicatorConfiguration.defaultEnableAutoPurge)
 #if os(iOS)
-        XCTAssertEqual(config.defaultAllowReplicatingInBackground, ReplicatorConfiguration.defaultAllowReplicatingInBackground)
+        XCTAssertEqual(config.allowReplicatingInBackground, ReplicatorConfiguration.defaultAllowReplicatingInBackground)
 #endif
         
         repl = Replicator(config: config)
@@ -1319,7 +1319,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertEqual(repl.config.replicatorType, ReplicatorConfiguration.defaultType)
         XCTAssertEqual(repl.config.enableAutoPurge, ReplicatorConfiguration.defaultEnableAutoPurge)
 #if os(iOS)
-        XCTAssertEqual(repl.config.defaultAllowReplicatingInBackground, ReplicatorConfiguration.defaultAllowReplicatingInBackground)
+        XCTAssertEqual(repl.config.allowReplicatingInBackground, ReplicatorConfiguration.defaultAllowReplicatingInBackground)
 #endif
     }
 }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1285,22 +1285,42 @@ class ReplicatorTest_Main: ReplicatorTest {
         let target = URLEndpoint(url: URL(string: "ws://foo.couchbase.com/db")!)
         let config = ReplicatorConfiguration(database: oDB, target: target)
         
-        #if COUCHBASE_ENTERPRISE
-        XCTAssertFalse(config.acceptOnlySelfSignedServerCertificate)
-        #endif
+#if COUCHBASE_ENTERPRISE
+        XCTAssertEqual(config.acceptOnlySelfSignedServerCertificate, ReplicatorConfiguration.defaultSelfSignedCertificateOnly)
+#endif
         XCTAssertNil(config.authenticator)
         XCTAssertNil(config.channels)
         XCTAssertNil(config.conflictResolver)
-        XCTAssertFalse(config.continuous)
         XCTAssertNil(config.documentIDs)
         XCTAssertNil(config.headers)
-        XCTAssertEqual(config.heartbeat, ReplicatorConfiguration.defaultHeartbeat)
-        XCTAssertEqual(config.maxAttempts, ReplicatorConfiguration.defaultMaxAttemptsSingleShot)
-        XCTAssertEqual(config.maxAttemptWaitTime, ReplicatorConfiguration.defaultMaxAttemptWaitTime)
         XCTAssertNil(config.pinnedServerCertificate)
         XCTAssertNil(config.pullFilter)
         XCTAssertNil(config.pushFilter)
-        XCTAssertEqual(config.replicatorType, .pushAndPull)
+        
+        XCTAssertEqual(config.continuous, ReplicatorConfiguration.defaultContinuous)
+        XCTAssertEqual(config.heartbeat, ReplicatorConfiguration.defaultHeartbeat)
+        XCTAssertEqual(config.maxAttempts, ReplicatorConfiguration.defaultMaxAttemptsSingleShot)
+        XCTAssertEqual(config.maxAttemptWaitTime, ReplicatorConfiguration.defaultMaxAttemptWaitTime)
+        XCTAssertEqual(config.replicatorType, ReplicatorConfiguration.defaultType)
+        XCTAssertEqual(config.enableAutoPurge, ReplicatorConfiguration.defaultEnableAutoPurge)
+#if os(iOS)
+        XCTAssertEqual(config.defaultAllowReplicatingInBackground, ReplicatorConfiguration.defaultAllowReplicatingInBackground)
+#endif
+        
+        repl = Replicator(config: config)
+        
+#if COUCHBASE_ENTERPRISE
+        XCTAssertEqual(repl.config.acceptOnlySelfSignedServerCertificate, ReplicatorConfiguration.defaultSelfSignedCertificateOnly)
+#endif
+        XCTAssertEqual(repl.config.continuous, ReplicatorConfiguration.defaultContinuous)
+        XCTAssertEqual(repl.config.heartbeat, ReplicatorConfiguration.defaultHeartbeat)
+        XCTAssertEqual(repl.config.maxAttempts, ReplicatorConfiguration.defaultMaxAttemptsSingleShot)
+        XCTAssertEqual(repl.config.maxAttemptWaitTime, ReplicatorConfiguration.defaultMaxAttemptWaitTime)
+        XCTAssertEqual(repl.config.replicatorType, ReplicatorConfiguration.defaultType)
+        XCTAssertEqual(repl.config.enableAutoPurge, ReplicatorConfiguration.defaultEnableAutoPurge)
+#if os(iOS)
+        XCTAssertEqual(repl.config.defaultAllowReplicatingInBackground, ReplicatorConfiguration.defaultAllowReplicatingInBackground)
+#endif
     }
 }
 


### PR DESCRIPTION
* Add the acceptOnlySelfSignedCert from defaults file. 
* Update the latest Defaults file as well
* Unit test updated to include the new default value