### PR TITLE
fix build error

### DIFF
--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -444,7 +444,7 @@ static void doDispose(C4Socket* s) {
     }
     
     CBLLogVerbose(WebSocket, @"%@: Successfully set network interface %u to socket option",
-                  self, info.interface);
+                  self, (unsigned int)info.interface);
     
     // Connect:
     dispatch_async(_socketConnectQueue, ^{
@@ -487,7 +487,7 @@ static void doDispose(C4Socket* s) {
             });
         } else {
             int errNo = errno;
-            NSString* msg = $sprintf(@"Failed to connect via the specified network interface %u with errno %d", info.interface, errNo);
+            NSString* msg = $sprintf(@"Failed to connect via the specified network interface %u with errno %d", (unsigned int)info.interface, errNo);
             CBLWarnError(WebSocket, @"%@: %@", self, msg);
             NSError* error = posixError(errNo, msg);
             dispatch_async(_queue, ^{


### PR DESCRIPTION
Jenkins failure: 

/****-lite-ios-ee/****-lite-ios/Objective-C/Internal/Replicator/CBLWebSocket.mm:447:25: values of type 'UInt32' should not be used as format arguments; add an explicit cast to 'unsigned int' instead [-Werror,-Wformat]
17:47:55 
17:47:55                   self, info.interface);
17:47:55                         ^~~~~~~~~~~~~~
17:47:55 
17:47:55 
17:47:55 
/****-lite-ios-ee/****-lite-ios/Objective-C/Internal/Replicator/CBLWebSocket.mm:490:113: values of type 'UInt32' should not be used as format arguments; add an explicit cast to 'unsigned int' instead [-Werror,-Wformat]
17:47:55 
17:47:55             NSString* msg = $sprintf(@"Failed to connect via the specified network interface %u with errno %d", info.interface, errNo);
17:47:55                                                     ~~~     ^~~~~~~~~~~
17:47:55 
17:47:55 