### PR TITLE
CBL-4080: Separate createIndex(index:) & createIndex(config:)

### DIFF
--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -30,6 +30,7 @@
 #import "CBLErrorMessage.h"
 #import "CBLIndexable.h"
 #import "CBLIndexConfiguration+Internal.h"
+#import "CBLIndex+Internal.h"
 #import "CBLScope.h"
 #import "CBLScope+Internal.h"
 #import "CBLStatus.h"
@@ -131,6 +132,29 @@ NSString* const kCBLDefaultCollectionName = @"_default";
                                   c4IndexSpec,
                                   config.queryLanguage,
                                   config.indexType,
+                                  &options,
+                                  &c4err) || convertError(c4err, error);
+    }
+}
+
+- (BOOL) createIndex: (CBLIndex*)index name:(NSString*)name error: (NSError**)error {
+    CBLAssertNotNil(name);
+    CBLAssertNotNil(index);
+    
+    CBL_LOCK(_mutex) {
+        if (![self collectionIsValid: error])
+            return NO;
+
+        CBLStringBytes iName(name);
+        CBLStringBytes c4IndexSpec(index.getIndexSpecs);
+        C4IndexOptions options = index.indexOptions;
+
+        C4Error c4err = {};
+        return c4coll_createIndex(_c4col,
+                                  iName,
+                                  c4IndexSpec,
+                                  index.queryLanguage,
+                                  index.indexType,
                                   &options,
                                   &c4err) || convertError(c4err, error);
     }

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -563,7 +563,13 @@ static const C4DatabaseConfig2 kDBConfig = {
 }
 
 - (BOOL) createIndex: (CBLIndex*)index withName: (NSString*)name error: (NSError**)error {
-    return [self createIndex: name withConfig: index error: error];
+    NSError *e = nil;
+    BOOL res = [[self defaultCollectionOrThrow] createIndex: index name: name error: &e];
+    throwIfNotOpenError(e);
+    
+    if (error)
+        *error = e;
+    return res;
 }
 
 - (BOOL) createIndexWithConfig: (CBLIndexConfiguration*)config

--- a/Objective-C/CBLIndex.h
+++ b/Objective-C/CBLIndex.h
@@ -18,7 +18,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "CBLIndexConfiguration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  CBLIndex represents an index which could be a value index for regular queries or
  full-text index for full-text queries (using the match operator).
  */
-@interface CBLIndex : CBLIndexConfiguration
+@interface CBLIndex : NSObject
 
 /** Not available */
 - (instancetype) init NS_UNAVAILABLE;

--- a/Objective-C/CBLIndex.m
+++ b/Objective-C/CBLIndex.m
@@ -18,7 +18,6 @@
 //
 
 #import "CBLIndex+Internal.h"
-#import "CBLIndexConfiguration+Internal.h"
 #import "CBLJSON.h"
 
 @implementation CBLIndex
@@ -27,8 +26,7 @@
 
 - (instancetype) initWithIndexType: (C4IndexType)indexType
                      queryLanguage: (C4QueryLanguage)language {
-    // since [super init] is unavailable, we use this constructor(which is unnecessary but harmless)
-    self = [super initWithIndexType: indexType queryLanguage: language];
+    self = [super init];
     if (self) {
         _indexType = indexType;
         _queryLanguage = language;

--- a/Objective-C/CBLIndexable.h
+++ b/Objective-C/CBLIndexable.h
@@ -18,6 +18,7 @@
 //
 
 #import "CBLIndexConfiguration.h"
+#import "CBLIndex.h"
 
 NS_ASSUME_NONNULL_BEGIN
 /** The Indexable interface defines a set of functions for managing the query indexes. */
@@ -30,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL) createIndexWithName: (NSString*)name
                       config: (CBLIndexConfiguration*)config
                        error: (NSError**)error;
+
+/** Create an index with the index name and index. */
+- (BOOL) createIndex: (CBLIndex*)index name: (NSString*)name error: (NSError**)error;
 
 /** Delete an index by name. */
 - (BOOL) deleteIndexWithName: (NSString*)name error: (NSError**)error;

--- a/Objective-C/Internal/CBLIndex+Internal.h
+++ b/Objective-C/Internal/CBLIndex+Internal.h
@@ -27,7 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CBLIndex ()
+@interface CBLIndex () <CBLIndexSpec>
 
 - (instancetype) initWithIndexType: (C4IndexType)indexType;
 

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2309,13 +2309,13 @@
     CBLValueIndexItem* lNameItem = [CBLValueIndexItem expression: lName];
     
     CBLValueIndex* index1 = [CBLIndexBuilder valueIndexWithItems: @[fNameItem, lNameItem]];
-    Assert([colA createIndexWithName: @"index1" config: index1 error: &error],
+    Assert([colA createIndex: index1 name: @"index1" error: &error],
            @"Error when creating value index: %@", error);
     
     // Create FTS index:
     CBLFullTextIndexItem* detailItem = [CBLFullTextIndexItem property: @"detail"];
     CBLFullTextIndex* index2 = [CBLIndexBuilder fullTextIndexWithItems: @[detailItem]];
-    Assert([colA createIndexWithName: @"index2" config: index2 error: &error],
+    Assert([colA createIndex: index2 name: @"index2" error: &error],
            @"Error when creating FTS index without options: %@", error);
     
     CBLFullTextIndexItem* detailItem2 = [CBLFullTextIndexItem property: @"es-detail"];
@@ -2323,7 +2323,7 @@
     index3.language = @"es";
     index3.ignoreAccents = YES;
     
-    Assert([colA createIndexWithName: @"index3" config: index3 error: &error],
+    Assert([colA createIndex: index3 name: @"index3" error: &error],
            @"Error when creating FTS index with options: %@", error);
     
     NSArray* names = [colA indexes: &error];

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2341,7 +2341,7 @@
     // Create FTS index:
     CBLFullTextIndexItem* detailItem = [CBLFullTextIndexItem property: @"passage"];
     CBLFullTextIndex* index2 = [CBLIndexBuilder fullTextIndexWithItems: @[detailItem]];
-    Assert([colA createIndexWithName: @"passageIndex" config: index2 error: &error],
+    Assert([colA createIndex: index2 name: @"passageIndex" error: &error],
            @"Error when creating FTS index without options: %@", error);
     
     CBLMutableDocument* doc = [self createDocument: @"doc1"];
@@ -2383,7 +2383,7 @@
     // Create FTS index:
     CBLFullTextIndexItem* detailItem = [CBLFullTextIndexItem property: @"passage"];
     CBLFullTextIndex* index2 = [CBLIndexBuilder fullTextIndexWithItems: @[detailItem]];
-    Assert([colA createIndexWithName: @"passageIndex" config: index2 error: &error],
+    Assert([colA createIndex: index2 name: @"passageIndex" error: &error],
            @"Error when creating FTS index without options: %@", error);
     
     CBLMutableDocument* doc = [self createDocument: @"doc1"];

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -276,6 +276,11 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
         try impl.createIndex(withName: name, config: config.toImpl())
     }
     
+    /// Create an index with the index name and index instance.
+    public func createIndex(_ index: Index, name: String) throws {
+        try impl.createIndex(index.toImpl(), name: name)
+    }
+    
     /// Delete an index by name.
     public func deleteIndex(forName name: String) throws {
         try impl.deleteIndex(withName: name)

--- a/Swift/Index.swift
+++ b/Swift/Index.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 /// Index protocol.
-public protocol Index : IndexConfiguration { }
+public protocol Index { }
 
 // MARK: Value Index
 

--- a/Swift/IndexConfiguration.swift
+++ b/Swift/IndexConfiguration.swift
@@ -92,8 +92,6 @@ extension IndexConfiguration {
     func toImpl() -> CBLIndexConfiguration {
         if let index = self as? IndexConfigConvertable {
             return index.toImpl()
-        } else if let index = self as? CBLIndexConvertible { // Index is inherited from IndexConfig
-            return index.toImpl()
         }
         
         fatalError("Unsupported index.")

--- a/Swift/Indexable.swift
+++ b/Swift/Indexable.swift
@@ -27,6 +27,9 @@ public protocol Indexable {
     /// Create an index with the index name and config.
     func createIndex(withName name: String, config: IndexConfiguration) throws
     
+    /// Create an index with the index name and index. 
+    func createIndex(_ index: Index, name: String) throws;
+    
     /// Delete an index by name.
     func deleteIndex(forName name: String) throws
 

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -1140,23 +1140,23 @@ class DatabaseTest: CBLTestCase {
         let lNameItem = ValueIndexItem.expression(Expression.property("lastName"))
 
         let index1 = IndexBuilder.valueIndex(items: fNameItem, lNameItem)
-        try colA.createIndex(withName: "index1", config: index1 as! IndexConfiguration)
+        try colA.createIndex(index1, name: "index1")
 
         let index2 = IndexBuilder.valueIndex(items: [fNameItem, lNameItem])
-        try colA.createIndex(withName: "index2", config: index2 as! IndexConfiguration)
+        try colA.createIndex(index2, name: "index2")
 
         // Create FTS index:
         let detailItem = FullTextIndexItem.property("detail")
         let index3 = IndexBuilder.fullTextIndex(items: detailItem)
-        try colA.createIndex(withName: "index3", config: index3 as! IndexConfiguration)
+        try colA.createIndex(index3, name: "index3")
 
         let detailItem2 = FullTextIndexItem.property("es-detail")
         let index4 = IndexBuilder.fullTextIndex(items: detailItem2).language("es").ignoreAccents(true)
-        try colA.createIndex(withName: "index4", config: index4 as! IndexConfiguration)
+        try colA.createIndex(index4, name: "index4")
 
         let nameItem = FullTextIndexItem.property("name")
         let index5 = IndexBuilder.fullTextIndex(items: [nameItem, detailItem])
-        try colA.createIndex(withName: "index5", config: index5 as! IndexConfiguration)
+        try colA.createIndex(index5, name: "index5")
 
         XCTAssertEqual(try colA.indexes().count, 5)
         XCTAssertEqual(try colA.indexes(), ["index1", "index2", "index3", "index4", "index5"])


### PR DESCRIPTION
* Convenience to deprecate
* Updated the unit tests - swift and objc