### PR TITLE
Increase Wait Interval in CBLDNSService

### DIFF
--- a/Objective-C/Internal/Replicator/CBLDNSService.mm
+++ b/Objective-C/Internal/Replicator/CBLDNSService.mm
@@ -95,7 +95,7 @@
 @end
 
 #define kTimeoutInterval 10.0
-#define kWaitingInterval 0.5
+#define kWaitingInterval 2.0
 
 @implementation CBLDNSService {
     NSString* _host;


### PR DESCRIPTION
Increased wait interval from 0.5 to 2 seconds for waiting for IPv4 result after getting IPv6 to avoid unexpected delay.