### PR TITLE
Fix DNS Service, Socket Connect and Cleanup

### DIFF
--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -38,9 +38,9 @@ typedef NS_ENUM(NSUInteger, CBLReplicatorType) {
 /** Network Interface experimental type. */
 typedef NS_ENUM(NSUInteger, CBLNetworkInterfaceExperimentalType) {
     kCBLNetworkInterfaceExperimentalTypeNone = 0,
-    kCBLNetworkInterfaceExperimentalTypeUseBindFunction,        /// use bind() function to bind socket to the specified network interface.
+    kCBLNetworkInterfaceExperimentalTypeUseDNSService,          /// use the DNSServiceGetAddrInfo function to resolve the DNS
     kCBLNetworkInterfaceExperimentalTypeUseNetworkFramework,    /// use network framework to specify the network interface.
-    kCBLNetworkInterfaceExperimentalTypeUseDNSService           /// use the DNSServiceGetAddrInfo function to resolve the DNS
+    kCBLNetworkInterfaceExperimentalTypeUseBindFunction         /// use bind() function to bind socket to the specified network interface.
 };
 
 /** Replication Filter */

--- a/Objective-C/Internal/Replicator/CBLDNSService.h
+++ b/Objective-C/Internal/Replicator/CBLDNSService.h
@@ -1,8 +1,20 @@
 //
-//  DNSResolver.h
-//  TestDNSService
+//  CBLDNSService.h
+//  CouchbaseLite
 //
-//  Created by Pasin Suriyentrakorn on 12/4/22.
+//  Copyright (c) 2022 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>
@@ -17,8 +29,15 @@ typedef NS_ENUM(NSUInteger, IPType) {
 @interface AddressInfo : NSObject
 
 @property (nonatomic, readonly) const struct sockaddr* addr;
-@property (nonatomic, readonly) NSString* addrstr; // For debugging or logging
+@property (nonatomic, readonly) const struct sockaddr_in* addrIn;
+@property (nonatomic, readonly) const struct sockaddr_in6* addrIn6;
+
+@property (nonatomic, readonly) NSString* addrstr;
 @property (nonatomic, readonly) IPType type;
+
+@property (nonatomic, readonly) NSString* host;
+@property (nonatomic, readonly) UInt16 port;
+@property (nonatomic, readonly) UInt32 interface;
 
 @end
 
@@ -27,9 +46,12 @@ typedef NS_ENUM(NSUInteger, IPType) {
 - (void) didResolveFailWithError: (NSError*)error;
 @end
 
-@interface CBLDNSResolver : NSObject
+@interface CBLDNSService : NSObject
 
-- (instancetype) initWithHost: (NSString*)host interface: (uint32_t)interface port: (UInt16)port delegate: (id<DNSServiceDelegate>)delegate;
+- (instancetype) initWithHost: (NSString*)host
+                    interface: (UInt32)interface
+                         port: (UInt16)port
+                     delegate: (id<DNSServiceDelegate>)delegate;
 - (void) start;
 - (void) stop;
 

--- a/Objective-C/Internal/Replicator/CBLDNSService.mm
+++ b/Objective-C/Internal/Replicator/CBLDNSService.mm
@@ -1,8 +1,20 @@
 //
-//  DNSService.mm
-//  TestDNSService
+//  CBLDNSService.mm
+//  CouchbaseLite
 //
-//  Created by Pasin Suriyentrakorn on 12/4/22.
+//  Copyright (c) 2022 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "CBLDNSService.h"
@@ -11,7 +23,12 @@
 #import <netdb.h>
 
 @interface AddressInfo ()
-- (instancetype) initWithAddress: (const struct sockaddr*)addr string: (NSString*)addrstr port: (UInt16)port type: (IPType)type;
+- (instancetype) initWithAddress: (const struct sockaddr*)addr
+                         addrstr: (NSString*)addrstr
+                            type: (IPType)type
+                            host: (NSString*)host
+                            port: (UInt16)port
+                       interface: (UInt32)interface;
 @end
 
 @implementation AddressInfo {
@@ -21,26 +38,35 @@
 @synthesize addrstr=_addrstr;
 @synthesize type=_type;
 
+@synthesize host=_host;
+@synthesize port=_port;
+@synthesize interface=_interface;
+
 - (instancetype) initWithAddress: (const struct sockaddr*)addr
-                          string: (NSString*)addrstr
+                         addrstr: (NSString*)addrstr
+                            type: (IPType)type
+                            host: (NSString*)host
                             port: (UInt16)port
-                            type: (IPType)type {
+                       interface: (UInt32)interface {
     self = [super init];
     if (self) {
-        if (type == kIPv4) {
-            const struct sockaddr_in *addr_in = (const struct sockaddr_in*)addr;
-            struct sockaddr_in addr2 = {
-                .sin_len    = sizeof(struct sockaddr_in),
-                .sin_family = AF_INET,
-                .sin_port   = htons(port),
-                .sin_addr   = {htonl(addr_in->sin_addr.s_addr)} };
-            _addr = [NSMutableData dataWithBytes: &addr2 length: sizeof(struct sockaddr_in)];
-        } else {
-            const struct sockaddr_in6* addrIn = reinterpret_cast<const struct sockaddr_in6*>(addr);
-            _addr = [NSMutableData dataWithBytes: addrIn length: sizeof(struct sockaddr_in6)];
+        if (self) {
+            struct sockaddr* mAddr = const_cast<struct sockaddr*>(addr);
+            if (type == kIPv4) {
+                struct sockaddr_in* addrIn = reinterpret_cast<struct sockaddr_in*>(mAddr);
+                addrIn->sin_port = htons(port);
+                _addr = [NSMutableData dataWithBytes: addrIn length: sizeof(struct sockaddr_in)];
+            } else {
+                struct sockaddr_in6* addrIn = reinterpret_cast<struct sockaddr_in6*>(mAddr);
+                addrIn->sin6_port = htons(port);
+                _addr = [NSMutableData dataWithBytes: addrIn length: sizeof(struct sockaddr_in6)];
+            }
+            _addrstr = addrstr;
+            _type = type;
+            _host = host;
+            _port = port;
+            _interface = interface;
         }
-        _addrstr = addrstr;
-        _type = type;
     }
     return self;
 }
@@ -49,8 +75,17 @@
     return (const struct sockaddr *)_addr.bytes;
 }
 
+- (const struct sockaddr_in*) addrIn {
+    return reinterpret_cast<const struct sockaddr_in*>(self.addr);
+}
+
+- (const struct sockaddr_in6*) addrIn6 {
+    return reinterpret_cast<const struct sockaddr_in6*>(self.addr);
+}
+
 - (NSString*) description {
-    return [NSString stringWithFormat: @"[%@],isIPv4=%d, %@", _addrstr, _type == 0, _addr];
+    return [NSString stringWithFormat: @"%@ (%@, %d, %d, %lu)",
+            _addrstr, _host, _port, _interface, (unsigned long)_type];
 }
 
 @end
@@ -58,9 +93,9 @@
 #define kTimeoutInterval 10.0
 #define kWaitingInterval 0.5
 
-@implementation CBLDNSResolver {
+@implementation CBLDNSService {
     NSString* _host;
-    uint32_t _interface;
+    UInt32 _interface;
     id<DNSServiceDelegate> _delegate;
     
     DNSServiceRef _dnsServiceRef;
@@ -72,13 +107,16 @@
     AddressInfo* _ipV6;
     DNSServiceErrorType _ipV6err;
     
-    NSTimer* _timeoutTimer;
-    NSTimer* _waitTimer;
+    dispatch_block_t _timeoutBlock;
+    dispatch_block_t _waitingBlock;
     
     UInt16 _port;
 }
 
-- (instancetype) initWithHost: (NSString*)host interface: (uint32_t)interface port: (UInt16)port delegate: (id<DNSServiceDelegate>)delegate {
+- (instancetype) initWithHost: (NSString*)host
+                    interface: (UInt32)interface
+                         port: (UInt16)port
+                     delegate: (id<DNSServiceDelegate>)delegate {
     self = [super init];
     if (self) {
         _host = host;
@@ -101,16 +139,19 @@
         if (_dnsServiceRef)
             return;
         
+        if ([self checkAlreadyIPAddress])
+            return;
+        
         _ipV4 = nil;
         _ipV4err = kDNSServiceErr_NoError;
         
         _ipV6 = nil;
         _ipV6err = kDNSServiceErr_NoError;
         
-        NSLog(@"Resolving %@ ...", _host);
+        CBLLogVerbose(WebSocket, @"%@: Looking up '%@' on interface index '%d'", self, _host, _interface);
         
         const char* cHost = [_host cStringUsingEncoding: NSUTF8StringEncoding];
-        DNSServiceFlags flags = kDNSServiceFlagsReturnIntermediates | kDNSServiceFlagsTimeout;
+        DNSServiceFlags flags = kDNSServiceFlagsReturnIntermediates;
         DNSServiceProtocol protocol = kDNSServiceProtocol_IPv4 | kDNSServiceProtocol_IPv6;
         DNSServiceErrorType result = DNSServiceGetAddrInfo(&_dnsServiceRef, flags, _interface, protocol,
                                                            cHost, getAddrInfoCallback, (__bridge void*)self);
@@ -120,18 +161,61 @@
         }
         
         if (result != kDNSServiceErr_NoError) {
-            [self notifyError: result];
+            dispatch_async(_dnsQueue, ^{
+                [self notifyError: result];
+            });
+            return;
         }
         
-        [_timeoutTimer invalidate];
-        _timeoutTimer = [NSTimer scheduledTimerWithTimeInterval: kTimeoutInterval
-                                                        repeats: NO
-                                                          block: ^(NSTimer * _Nonnull timer) {
-            @synchronized (self) {
-                [self notifyError: kDNSServiceErr_Timeout];
-            }
-        }];
+        if (!_timeoutBlock) {
+            _timeoutBlock = dispatch_block_create(DISPATCH_BLOCK_ASSIGN_CURRENT, ^{
+                @synchronized (self) {
+                    CBLWarnError(WebSocket, @"%@: Looking up '%@' timeout", self, _host);
+                    [self notifyError: kDNSServiceErr_Timeout];
+                }
+            });
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kTimeoutInterval * NSEC_PER_SEC)),
+                           _dnsQueue, _timeoutBlock);
+        }
     }
+}
+
+- (BOOL) checkAlreadyIPAddress {
+    AddressInfo* info;
+    
+    const char* cHost = [_host cStringUsingEncoding: NSUTF8StringEncoding];
+    
+    struct sockaddr_in addrV4;
+    if (inet_pton(AF_INET, cHost, &addrV4.sin_addr) == 1) {
+        addrV4.sin_family = AF_INET;
+        info = [[AddressInfo alloc] initWithAddress: (const struct sockaddr*)&addrV4
+                                            addrstr: _host
+                                               type: kIPv4
+                                               host: _host
+                                               port: _port
+                                          interface: _interface];
+    }
+
+    if (!info) {
+        struct sockaddr_in6 addrV6;
+        if (inet_pton(AF_INET6, cHost, &addrV6.sin6_addr) == 1) {
+            addrV6.sin6_family = AF_INET6;
+            info = [[AddressInfo alloc] initWithAddress: (const struct sockaddr*)&addrV6
+                                                addrstr: _host
+                                                   type: kIPv6
+                                                   host: _host
+                                                   port: _port
+                                              interface: _interface];
+        }
+    }
+    
+    if (info) {
+        dispatch_async(_dnsQueue, ^{
+            [_delegate didResolveSuccessWithAddress: info];
+        });
+        return true;
+    }
+    return false;
 }
 
 static void getAddrInfoCallback(DNSServiceRef sdref,
@@ -143,7 +227,7 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
                                 uint32_t ttl,
                                 void *context)
 {
-    CBLDNSResolver* resolver = (__bridge CBLDNSResolver*)context;
+    CBLDNSService* resolver = (__bridge CBLDNSService*)context;
     [resolver didResolveAddressWithDNSService: sdref address: address flags: flags error: errorCode];
 }
 
@@ -160,17 +244,19 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
         
         if (errorCode != kDNSServiceErr_NoError) {
             if (address->sa_family != AF_INET && address->sa_family != AF_INET6 && !moreComing) {
-                NSLog(@"DNS Service Error : %d", errorCode);
+                CBLLogVerbose(WebSocket, @"%@: Received error %@", self, [self errorInfo: errorCode]);
                 [self notifyError: errorCode];
                 return;
             }
             
             if (address->sa_family == AF_INET && !_ipV4) {
                 _ipV4err = errorCode;
-                NSLog(@"IPv4 Error : %d", errorCode);
+                CBLLogVerbose(WebSocket, @"%@: Received error %@ from querying IPv4 record",
+                              self, [self errorInfo: errorCode]);
             } else if (!_ipV6) {
                 _ipV6err = errorCode;
-                NSLog(@"IPv6 Error : %d", errorCode);
+                CBLLogVerbose(WebSocket, @"%@: Received error %@ from querying IPv6 record",
+                              self, [self errorInfo: errorCode]);
             }
             
             if (!moreComing) {
@@ -180,19 +266,22 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
         }
         
         if (address->sa_family != AF_INET && address->sa_family != AF_INET6) {
-            NSLog(@"Skip : Address is not either ipv4 or ipv6");
             return;
         }
         
         BOOL isValid = flags & kDNSServiceFlagsAdd;
         if (!isValid) {
-            NSLog(@"Skip : Address is not valid");
             return;
         }
         
         NSString* addrstr = [self addrstr: address];
         IPType type = address->sa_family == AF_INET ? kIPv4 : kIPv6;
-        AddressInfo* info = [[AddressInfo alloc] initWithAddress: address string: addrstr port: _port type: type];
+        AddressInfo* info = [[AddressInfo alloc] initWithAddress: address
+                                                         addrstr: addrstr
+                                                            type: type
+                                                            host: _host
+                                                            port: _port
+                                                       interface: _interface];
         if (type == kIPv4) {
             _ipV4 = info;
             _ipV4err = kDNSServiceErr_NoError;
@@ -201,9 +290,9 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
             _ipV6err = kDNSServiceErr_NoError;
         }
         
-        NSLog(@"Found Address : %@", addrstr);
-        NSLog(@"  IP Type : %@", type == kIPv4 ? @"IPv4" : @"IPv6");
-        NSLog(@"  More Coming? : %@", moreComing ? @"YES" : @"NO");
+        CBLLogVerbose(WebSocket, @"%@: Found address : %@", self, addrstr);
+        CBLLogVerbose(WebSocket, @"%@:   Type : %@", self, type == kIPv4 ? @"IPv4" : @"IPv6");
+        CBLLogVerbose(WebSocket, @"%@:   More Coming? : %@", self, moreComing ? @"YES" : @"NO");
         
         if (!moreComing) {
             [self checkResult];
@@ -219,15 +308,15 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
         if (_ipV4err == kDNSServiceErr_NoSuchRecord) {
             [self notifyResult];
         } else {
-            // Wait for 500ms to see if there is ipv4 address coming:
-            if (!_waitTimer) {
-                _waitTimer = [NSTimer scheduledTimerWithTimeInterval: kWaitingInterval
-                                                             repeats: false
-                                                               block: ^(NSTimer *timer) {
+            // Wait to see if there is ipv4 address coming:
+            if (!_waitingBlock) {
+                _waitingBlock = dispatch_block_create(DISPATCH_BLOCK_ASSIGN_CURRENT, ^{
                     @synchronized (self) {
                         [self notifyResult];
                     }
-                }];
+                });
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kWaitingInterval * NSEC_PER_SEC)),
+                               _dnsQueue, _waitingBlock);
             }
         }
     } else {
@@ -244,11 +333,15 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
             _dnsServiceRef = NULL;
         }
         
-        [_waitTimer invalidate];
-        _waitTimer = nil;
+        if (_waitingBlock) {
+            dispatch_cancel(_waitingBlock);
+            _waitingBlock = nil;
+        }
         
-        [_timeoutTimer invalidate];
-        _timeoutTimer = nil;
+        if (_timeoutBlock) {
+            dispatch_cancel(_timeoutBlock);
+            _timeoutBlock = nil;
+        }
     }
 }
 
@@ -268,6 +361,17 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
     return addrstr;
 }
 
+- (NSString*) errorInfo: (DNSServiceErrorType)errorCode {
+    NSString* desc;
+    if (errorCode == kDNSServiceErr_NoSuchRecord)
+        desc = @"NoSuchRecord";
+    
+    if (desc)
+        return [NSString stringWithFormat: @"%d (%@)", errorCode, desc];
+    else
+        return [NSString stringWithFormat: @"%d", errorCode];
+}
+
 - (void) notifyResult {
     if (!_dnsServiceRef) {
         return;
@@ -279,7 +383,6 @@ static void getAddrInfoCallback(DNSServiceRef sdref,
         return;
     }
     
-    NSLog(@"Notify Result : %@", info.addrstr);
     [_delegate didResolveSuccessWithAddress: info];
     [self stop];
 }

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -18,28 +18,33 @@
 //
 
 #import "CBLWebSocket.h"
+
+#import "CBLDNSService.h"
 #import "CBLHTTPLogic.h"
 #import "CBLTrustCheck.h"
+
 #import "CBLCoreBridge.h"
-#import "CBLStatus.h"
 #import "CBLReplicatorConfiguration.h"  // for the options constants
 #import "CBLReplicator+Internal.h"
 #import "CBLDatabase+Internal.h"
+#import "CBLStatus.h"
+#import "CBLStringBytes.h"
+#import "CBLURLEndpoint.h"
+
 #import "c4Socket.h"
-#import "MYURLUtils.h"
 #import "fleece/Fleece.hh"
+
+#import "CollectionUtils.h"
+#import "MYURLUtils.h"
+
 #import <CommonCrypto/CommonDigest.h>
-#import <dispatch/dispatch.h>
-#import <memory>
-#import <net/if.h>
+
 #import <arpa/inet.h>
 #import <ifaddrs.h>
+#import <memory>
+#import <net/if.h>
 #import <netdb.h>
 #import <vector>
-#import "CollectionUtils.h"
-#import "CBLURLEndpoint.h"
-#import "CBLStringBytes.h"
-#import "CBLDNSService.h"
 
 #ifdef COUCHBASE_ENTERPRISE
 #import "CBLCert.h"
@@ -112,7 +117,7 @@ struct PendingWrite {
     struct addrinfo* _addr;
     dispatch_queue_t _socketConnectQueue;
     
-    CBLDNSResolver* _dnsResolver;
+    CBLDNSService* _dnsService;
 }
 
 @synthesize sockfd=_sockfd;
@@ -223,7 +228,7 @@ static void doDispose(C4Socket* s) {
 }
 
 - (void) dealloc {
-    CBLLogVerbose(WebSocket, @"DEALLOC %@", self);
+    CBLLogVerbose(WebSocket, @"%@: DEALLOC ...", self);
     Assert(!_in);
     Assert(_sockfd < 0);
     free(_readBuffer);
@@ -234,7 +239,7 @@ static void doDispose(C4Socket* s) {
 }
 
 - (void) dispose {
-    CBLLogVerbose(WebSocket, @"C4Socket of %@ is being disposed", self);
+    CBLLogVerbose(WebSocket, @"%@: C4Socket is being disposed", self);
     // This has to be done synchronously, because _c4socket will be freed when this method returns
     auto socket = _c4socket.exchange(nullptr);
     if (socket)
@@ -280,21 +285,21 @@ static void doDispose(C4Socket* s) {
                         c4cert_release(c4cert);
                         return;
                     }
-                    CBLWarnError(Sync, @"Couldn't lookup the identity from the KeyChain: %@", error);
+                    CBLWarnError(Sync, @"%@: Couldn't lookup the identity from the KeyChain: %@", self, error);
                 } else {
-                    CBLWarnError(Sync, @"Client Cert Auth is not supported by macOS < 10.12 and iOS < 10.0");
+                    CBLWarnError(Sync, @"%@: Client Cert Auth is not supported by macOS < 10.12 and iOS < 10.0", self);
                 }
                 c4cert_release(c4cert);
             } else {
                 NSError* error;
                 convertError(err, &error);
-                CBLWarnError(Sync, @"Couldn't create C4Cert from the certificate data: %@", error);
+                CBLWarnError(Sync, @"%@: Couldn't create C4Cert from the certificate data: %@", self, error);
             }
         }
     }
 #endif
 
-    CBLWarn(Sync, @"Unknown auth type or missing parameters for auth");
+    CBLWarn(Sync, @"%@: Unknown auth type or missing parameters for auth", self);
 }
 
 - (void) callC4Socket: (void (^)(C4Socket*))callback {
@@ -327,7 +332,6 @@ static void doDispose(C4Socket* s) {
     _connectedThruProxy = NO;
 
     if (_networkInterface) {
-        CBLLogInfo(WebSocket, @"%@ connecting thru network interface %@", self, _networkInterface);
         [self connectToHostWithName: _logic.directHost
                                port: _logic.directPort
                    networkInterface: _networkInterface];
@@ -359,12 +363,12 @@ static void doDispose(C4Socket* s) {
     [_out open];
 
     if (_connectingToProxy) {
-        CBLLogInfo(WebSocket, @"%@ connecting to HTTP proxy %@:%d...",
+        CBLLogInfo(WebSocket, @"%@: Connecting to HTTP proxy %@:%d ...",
                    self, _logic.directHost, _logic.directPort);
         _logic.useProxyCONNECT = YES;
         [self writeData: _logic.HTTPRequestData completionHandler: nil];
     } else {
-        CBLLogInfo(WebSocket, @"%@ connecting to %@:%d...", self, _logic.URL.host, _logic.port);
+        CBLLogInfo(WebSocket, @"%@: Sending WebSocket request to %@:%d ...", self, _logic.URL.host, _logic.port);
         [self _sendWebSocketRequest];
     }
 }
@@ -389,7 +393,6 @@ static void doDispose(C4Socket* s) {
         if (_experimentalType == kCBLNetworkInterfaceExperimentalTypeUseBindFunction) {
             result = [self bindToInterface: interface useIPv4: useIPv4 error: &err];
         } else  {
-            // experimentalType = DNSService OR None
             result = [self setSocketOptForInterface: interface useIPv4: useIPv4 error: &err];
         }
         
@@ -406,19 +409,8 @@ static void doDispose(C4Socket* s) {
             return; // Already disconnected
         }
         
-        struct sockaddr_in *addr = (struct sockaddr_in *)_addr->ai_addr;
-        char addrBuf[INET_ADDRSTRLEN];
-        if (addr->sin_family == AF_INET) {
-            if (inet_ntop(AF_INET, &addr->sin_addr, addrBuf, INET_ADDRSTRLEN) != NULL) {
-                CBLLogVerbose(WebSocket, @"%@: Going to connect to IPv4 addr: %@",
-                              self, [NSString stringWithUTF8String: addrBuf]);
-            } else {
-                CBLWarnError(WebSocket, @"%@: inet_ntop(..) failed %@", self, addrInfo(_addr));
-            }
-        }
-        
+        CBLLogVerbose(WebSocket, @"%@: Connect to IP address %@", self, getIPAddress(_addr->ai_addr));
         int status = connect(sockfd, _addr->ai_addr, _addr->ai_addrlen);
-        
         if (status == 0) {
             dispatch_async(_queue, ^{
                 if (_sockfd < 0)
@@ -465,6 +457,8 @@ static void doDispose(C4Socket* s) {
 - (void) connectToHostWithName: (NSString*)hostname
                           port: (NSInteger)port
               networkInterface: (NSString*)interface {
+    CBLLogInfo(WebSocket, @"%@: Connect to host '%@' port '%ld' interface '%@' (exp mode '%lu')",
+               self, hostname, (long)port, interface, (unsigned long)_experimentalType);
     if (_experimentalType == kCBLNetworkInterfaceExperimentalTypeUseDNSService) {
         [self resolveAndConnectViaDNSService: hostname port: port interface: interface];
     } else {
@@ -491,8 +485,7 @@ static void doDispose(C4Socket* s) {
         return;
     }
     
-    CBLLogVerbose(WebSocket, @"%@: %@:%ld(%@) got address info as %@",
-                  self, hostname, (long)port, interface, addrInfo(_addr));
+    CBLLogVerbose(WebSocket, @"%@: Host '%@' was resolved as %@", self, hostname, addrInfo(_addr));
     
     if (_addr->ai_family != AF_INET && _addr->ai_family != AF_INET6) {
         NSString* msg = $sprintf(@"Address family %d is not supported", _addr->ai_family);
@@ -515,7 +508,7 @@ static void doDispose(C4Socket* s) {
         return false;
     }
     
-    CBLLogVerbose(WebSocket, @"%@: name(%@) converted to index %u", self, interface, index);
+    CBLLogVerbose(WebSocket, @"%@: Interface '%@' is mapped to index '%u'", self, interface, index);
     int result = -1;
     if (useIPv4) {
         result = setsockopt(_sockfd, IPPROTO_IP, IP_BOUND_IF, &index, sizeof(index));
@@ -532,7 +525,7 @@ static void doDispose(C4Socket* s) {
         return false;
     }
     
-//    CBLLogVerbose(WebSocket, @"%@: setsockopt: %d %@", self, result, addrInfo(_addr));
+    CBLLogVerbose(WebSocket, @"%@: Successfully set network interface %@ to socket option", self, interface);
     return true;
 }
 
@@ -605,8 +598,24 @@ static inline NSError* addrInfoError(int res, NSString* msg) {
 }
 
 static inline NSString* addrInfo(const struct addrinfo* addr) {
-    return $sprintf(@"family=%d, socktype=%d, protocol=%d",
-                    addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+    return $sprintf(@"ip=%@, family=%d, socktype=%d, protocol=%d",
+                    getIPAddress(addr->ai_addr), addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+}
+
+static NSString* getIPAddress(const struct sockaddr* addr) {
+    NSString* ipaddr = @"Unknown";
+    if (addr->sa_family == AF_INET) {
+        char addrBuf[INET_ADDRSTRLEN];
+        if (inet_ntop(AF_INET, &((struct sockaddr_in*)addr)->sin_addr, addrBuf, INET_ADDRSTRLEN) != NULL) {
+            ipaddr = [NSString stringWithUTF8String: addrBuf];
+        }
+    } else {
+        char addrBuf[INET6_ADDRSTRLEN];
+        if (inet_ntop(AF_INET6, &((struct sockaddr_in6*)addr)->sin6_addr, addrBuf, INET6_ADDRSTRLEN) != NULL) {
+            ipaddr = [NSString stringWithUTF8String: addrBuf];
+        }
+    }
+    return ipaddr;
 }
 
 - (void) configureSOCKS {
@@ -623,7 +632,7 @@ static inline NSString* addrInfo(const struct addrinfo* addr) {
 - (void) configureTLS {
     _checkSSLCert = false;
     if (_logic.useTLS) {
-        CBLLogVerbose(WebSocket, @"%@ enabling TLS", self);
+        CBLLogVerbose(WebSocket, @"%@: Enabling TLS ...", self);
         NSMutableDictionary* settings = [NSMutableDictionary dictionary];
         if (_connectedThruProxy)
             [settings setObject: _logic.directHost
@@ -645,7 +654,7 @@ static inline NSString* addrInfo(const struct addrinfo* addr) {
         
         if (![_in setProperty: settings
                        forKey: (__bridge NSString *)kCFStreamPropertySSLSettings]) {
-            CBLWarnError(WebSocket, @"%@ failed to set SSL settings", self);
+            CBLWarnError(WebSocket, @"%@: Failed to set TLS settings", self);
         }
         
         _checkSSLCert = true;
@@ -689,7 +698,7 @@ static inline NSString* addrInfo(const struct addrinfo* addr) {
     NSString* cookie = [_db getCookies: _remoteURL error: &error];
     if (error) {
         // in case database is not open: CBL-2657
-        CBLWarn(Sync, @"Error while fetching cookies: %@", error);
+        CBLWarn(Sync, @"%@: Error while fetching cookies: %@", self, error);
         [self closeWithError: error];
         return;
     }
@@ -714,7 +723,7 @@ static inline NSString* addrInfo(const struct addrinfo* addr) {
 
 // Parses the HTTP response.
 - (void) receivedHTTPResponseBytes: (const void*)bytes length: (size_t)length {
-    CBLLogVerbose(WebSocket, @"Received %zu bytes of HTTP response", length);
+    CBLLogVerbose(WebSocket, @"%@: Received %zu bytes of HTTP response", self, length);
 
     if (!CFHTTPMessageAppendBytes(_httpResponse, (const UInt8*)bytes, length)) {
         // Error reading response!
@@ -757,7 +766,7 @@ static inline NSString* addrInfo(const struct addrinfo* addr) {
     [self clearHTTPState];
     [self configureTLS];
 
-    CBLLogInfo(WebSocket, @"%@ Proxy CONNECT to %@:%d...", self, _logic.URL.host, _logic.port);
+    CBLLogInfo(WebSocket, @"%@: Proxy CONNECT to %@:%d...", self, _logic.URL.host, _logic.port);
     [self _sendWebSocketRequest];
 }
 
@@ -815,7 +824,7 @@ static inline NSString* addrInfo(const struct addrinfo* addr) {
 
 // Notifies LiteCore that the WebSocket is connected.
 - (void) connected: (NSDictionary*)responseHeaders {
-    CBLLogInfo(WebSocket, @"CBLWebSocket CONNECTED!");
+    CBLLogInfo(WebSocket, @"%@: CBLWebSocket CONNECTED!", self);
     [self callC4Socket:^(C4Socket *socket) {
         c4socket_opened(socket);
     }];
@@ -855,12 +864,12 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
     NSData* data = [NSData dataWithBytesNoCopy: (void*)allocatedData.buf
                                         length: allocatedData.size
                                   freeWhenDone: NO];
-    CBLLogVerbose(WebSocket, @">>> sending %zu bytes...", allocatedData.size);
+    CBLLogVerbose(WebSocket, @"%@: >>> sending %zu bytes...", self, allocatedData.size);
     dispatch_async(_queue, ^{
         [self writeData: data completionHandler: ^() {
             size_t size = allocatedData.size;
             c4slice_free(allocatedData);
-            CBLLogVerbose(WebSocket, @"    (...sent %zu bytes)", size);
+            CBLLogVerbose(WebSocket, @"%@:    (...sent %zu bytes)", self, size);
             [self callC4Socket:^(C4Socket *socket) {
                 c4socket_completedWrite(socket, size);
             }];
@@ -871,7 +880,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 // Called when WebSocket data is received (NOT necessarily an entire message.)
 - (void) receivedBytes: (const void*)bytes length: (size_t)length {
     self->_receivedBytesPending += length;
-    CBLLogVerbose(WebSocket, @"<<< received %zu bytes [now %zu pending]",
+    CBLLogVerbose(WebSocket, @"%@: <<< received %zu bytes [now %zu pending]", self,
                   (size_t)length, self->_receivedBytesPending);
     [self callC4Socket:^(C4Socket *socket) {
         c4socket_received(socket, {bytes, length});
@@ -890,7 +899,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 
 // callback from C4Socket
 - (void) closeSocket {
-    CBLLogInfo(WebSocket, @"%@ CBLWebSocket closeSocket requested", self);
+    CBLLogInfo(WebSocket, @"%@: CBLWebSocket closeSocket requested", self);
     dispatch_async(_queue, ^{
         if (_in || _out || _sockfd >= 0) {
             [self closeWithError: nil];
@@ -909,7 +918,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
     if (!_in)
         return;
 
-    CBLLogInfo(WebSocket, @"CBLWebSocket CLOSING WITH STATUS %d \"%@\"", (int)code, reason);
+    CBLLogInfo(WebSocket, @"%@: CBLWebSocket CLOSING WITH STATUS %d \"%@\"", self, (int)code, reason);
     [self disconnect];
     nsstring_slice reasonSlice(reason);
     [self c4SocketClosed: c4error_make(WebSocketDomain, code, reasonSlice)];
@@ -919,7 +928,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 - (void) closeWithError: (NSError*)error {
     // This function is always called from queue.
     if (_closing) {
-        CBLLogVerbose(Sync, @"%@ Websocket is already closing. Ignoring the close.", self);
+        CBLLogVerbose(Sync, @"%@: CBLWebsocket is closing. Ignoring the close.", self);
         return;
     }
     _closing = YES;
@@ -928,10 +937,10 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 
     C4Error c4err;
     if (error) {
-        CBLLogInfo(WebSocket, @"CBLWebSocket CLOSED WITH ERROR: %@", error.my_compactDescription);
+        CBLLogInfo(WebSocket, @"%@: CBLWebSocket CLOSED WITH ERROR: %@", self, error.my_compactDescription);
         convertError(error, &c4err);
     } else {
-        CBLLogInfo(WebSocket, @"CBLWebSocket CLOSED");
+        CBLLogInfo(WebSocket, @"%@: CBLWebSocket CLOSED", self);
         c4err = {};
     }
     [self c4SocketClosed: c4err];
@@ -990,11 +999,11 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 #endif
     
     if (!credentials) {
-        CBLWarn(WebSocket, @"TLS handshake failed: %@", error.localizedDescription);
+        CBLWarn(WebSocket, @"%@: TLS handshake failed: %@", self, error.localizedDescription);
         [self closeWithError: error];
         return false;
     } else
-        CBLLogVerbose(WebSocket, @"TLS handshake succeeded");
+        CBLLogVerbose(WebSocket, @"%@: TLS handshake succeeded", self);
     
     return true;
 }
@@ -1005,7 +1014,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
         if (SecTrustGetCertificateCount(trust) > 0)
             cert = SecTrustGetCertificateAtIndex(trust, 0);
         else
-            CBLWarn(WebSocket, @"SecTrust has no certificates"); // Shouldn't happen
+            CBLWarn(WebSocket, @"%@: SecTrust has no certificates", self); // Shouldn't happen
     }
     _replicator.serverCertificate = cert;
 }
@@ -1042,7 +1051,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 }
 
 - (void) doRead {
-    CBLLogVerbose(WebSocket, @"DoRead...");
+    CBLLogVerbose(WebSocket, @"%@: DoRead...", self);
     Assert(_hasBytes);
     _hasBytes = false;
     while (_in.hasBytesAvailable) {
@@ -1051,7 +1060,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
             break;
         }
         NSInteger nBytes = [_in read: _readBuffer maxLength: kReadBufferSize];
-        CBLLogVerbose(WebSocket, @"DoRead read %zu bytes", nBytes);
+        CBLLogVerbose(WebSocket, @"%@: DoRead read %zu bytes", self, nBytes);
         if (nBytes <= 0)
             break;
         if (!_gotResponseHeaders)
@@ -1064,7 +1073,7 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 - (void)stream: (NSStream*)stream handleEvent: (NSStreamEvent)eventCode {
     switch (eventCode) {
         case NSStreamEventOpenCompleted:
-            CBLLogVerbose(WebSocket, @"%@: OpenCompleted on %@", self, stream);
+            CBLLogVerbose(WebSocket, @"%@: Open Completed on %@", self, stream);
             break;
         case NSStreamEventHasBytesAvailable:
             Assert(stream == _in);
@@ -1081,12 +1090,12 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
             [self doWrite];
             break;
         case NSStreamEventEndEncountered:
-            CBLLogVerbose(WebSocket, @"%@: EndEncountered on %s stream",
+            CBLLogVerbose(WebSocket, @"%@: End Encountered on %s stream",
                           self, ((stream == _out) ? "write" : "read"));
             [self closeWithError: nil];
             break;
         case NSStreamEventErrorOccurred:
-            CBLLogVerbose(WebSocket, @"%@: ErrorEncountered on %@", self, stream);
+            CBLLogVerbose(WebSocket, @"%@: Error Encountered on %@", self, stream);
             if (_checkSSLCert) {
                 SecTrustRef trust = [self copyTrustFromReadStream];
                 [self updateServerCertificateFromTrust:
@@ -1114,12 +1123,17 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
         close(_sockfd);
         self.sockfd = -1;
     }
+    
+    if (_dnsService) {
+        [_dnsService stop];
+        _dnsService = nil;
+    }
 }
 
 #pragma mark - Helper
 
 + (NSArray*) parseCookies: (NSString*) cookieStr {
-    Assert(cookieStr.length > 0, @"Trtying to parse empty cookie string");
+    Assert(cookieStr.length > 0, @"%@: Trying to parse empty cookie string", self);
     
     NSArray* rawAttrs = [cookieStr componentsSeparatedByString: @";"];
     
@@ -1159,41 +1173,46 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
 
 - (void) resolveAndConnectViaDNSService: (NSString*)host port: (NSInteger)port interface: (NSString*)interface {
     unsigned int index = if_nametoindex([interface cStringUsingEncoding: NSUTF8StringEncoding]);
-    _dnsResolver = [[CBLDNSResolver alloc] initWithHost: host interface: index port: (UInt16)port delegate: self];
-    [_dnsResolver start];
+    if (index == 0) {
+        int errNo = errno;
+        NSString* msg = $sprintf(@"Failed to find network interface %@ with errno %d", interface, errNo);
+        CBLWarnError(WebSocket, @"%@: %@", self, msg);
+        [self closeWithError: posixError(errNo, msg)];
+        return;
+    }
+    
+    _dnsService = [[CBLDNSService alloc] initWithHost: host interface: index port: (UInt16)port delegate: self];
+    [_dnsService start];
 }
 
 #pragma mark DNSServiceDelegate
 
 - (void) didResolveSuccessWithAddress: (AddressInfo*)info {
-    NSString* resolved = @"Unknown";
-    if (info.addr->sa_family == AF_INET) {
-        char addrBuf[INET_ADDRSTRLEN];
-        if (inet_ntop(AF_INET, &((struct sockaddr_in*)info.addr)->sin_addr, addrBuf, INET_ADDRSTRLEN) != NULL) {
-            resolved = [NSString stringWithUTF8String: addrBuf];
+    dispatch_async(_queue, ^{
+        if (_dnsService) {
+            CBLLogVerbose(WebSocket, @"%@: Host '%@' was resolved as ip=%@, family=%d",
+                          self, info.host, info.addrstr, info.addr->sa_family);
+            [self _socketConnect: _networkInterface addrInfo: info];
         }
-    } else {
-        char addrBuf[INET6_ADDRSTRLEN];
-        if (inet_ntop(AF_INET6, &((struct sockaddr_in6*)info.addr)->sin6_addr, addrBuf, INET6_ADDRSTRLEN) != NULL) {
-            resolved = [NSString stringWithUTF8String: addrBuf];
-        }
-    }
-    NSLog(@"Resolved IP: %@", resolved);
-    
-    [self _socketConnect: _networkInterface addrInfo: info];
+    });
 }
 
 - (void) didResolveFailWithError: (NSError*)error {
-    NSLog(@"Resolving Error: %@", error.localizedDescription);
+    dispatch_async(_queue, ^{
+        if (_dnsService) {
+            CBLWarnError(WebSocket, @"%@: Host was failed to resolve with error '%@'",
+                          self, error.my_compactDescription);
+            [self closeWithError: error];
+        }
+    });
 }
 
-- (void) _socketConnect: (NSString*)interface addrInfo: (AddressInfo*)addInfo {
-    BOOL isIPv4 = addInfo.type == 0;
+- (void) _socketConnect: (NSString*)interface addrInfo: (AddressInfo*)info {
     Assert(_sockfd < 0);
-    _sockfd = socket(isIPv4 ? AF_INET :  AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    _sockfd = socket(info.addr->sa_family, SOCK_STREAM, 0);
     if (_sockfd < 0) {
         int errNo = errno;
-        NSString* msg = $sprintf(@"Failed to create socket with errno %d (%@)", errNo, addInfo);
+        NSString* msg = $sprintf(@"Failed to create socket with errno %d (%@)", errNo, info);
         CBLWarnError(WebSocket, @"%@: %@", self, msg);
         [self closeWithError: posixError(errNo, msg)];
         return;
@@ -1203,14 +1222,13 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
     if (interface) {
         bool result = false;
         NSError* err;
-        
+        BOOL isIPv4 = info.type == kIPv4;
         if (_experimentalType == kCBLNetworkInterfaceExperimentalTypeUseBindFunction) {
             result = [self bindToInterface: interface useIPv4: isIPv4 error: &err];
         } else  {
             // experimentalType = DNSService OR None
             result = [self setSocketOptForInterface: interface useIPv4: isIPv4 error: &err];
         }
-        
         if (!result) {
             [self closeWithError: err];
             return;
@@ -1224,10 +1242,8 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
             return; // Already disconnected
         }
         
-        CBLLogVerbose(WebSocket, @"%@: Going to connect to: %@", self, addInfo);
-        
-        int status = connect(sockfd, addInfo.addr, isIPv4 ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN);
-        
+        socklen_t len = info.type == kIPv4 ? sizeof(*info.addrIn) : sizeof(*info.addrIn6);
+        int status = connect(sockfd, info.addr, len);
         if (status == 0) {
             dispatch_async(_queue, ^{
                 if (_sockfd < 0)


### PR DESCRIPTION
[AddressInfo]

* Updated port to sockaddr directly by using const_cast - this is not the best practice but it is the simplest way to do.
* Added addrIn and addrIn6 for easier accessing to the ip address structure.
* Added host and interface for debugging and logging purpose.

[CBLDNSService]

* Renamed the class to CBLDNSService for consistency
* Added the logic to check whether the host is already IP Address and notify the result right away.
* Ensured to notify result or error on the dispatch queue.
* Remove kDNSServiceFlagsTimeout flas as we are doing our own timeout to better match the default litecore connection timeout of 15 seconds.
* Used dispatch after instead of NSTimer as NSTimer does work in dispatch queue correctly.
* Updated log messages.
* Updated license

[CBLWebSocket]
* Fiexed the code that creates and connects the socket; Correct len passed to connect() function.
* Updated log messages
* Cleaned up imports

[CBLReplicatorConfiguration]
* Reordered the experimental options per priority