### PR TITLE
CBL-4336 : Add subscript function to Collection class

### DIFF
--- a/Objective-C/CBLCollection.h
+++ b/Objective-C/CBLCollection.h
@@ -23,6 +23,7 @@
 
 @class CBLDocument;
 @class CBLDocumentChange;
+@class CBLDocumentFragment;
 @class CBLMutableDocument;
 @class CBLScope;
 @protocol CBLListenerToken;
@@ -89,6 +90,16 @@ extern NSString* const kCBLDefaultCollectionName;
  */
 - (nullable CBLDocument*) documentWithID: (NSString*)documentID
                                    error: (NSError**)error NS_SWIFT_NOTHROW;
+
+#pragma mark - Subscript
+
+/**
+ Gets a document fragment with the given document ID.
+ 
+ @param documentID The document ID.
+ @return The CBLDocumentFragment object.
+ */
+- (CBLDocumentFragment*) objectForKeyedSubscript: (NSString*)documentID;
 
 #pragma mark - Save, Delete, Purge
 

--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -239,6 +239,17 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     }
 }
 
+#pragma mark - Subscript
+
+- (CBLDocumentFragment*) objectForKeyedSubscript: (NSString*)documentID {
+    NSError* error;
+    CBLDocument* doc = [self documentWithID: documentID error: &error];
+    if (error) {
+        CBLWarn(Database, @"%@: Error when getting a document with ID '%@': %@", self, documentID, error.description);
+    }
+    return [[CBLDocumentFragment alloc] initWithDocument: doc];
+}
+
 #pragma mark - Purge
 
 - (BOOL) purgeDocument: (CBLDocument*)document

--- a/Objective-C/CBLDatabase.h
+++ b/Objective-C/CBLDatabase.h
@@ -118,12 +118,13 @@ __deprecated_msg("Use [database defaultCollection] documentWithID:] instead.");
 
 
 /** 
- Gets a document fragment with the given document ID.
+ Gets a document fragment with the given document ID from the default collection.
  
  @param documentID The document ID.
  @return The CBLDocumentFragment object.
  */
-- (CBLDocumentFragment*) objectForKeyedSubscript: (NSString*)documentID;
+- (CBLDocumentFragment*) objectForKeyedSubscript: (NSString*)documentID
+__deprecated_msg("Use [[database defaultCollection] objectForKeyedSubscript:] instead.");
 
 
 #pragma mark - Save, Delete, Purge

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -206,12 +206,7 @@ static const C4DatabaseConfig2 kDBConfig = {
 #pragma mark - SUBSCRIPTION
 
 - (CBLDocumentFragment*) objectForKeyedSubscript: (NSString*)documentID {
-// TODO: Remove https://issues.couchbase.com/browse/CBL-3206
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [[CBLDocumentFragment alloc] initWithDocument: [self documentWithID: documentID]];
-#pragma clang diagnostic pop
-    
+    return [[self defaultCollectionOrThrow] objectForKeyedSubscript: documentID];
 }
 
 #pragma mark - SAVE

--- a/Objective-C/Tests/FragmentTest.m
+++ b/Objective-C/Tests/FragmentTest.m
@@ -166,14 +166,31 @@
     
 }
 
-- (void) testGetDocFragmentWithNonExistingID {
-    CBLDocumentFragment* doc = _db[@"doc1"];
+- (void) testGetDocFragmentWithIDFromCollection {
+    NSError* error;
+    CBLCollection* col = [self.db createCollectionWithName: @"colA" scope: @"scopeA" error: &error];
+    AssertNotNil(col);
+    
+    // Not exist:
+    CBLDocumentFragment* doc = col[@"doc1"];
     AssertNotNil(doc);
     AssertFalse(doc.exists);
     AssertNil(doc.document);
-    AssertNil(doc[@"address"][@"street"].string);
-    AssertNil(doc[@"address"][@"city"].string);
-    AssertNil(doc[@"address"][@"state"].string);
+    
+    NSDictionary* dict = @{@"address": @{
+                                   @"street": @"1 Main street",
+                                   @"city": @"Mountain View",
+                                   @"state": @"CA"}};
+    [self saveDocument: [self createDocument: @"doc1" data: dict] collection: col];
+    
+    // Exist:
+    doc = col[@"doc1"];
+    AssertNotNil(doc);
+    Assert(doc.exists);
+    AssertNotNil(doc.document);
+    AssertEqualObjects(doc[@"address"][@"street"].string, @"1 Main street");
+    AssertEqualObjects(doc[@"address"][@"city"].string, @"Mountain View");
+    AssertEqualObjects(doc[@"address"][@"state"].string, @"CA");
 }
 
 - (void) testGetFragmentFromDictionaryValue {

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -84,6 +84,11 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
         return nil
     }
     
+    /// Gets document fragment object by the given document ID.
+    public subscript(key: String) -> DocumentFragment {
+        return DocumentFragment(impl[key], collection: self)
+    }
+    
     /// Save a document into the collection. The default concurrency control, lastWriteWins,
     /// will be used when there is conflict during  save.
     ///

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -91,12 +91,12 @@ public final class Database {
         return nil
     }
     
-    /// Gets document fragment object by the given document ID.
+    /// Gets document fragment object from the default collection by the given document ID.
+    @available(*, deprecated, message: "Use database.defaultCollection().subscript(key:) instead.")
     public subscript(key: String) -> DocumentFragment {
         guard let col = try? defaultCollection() else {
             Database.throwNotOpenError()
         }
-        
         return DocumentFragment(impl[key], collection: col)
     }
     

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -175,6 +175,13 @@ class CBLTestCase: XCTestCase {
         eval(savedDoc)
     }
     
+    func saveDocument(_ document: MutableDocument, collection: Collection) throws {
+        try collection.save(document: document)
+        let savedDoc = try collection.document(id: document.id)
+        XCTAssertNotNil(savedDoc)
+        XCTAssertEqual(savedDoc!.id, document.id)
+    }
+    
     func urlForResource(name: String, ofType type: String) -> URL? {
         let res = ("Support" as NSString).appendingPathComponent(name)
         return Bundle(for: Swift.type(of:self)).url(forResource: res, withExtension: type)

--- a/Swift/Tests/FragmentTest.swift
+++ b/Swift/Tests/FragmentTest.swift
@@ -82,6 +82,30 @@ class FragmentTest: CBLTestCase {
         XCTAssertNil(doc["address"]["state"].string)
     }
     
+    func testGetDocFragmentWithIDFromCollection() throws {
+        let col = try self.db.createCollection(name: "colA", scope: "scopeA")
+        
+        // Not exist
+        var doc = col["doc1"]
+        XCTAssertNotNil(doc)
+        XCTAssertFalse(doc.exists)
+        
+        let dict: [String: Any] = ["address": [
+                                    "street": "1 Main street",
+                                    "city": "Mountain View",
+                                    "state": "CA"]]
+        try saveDocument(createDocument("doc1", data: dict), collection: col)
+        
+        // Exist
+        doc = col["doc1"]
+        XCTAssertNotNil(doc)
+        XCTAssertTrue(doc.exists)
+        XCTAssertNotNil(doc.document)
+        XCTAssertEqual(doc["address"]["street"].string!, "1 Main street")
+        XCTAssertEqual(doc["address"]["city"].string!, "Mountain View")
+        XCTAssertEqual(doc["address"]["state"].string!, "CA")
+    }
+    
     func testGetFragmentFromDictionaryValue() throws {
         let dict: [String: Any] = ["address": [
                                     "street": "1 Main street",


### PR DESCRIPTION
* Ported the fix (6dbd9d65d5cea7556cd88ab380c10428796913a6) from release/3.1 branch (CBL-4308)

* We have a subscript function in the Database class for getting a document from the database using the subscript syntax such as database[“doc1”]. This is Apple platform only API.  The subscript function in the database class should be deprecated and there should be the same functionality implemented in the Collection class for an alternative API.

* Deprecated subscript function the in Database class for both Swift and Objective-C.

* Implemented subscript function in Collection class.