### PR TITLE
Fixing a crash “Attempt to perform an operation on a closed database”

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -345,8 +345,15 @@ static const C4DatabaseConfig2 kDBConfig = {
     CBLAssertNotNil(block);
     
     CBL_LOCK(_mutex) {
-        [self mustBeOpen];
-        
+        NSError* exception = nil;
+        [self mustBeOpen exception];
+        if (err) {
+            transaction.abort();
+            return createError(CBLErrorUnexpectedError,
+                               [NSString stringWithFormat: @"%@", exception.localizedDescription],
+                               outError);
+        }
+
         C4Transaction transaction(_c4db);
         if (outError)
             *outError = nil;

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -346,9 +346,8 @@ static const C4DatabaseConfig2 kDBConfig = {
     
     CBL_LOCK(_mutex) {
         NSError* exception = nil;
-        [self mustBeOpen exception];
-        if (err) {
-            transaction.abort();
+        [self mustBeOpen: &exception];
+        if (exception) {
             return createError(CBLErrorUnexpectedError,
                                [NSString stringWithFormat: @"%@", exception.localizedDescription],
                                outError);


### PR DESCRIPTION
**Bug**: “Attempt to perform an operation on a closed database”

**Reason**: self.mustBeOpen may raise an exception but the code cannot capture it without this PR, so usually when the error happen, the app will crash

**Fix**: Call `self.mustBeOpen` with an error parameter.
 