### PR TITLE
CBL-4190 : Fix getDefaultCollection returning nullable

### DIFF
--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -119,7 +119,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     CBLAssertNotNil(config);
     
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return NO;
         
         CBLStringBytes iName(name);
@@ -142,7 +142,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     CBLAssertNotNil(index);
     
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return NO;
 
         CBLStringBytes iName(name);
@@ -164,7 +164,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
                        error: (NSError**)error {
     CBLAssertNotNil(name);
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return NO;
         
         C4Error c4err = {};
@@ -175,7 +175,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
 
 - (nullable NSArray*) indexes: (NSError**)error {
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return nil;
         
         C4Error err = {};
@@ -221,7 +221,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     CBLAssertNotNil(documentID);
     
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return nil;
         
         NSError* err = nil;
@@ -246,7 +246,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     CBLAssertNotNil(document);
     
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return NO;
         
         if (![self prepareDocument: document error: error])
@@ -269,7 +269,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
                        error: (NSError**)error {
     CBLAssertNotNil(documentID);
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return NO;
         
         CBLDatabase* db = _db;
@@ -394,7 +394,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     CBLAssertNotNil(documentID);
     
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return nil;
         
         CBLStringBytes docID(documentID);
@@ -418,7 +418,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     CBLAssertNotNil(documentID);
     
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: error])
+        if (![self checkIsValid: error])
             return NO;
         
         UInt64 timestamp = date ? (UInt64)(date.timeIntervalSince1970*msec) : 0;
@@ -440,7 +440,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     
     CBL_LOCK(_mutex) {
         NSError* error = nil;
-        if (![self collectionIsValid: &error]) {
+        if (![self checkIsValid: &error]) {
             CBLWarn(Database,
                     @"%@ Cannot add change listener. Database is closed or collection is removed.",
                     self);
@@ -452,7 +452,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
 
 #pragma mark - Internal
 
-- (BOOL) collectionIsValid: (NSError**)error {
+- (BOOL) checkIsValid: (NSError**)error {
     BOOL valid = c4coll_isValid(_c4col);
     if (!valid) {
         if (error)
@@ -463,7 +463,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
 }
 
 - (BOOL) isValid {
-    return [self collectionIsValid: nil];
+    return [self checkIsValid: nil];
 }
 
 - (BOOL) database: (CBLDatabase*)db isValid: (NSError**)error {
@@ -632,7 +632,7 @@ static void colObserverCallback(C4CollectionObserver* obs, void* context) {
         return createError(CBLErrorNotFound,
                            kCBLErrorMessageDeleteDocFailedNotSaved, outError);
     CBL_LOCK(_mutex) {
-        if (![self collectionIsValid: outError])
+        if (![self checkIsValid: outError])
             return NO;
         
         CBLDatabase* db = _db;

--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -497,11 +497,9 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
 /**
  Get scope names that have at least one collection.
  
- @note: The default scope is exceptional as it will always be listed
- even though there are no collections under it.
+ @note: The default scope is exceptional as it will always be listed even though there are no collections under it.
  
- @param error On return, the error if any. CBLErrorNotOpen code will be returned
-        if the database is closed.
+ @param error On return, the error if any. CBLErrorNotOpen code will be returned if the database is closed.
  @return returns the scope names, or nil if an error occurred.
  */
 - (nullable NSArray<CBLScope*>*) scopes: (NSError**)error;
@@ -513,9 +511,7 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
  @note: The default scope is exceptional, and it will always be returned.
  
  @param name Scope name, if empty, it will use default scope name.
- @param error On return, the error if any. CBLErrorNotOpen code will be returned
-        if the database is closed. CBLErrorNotFound code will be returned if the
-        scope doesn't exist.
+ @param error On return, the error if any. CBLErrorNotOpen code will be returned if the database is closed.
  @return Scope object, or nil if an error occurred.
  */
 - (nullable CBLScope*) scopeWithName: (nullable NSString*)name
@@ -526,8 +522,7 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
 /** Get all collections in the specified scope.
  
  @param scope Scope name
- @param error On return, the error if any. CBLErrorNotOpen code will be
- returned if the database is closed.
+ @param error On return, the error if any. CBLErrorNotOpen code will be returned if the database is closed.
  @return list of collections in the scope, or nil if an error occurred.
  */
 - (nullable NSArray<CBLCollection*>*) collections: (nullable NSString*)scope
@@ -538,7 +533,7 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
  
  @param name name for the new collection
  @param scope collection will be created under this scope, if not specified, use the default scope.
- @param error On return, the error if any.
+ @param error On return, the error if any. CBLErrorNotOpen code will be returned if the database is closed.
  @return Newly created collection or if already exists, the existing collection will be returned
         , or nil if an error occurred.
  */
@@ -561,15 +556,11 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
                                          error: (NSError**)error NS_SWIFT_NOTHROW;
 
 /**
- Delete a collection by name  in the specified scope.
- If the collection doesn't exist, the operation will be no-ops.
- 
- @note: the default collection can be deleted but cannot be recreated.
+ Delete a collection by name  in the specified scope. If the collection doesn't exist, the operation will be no-ops.
  
  @param name Name of the collection to be deleted
  @param scope Name of the scope the collection resides, if not specified uses the default scope.
- @param error On return, the error if any. CBLErrorNotOpen code will be returned
-        if the database is closed.
+ @param error On return, the error if any. CBLErrorNotOpen code will be returned if the database is closed.
  @return True on success, false on failure.
  */
 - (BOOL) deleteCollectionWithName: (NSString*)name
@@ -579,16 +570,15 @@ __deprecated_msg("Use [[database defaultCollection] getDocumentExpirationWithID:
 /**
  Get the default scope.
  
- @param error On return, the error if any.
+ @param error On return, the error if any. CBLErrorNotOpen code will be returned if the database is closed.
  @return Default Scope, or nil if an error occurred.
  */
 - (nullable CBLScope*) defaultScope: (NSError**)error;
 
 /**
- Get the default collection. If the default collection is deleted, nil will be returned.
+ Get the default collection.
  
- @param error On return, the error if any. CBLErrorNotFound code will be returned if the
-        default collection is deleted.
+ @param error On return, the error if any.
  @return Default collection, or nil if an error occurred.
  */
 - (nullable CBLCollection*) defaultCollection: (NSError**)error;

--- a/Objective-C/Internal/CBLCollection+Internal.h
+++ b/Objective-C/Internal/CBLCollection+Internal.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) dispatch_queue_t dispatchQueue;
 
 /** The database associated with the collection. */
-// TODO: https://issues.couchbase.com/browse/CBL-3367
 @property (nonatomic, readonly, weak) CBLDatabase* db;
 
 @property (nonatomic, readonly) BOOL isValid;
@@ -56,6 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (bool) resolveConflictInDocument: (NSString*)docID
               withConflictResolver: (nullable id<CBLConflictResolver>)conflictResolver
                              error: (NSError**)outError;
+
+- (BOOL) checkIsValid: (NSError**)error;
 
 @end
 

--- a/Objective-C/Internal/CBLScope+Internal.h
+++ b/Objective-C/Internal/CBLScope+Internal.h
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLScope ()
 
-// TODO: https://issues.couchbase.com/browse/CBL-3367
 @property (nonatomic, readonly, weak) CBLDatabase* db;
 
 - (instancetype) initWithDB: (CBLDatabase*)db

--- a/Objective-C/Tests/CollectionTest.m
+++ b/Objective-C/Tests/CollectionTest.m
@@ -183,7 +183,7 @@
 - (void) testCreateAndGetCollectionsInNamedScope {
     NSError* error = nil;
     AssertNil([self.db scopeWithName: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     error = nil;
     CBLCollection* colA = [self.db createCollectionWithName: @"colA"
@@ -237,9 +237,8 @@
 
 - (void) testGetNonExistingCollection {
     NSError* error = nil;
-    AssertNil([self.db collectionWithName: @"colA"
-                                    scope: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil([self.db collectionWithName: @"colA" scope: @"scopeA" error: &error]);
+    AssertNil(error);
 }
 
 - (void) testDeleteCollection {
@@ -292,7 +291,7 @@
     AssertNil(error);
     
     AssertNil([scope collectionWithName: @"colC" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     error = nil;
     NSArray<CBLCollection*>* cols = [self.db collections: @"scopeA" error: &error];
@@ -331,16 +330,14 @@
     
     // make sure scope doesn't exist
     AssertNil([self.db scopeWithName: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     // make sure, collections return NotFound error
-    error = nil;
     AssertNil([self.db collectionWithName: @"colA" scope: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
-    error = nil;
     AssertNil([self.db collectionWithName: @"colB" scope: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
 }
 
 - (void) testScopeCollectionNameWithValidChars {
@@ -522,9 +519,9 @@
     AssertNil(error);
     
     AssertNil([self.db collectionWithName: @"colA" scope: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     AssertNil([db2 collectionWithName: @"colA" scope: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
 }
 
 - (void) testDeleteAndRecreateThenGetCollectionFromDifferentDatabaseInstance {
@@ -550,11 +547,11 @@
     AssertNil(error);
     
     AssertNil([self.db collectionWithName: @"colA" scope: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     error = nil;
     AssertNil([db2 collectionWithName: @"colA" scope: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     // Recreate:
     error = nil;
@@ -987,10 +984,8 @@
     CBLScope* scope = col.scope;
     
     Assert([db deleteCollectionWithName: @"colA" scope: @"scopeA" error: &error]);
-    
-    [self expectError: CBLErrorDomain code: CBLErrorNotFound in: ^BOOL(NSError** err) {
-        return [scope collectionWithName: @"colA" error: err] != nil;
-    }];
+    AssertNil([scope collectionWithName: @"colA" error: &error]);
+    AssertNil(error);
 
     // Empty result & no error
     NSArray* list = [scope collections: &error];
@@ -1009,9 +1004,8 @@
     [self.db deleteCollectionWithName: @"colA" scope: @"scopeA" error: &error];
     AssertNil(error);
     AssertNil([self.db scopeWithName: @"scopeA" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
-    error = nil;
     [self.db close: &error];
     AssertNil(error);
     

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2648,15 +2648,13 @@
 - (void) testEmptyCollection {
     NSError* error = nil;
     AssertNil([self.db collectionWithName: @"dummy" scope: nil error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
-    error = nil;
     AssertNil([self.db collectionWithName: @"dummy" scope: kCBLDefaultScopeName error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
-    error = nil;
     AssertNil([self.db collectionWithName: @"dummy" scope: @"scope1" error: &error]);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
 }
 
 #pragma mark - Collection Indexable

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -474,10 +474,6 @@ public final class Database {
         var error: NSError?
         let s = impl.scope(withName: name, error: &error)
         if let err = error {
-            if err.code == CBLErrorNotFound {
-                return nil
-            }
-            
             throw err
         }
         
@@ -490,17 +486,10 @@ public final class Database {
     
     // MARK: Collections
     
-    /// Get the default collection. If the default collection is deleted, nil will be returned.
-    public func defaultCollection() throws  -> Collection? {
-        do {
-            let c = try impl.defaultCollection()
-            return Collection(c, db: self)
-        } catch let err as NSError {
-            if err.code == CBLErrorNotFound {
-                return nil
-            }
-            throw err
-        }
+    /// Get the default collection.
+    public func defaultCollection() throws  -> Collection {
+        let c = try impl.defaultCollection()
+        return Collection(c, db: self)
     }
 
     /// Get all collections in the specified scope.
@@ -526,9 +515,6 @@ public final class Database {
         var error: NSError?
         let result = impl.collection(withName: name, scope: scope, error: &error)
         if let err = error {
-            if err.code == CBLErrorNotFound {
-                return nil
-            }
             throw err
         }
         
@@ -539,8 +525,7 @@ public final class Database {
         return nil
     }
     
-    /// Delete a collection by name  in the specified scope. If the collection doesn't exist, the operation
-    /// will be no-ops. Note: the default collection can be deleted but cannot be recreated.
+    /// Delete a collection by name  in the specified scope. If the collection doesn't exist, the operation will be no-ops. 
     public func deleteCollection(name: String, scope: String? = defaultScopeName) throws {
         try impl.deleteCollection(withName: name, scope: scope)
     }

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -208,12 +208,7 @@ class CBLTestCase: XCTestCase {
     }
     
     func loadJSONResource(name: String) throws {
-        guard let col = try self.db.defaultCollection() else {
-            XCTFail("Failed to load resource")
-            return
-        }
-        
-        try loadJSONResource(name, collection: col)
+        try loadJSONResource(name, collection: self.db.defaultCollection())
     }
     
     func jsonFromDate(_ date: Date) -> String {

--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -33,11 +33,7 @@ class CollectionTest: CBLTestCase {
     // MARK: Get nonexisting doc
     
     func testGetNonExistingDoc() throws {
-        guard let collection = try self.db.defaultCollection() else {
-            XCTFail("Collection shouldn't be empty!")
-            return
-        }
-        
+        let collection = try self.db.defaultCollection()
         let doc = try collection.document(id: "NotExists");
         XCTAssertNil(doc)
     }
@@ -45,10 +41,7 @@ class CollectionTest: CBLTestCase {
     // MARK: Default Scope/Collection
     
     func testDefaultCollectionExists() throws {
-        guard let collection = try self.db.defaultCollection() else {
-            XCTFail("Collection shouldn't be empty!")
-            return
-        }
+        let collection = try self.db.defaultCollection()
         XCTAssertEqual(collection.name, Database.defaultCollectionName)
         
         let cols = try self.db.collections()
@@ -85,13 +78,13 @@ class CollectionTest: CBLTestCase {
         
         var collection = try self.db.defaultCollection()
         XCTAssertNotNil(collection)
-        XCTAssertEqual(collection!.name, Database.defaultCollectionName)
-        XCTAssertEqual(collection!.scope.name, Scope.defaultScopeName)
+        XCTAssertEqual(collection.name, Database.defaultCollectionName)
+        XCTAssertEqual(collection.scope.name, Scope.defaultScopeName)
         
         collection = try self.db.createCollection(name: Database.defaultCollectionName)
         XCTAssertNotNil(collection)
-        XCTAssertEqual(collection!.name, Database.defaultCollectionName)
-        XCTAssertEqual(collection!.scope.name, Scope.defaultScopeName)
+        XCTAssertEqual(collection.name, Database.defaultCollectionName)
+        XCTAssertEqual(collection.scope.name, Scope.defaultScopeName)
     }
     
     func testGetDefaultScopeAfterDeleteDefaultCollection() throws {
@@ -612,10 +605,7 @@ class CollectionTest: CBLTestCase {
     // MARK: Index
     
     func testCollectionIndex() throws {
-        guard let collection = try db.defaultCollection() else {
-            XCTFail("default collection is missing")
-            return
-        }
+        let collection = try db.defaultCollection()
         
         let config1 = ValueIndexConfiguration(["firstName", "lastName"])
         try collection.createIndex(withName: "index1", config: config1)
@@ -841,10 +831,8 @@ class CollectionTest: CBLTestCase {
     // MARK: change observer
     
     func testCollectionChangeEvent() throws {
-        guard let collection = try db.defaultCollection() else {
-            XCTFail("default collection is missing")
-            return
-        }
+        let collection = try db.defaultCollection()
+        
         let doc = try generateDocument(withID: "doc1")
         let x = self.expectation(description: "change")
         let token = collection.addChangeListener { (change) in

--- a/Swift/Tests/QueryTest+Collection.swift
+++ b/Swift/Tests/QueryTest+Collection.swift
@@ -32,12 +32,7 @@ class QueryTest_Collection: QueryTest {
     // MARK: 8.11 SQL++ Query
     
     func testQueryDefaultCollection() throws {
-        guard let collection = try self.db.defaultCollection() else {
-            XCTFail("Default collection should exists")
-            return
-        }
-        
-        try testQueryCollection(collection, queries: [
+        try testQueryCollection(self.db.defaultCollection(), queries: [
             "SELECT name.first FROM _ ORDER BY name.first LIMIT 1",
             "SELECT name.first FROM _default ORDER BY name.first limit 1",
             "SELECT name.first FROM testdb ORDER BY name.first limit 1"
@@ -95,12 +90,9 @@ class QueryTest_Collection: QueryTest {
     }
     
     func testQueryBuilderWithDefaultCollectionAsDataSource() throws {
-        guard let col = try self.db.defaultCollection() else {
-            XCTFail("Default collection")
-            return
-        }
+        let col = try self.db.defaultCollection();
         
-        try loadJSONResource("names_100", collection: col)
+        try loadJSONResource("names_100", collection: self.db.defaultCollection())
         
         let q = QueryBuilder
             .select([SelectResult.property("name.first")])

--- a/Swift/Tests/ReplicatorTest+Collection.swift
+++ b/Swift/Tests/ReplicatorTest+Collection.swift
@@ -39,11 +39,7 @@ class ReplicatorTest_Collection: ReplicatorTest {
         XCTAssertEqual(config.collections.count, 1)
         
         
-        guard let col = try self.db.defaultCollection() else {
-            XCTFail("Default collection is missing!")
-            return
-        }
-        
+        let col = try self.db.defaultCollection()
         XCTAssertEqual(col, config.collections[0])
         XCTAssertEqual(col.name, config.collections[0].name)
         XCTAssertEqual(col.scope.name, config.collections[0].scope.name)
@@ -71,17 +67,12 @@ class ReplicatorTest_Collection: ReplicatorTest {
     }
     
     func defaultCollection() throws -> Collection {
-        guard let col = try self.db.defaultCollection() else {
-            fatalError("Default collection is missing!")
-        }
-        
-        return col
+        return try self.db.defaultCollection()
     }
     
     func testConfigWithDatabaseAndConflictResolver() throws {
         let url = URL(string: "wss://foo")!
         let target = URLEndpoint(url: url)
-        
         var config = ReplicatorConfiguration(database: self.db, target: target)
         
         let conflictResolver = TestConflictResolver({ (con: Conflict) -> Document? in


### PR DESCRIPTION
* As we do not allow to delete the default collection, getting the default collection should return non-null collection for swift.

* Fixed -defaultCollection: collection logic in CBLDatabase to return error correctly, and made getting default collection lazily.

* Cleaned up get collection and get scope implementation in both objective-c and swift, and ensured that there is no NotFound error returned when the collection or scope doesn’t exist.