### PR TITLE
CBL-3953: documentWithID shouldn't throw, if document doesn't exists

### DIFF
--- a/Objective-C/CBLCollection.h
+++ b/Objective-C/CBLCollection.h
@@ -87,7 +87,8 @@ extern NSString* const kCBLDefaultCollectionName;
  @param error On return, the error if any.
  @return The CBLDocument object.
  */
-- (nullable CBLDocument*) documentWithID: (NSString*)documentID error: (NSError**)error;
+- (nullable CBLDocument*) documentWithID: (NSString*)documentID
+                                   error: (NSError**)error NS_SWIFT_NOTHROW;
 
 #pragma mark - Save, Delete, Purge
 

--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -200,10 +200,18 @@ NSString* const kCBLDefaultCollectionName = @"_default";
         if (![self collectionIsValid: error])
             return nil;
         
-        return [[CBLDocument alloc] initWithCollection: self
-                                            documentID: documentID
-                                        includeDeleted: NO
-                                                 error: error];
+        NSError* err = nil;
+        CBLDocument* doc = [[CBLDocument alloc] initWithCollection: self
+                                                        documentID: documentID
+                                                    includeDeleted: NO
+                                                             error: &err];
+        
+        if (!doc && err.code != CBLErrorNotFound) {
+            if (error)
+                *error = err;
+        }
+        
+        return doc;
     }
 }
 

--- a/Objective-C/Tests/CollectionTest.m
+++ b/Objective-C/Tests/CollectionTest.m
@@ -33,6 +33,16 @@
     [super tearDown];
 }
 
+- (void) testGetNonExistingDoc {
+    NSError* error = nil;
+    CBLCollection* col = [self.db defaultCollection: &error];
+    AssertNil(error);
+    
+    CBLDocument* doc = [col documentWithID: @"nonExisting" error: &error];
+    AssertNil(error);
+    AssertNil(doc);
+}
+
 #pragma mark - Default Scope/Collection
 
 - (void) testDefaultCollectionExists {

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -73,8 +73,17 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     /// Throws an NSError with the CBLError.notOpen code, if the collection is deleted or
     /// the database is closed.
     public func document(id: String) throws -> Document? {
-        let implDoc = try impl.document(withID: id)
-        return Document(implDoc, collection: self)
+        var error: NSError?
+        let doc = impl.document(withID: id, error: &error)
+        if let err = error {
+            throw err
+        }
+
+        if let implDoc = doc {
+            return Document(implDoc, collection: self)
+        }
+        
+        return nil
     }
     
     /// Save a document into the collection. The default concurrency control, lastWriteWins,

--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -30,6 +30,18 @@ class CollectionTest: CBLTestCase {
         try super.tearDownWithError()
     }
     
+    // MARK: Get nonexisting doc
+    
+    func testGetNonExistingDoc() throws {
+        guard let collection = try self.db.defaultCollection() else {
+            XCTFail("Collection shouldn't be empty!")
+            return
+        }
+        
+        let doc = try collection.document(id: "NotExists");
+        XCTAssertNil(doc)
+    }
+    
     // MARK: Default Scope/Collection
     
     func testDefaultCollectionExists() throws {


### PR DESCRIPTION
* NonExisting document shouldn't throw NotFound error inside documentWithID, will skip the error populating. 
* Default Swift API from ObjC overriden(NS_SWIFT_NOTHROW) to avoid throw nilError; 
* ObjC API ending with ':(NSError**)' treated as throwable compulsory return type, but we need nullable(optional) return type.