### PR TITLE
Helium readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Couchbase Lite implementation is on top of [Couchbase Lite Core](https://github.
 
 
 ## Requirements
-- iOS 9.0+ | macOS 10.11+
-- Xcode 10.3+
-
+- iOS 11.0+ | macOS 10.12+
 
 ## Installation
 
@@ -25,7 +23,7 @@ Couchbase Lite implementation is on top of [Couchbase Lite Core](https://github.
 dependencies: [
         .package(name: "CouchbaseLiteSwift",
                  url: "https://github.com/couchbase/couchbase-lite-ios.git", 
-                 from: "3.0.0"),
+                 from: "3.1.0"),
     ],
 ```
 
@@ -35,7 +33,7 @@ dependencies: [
 dependencies: [
         .package(name: "CouchbaseLiteSwift",
                  url: "https://github.com/couchbase/couchbase-lite-swift-ee.git", 
-                 from: "3.0.0"),
+                 from: "3.1.0"),
     ],
 ```
 


### PR DESCRIPTION
* Removed the Xcode 10.3+ mention in the requirements. Since it's not tested, we might not sure. Testing it might add much value as most users will be on latest or 1-2 versions lower. Keeping lower version is also not easy, since OS might not support, so we might end up keeping a separate machine to track the lowest version. 
* Update version to 3.1.0

I guess, we could keep the PR open, till the code freeze?