### PR TITLE
CBL-4401: Update tests to avoid use of deprecated api 1

### DIFF
--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -40,7 +40,9 @@ class CBLTestCase: XCTestCase {
     
     let otherDatabaseName = "otherdb"
     
-    var defaultCol: Collection?
+    var defaultCollection: Collection?
+    
+    var otherDB_defaultCollection: Collection?
     
     #if COUCHBASE_ENTERPRISE
         let directory = NSTemporaryDirectory().appending("CouchbaseLite-EE")
@@ -89,7 +91,7 @@ class CBLTestCase: XCTestCase {
     }
     
     override func tearDown() {
-        self.defaultCol = nil
+        self.defaultCollection = nil
         try! db.close()
         try! otherDB?.close()
         super.tearDown()
@@ -103,7 +105,7 @@ class CBLTestCase: XCTestCase {
     
     func openDB() throws {
         db = try openDB(name: databaseName)
-        self.defaultCol = try! db.defaultCollection()
+        self.defaultCollection = try! db.defaultCollection()
     }
     
     func reopenDB() throws {
@@ -119,6 +121,7 @@ class CBLTestCase: XCTestCase {
     
     func openOtherDB() throws {
         otherDB = try openDB(name: otherDatabaseName)
+        self.otherDB_defaultCollection = try! otherDB?.defaultCollection()
     }
     
     func reopenOtherDB() throws {
@@ -165,8 +168,8 @@ class CBLTestCase: XCTestCase {
     }
     
     func saveDocument(_ document: MutableDocument) throws {
-        try defaultCol!.save(document: document)
-        let savedDoc = try defaultCol!.document(id: document.id)
+        try defaultCollection!.save(document: document)
+        let savedDoc = try defaultCollection!.document(id: document.id)
         XCTAssertNotNil(savedDoc)
         XCTAssertEqual(savedDoc!.id, document.id)
     }
@@ -175,7 +178,7 @@ class CBLTestCase: XCTestCase {
         eval(document)
         try saveDocument(document)
         eval(document)
-        let savedDoc = try defaultCol!.document(id: document.id)!
+        let savedDoc = try defaultCollection!.document(id: document.id)!
         eval(savedDoc)
     }
     
@@ -219,7 +222,7 @@ class CBLTestCase: XCTestCase {
     }
     
     func loadJSONResource(name: String) throws {
-        try loadJSONResource(name, collection: self.db.defaultCollection())
+        try loadJSONResource(name, collection: self.defaultCollection!)
     }
     
     func jsonFromDate(_ date: Date) -> String {

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -40,6 +40,8 @@ class CBLTestCase: XCTestCase {
     
     let otherDatabaseName = "otherdb"
     
+    var defaultCol: Collection?
+    
     #if COUCHBASE_ENTERPRISE
         let directory = NSTemporaryDirectory().appending("CouchbaseLite-EE")
     #else
@@ -87,6 +89,7 @@ class CBLTestCase: XCTestCase {
     }
     
     override func tearDown() {
+        self.defaultCol = nil
         try! db.close()
         try! otherDB?.close()
         super.tearDown()
@@ -100,6 +103,7 @@ class CBLTestCase: XCTestCase {
     
     func openDB() throws {
         db = try openDB(name: databaseName)
+        self.defaultCol = try! db.defaultCollection()
     }
     
     func reopenDB() throws {
@@ -161,8 +165,8 @@ class CBLTestCase: XCTestCase {
     }
     
     func saveDocument(_ document: MutableDocument) throws {
-        try db.saveDocument(document)
-        let savedDoc = db.document(withID: document.id)
+        try defaultCol!.save(document: document)
+        let savedDoc = try defaultCol!.document(id: document.id)
         XCTAssertNotNil(savedDoc)
         XCTAssertEqual(savedDoc!.id, document.id)
     }
@@ -171,7 +175,7 @@ class CBLTestCase: XCTestCase {
         eval(document)
         try saveDocument(document)
         eval(document)
-        let savedDoc = db.document(withID: document.id)!
+        let savedDoc = try defaultCol!.document(id: document.id)!
         eval(savedDoc)
     }
     

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -22,8 +22,8 @@ import CouchbaseLiteSwift
 
 class DatabaseTest: CBLTestCase {
 
-    func verifyDocument(withID id: String, data: Dictionary<String, Any>) {
-        let doc = db.document(withID: id)
+    func verifyDocument(withID id: String, data: Dictionary<String, Any>) throws {
+        let doc = try defaultCol!.document(id: id )
         XCTAssertNotNil(doc)
         XCTAssertEqual(doc!.id, id)
         XCTAssertTrue(doc!.toDictionary() == data)
@@ -41,26 +41,27 @@ class DatabaseTest: CBLTestCase {
         return docs;
     }
     
-    func validateDocs(_ n: Int) {
+    func validateDocs(_ n: Int) throws {
         for i in 0..<n {
             let docID = String(format: "doc_%03d", i)
-            verifyDocument(withID: docID, data: ["key": i])
+            try verifyDocument(withID: docID, data: ["key": i])
         }
     }
     
     func saveDocument(_ document: MutableDocument,
                       concurrencyControl: ConcurrencyControl?) throws -> Bool
     {
+        
         var success = true
         if let cc = concurrencyControl {
-            success = try db.saveDocument(document, concurrencyControl: cc)
+            success = try defaultCol!.save(document: document, concurrencyControl: cc)
             if cc == .failOnConflict {
                 XCTAssertFalse(success)
             } else {
                 XCTAssertTrue(success)
             }
         } else {
-            try db.saveDocument(document)
+            try defaultCol!.save(document: document)
         }
         return success
     }
@@ -70,14 +71,14 @@ class DatabaseTest: CBLTestCase {
     {
         var success = true
         if let cc = concurrencyControl {
-            success = try db.deleteDocument(document, concurrencyControl: cc)
+            success = try defaultCol!.delete(document: document, concurrencyControl: cc)
             if cc == .failOnConflict {
                 XCTAssertFalse(success)
             } else {
                 XCTAssertTrue(success)
             }
         } else {
-            try db.deleteDocument(document)
+            try defaultCol!.delete(document: document)
         }
         return success
     }
@@ -95,13 +96,13 @@ class DatabaseTest: CBLTestCase {
     }
     
     func testCreateNamedDocument() throws {
-        XCTAssertNil(db.document(withID: "doc1"))
+        XCTAssertNil(try defaultCol!.document(id: "doc1"))
 
         let doc = MutableDocument(id: "doc1")
         XCTAssertEqual(doc.id, "doc1")
         XCTAssertTrue(doc.toDictionary() == [:] as [String: Any])
         
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
     }
     
     
@@ -115,21 +116,21 @@ class DatabaseTest: CBLTestCase {
                 for i in 0...25{
                     let mdoc = doc.toMutable()
                     mdoc.setValue(i, forKey: "number")
-                    try db.saveDocument(mdoc)
+                    try defaultCol!.save(document:mdoc)
                 }
             }
         }
         
         // Add each doc with a blob object:
         for doc in docs {
-            let mdoc = db.document(withID: doc.id)!.toMutable()
+            let mdoc = try defaultCol!.document(id: doc.id)!.toMutable()
             let data = doc.id.data(using: .utf8)
             let blob = Blob.init(contentType: "text/plain", data: data!)
             mdoc.setValue(blob, forKey: "blob")
-            try db.saveDocument(mdoc)
+            try defaultCol!.save(document:mdoc)
         }
         
-        XCTAssertEqual(db.count, 20)
+        XCTAssertEqual(defaultCol!.count, 20)
         
         let attachmentDir = (db.path! as NSString).appendingPathComponent("Attachments")
         var attachments = try FileManager.default.contentsOfDirectory(atPath: attachmentDir)
@@ -140,11 +141,11 @@ class DatabaseTest: CBLTestCase {
         
         // Delete all docs:
         for doc in docs {
-            let doc = db.document(withID: doc.id)!
-            try db.deleteDocument(doc)
-            XCTAssertNil(db.document(withID: doc.id))
+            let doc = try defaultCol!.document(id: doc.id)!
+            try defaultCol!.delete(document: doc)
+            XCTAssertNil(try defaultCol!.document(id: doc.id))
         }
-        XCTAssertEqual(db.count, 0)
+        XCTAssertEqual(defaultCol!.count, 0)
         
         attachments = try FileManager.default.contentsOfDirectory(atPath: attachmentDir)
         XCTAssertEqual(attachments.count, 20)
@@ -167,13 +168,13 @@ class DatabaseTest: CBLTestCase {
         let key = Expression.property("key")
         let keyItem = ValueIndexItem.expression(key)
         let keyIndex = IndexBuilder.valueIndex(items: keyItem)
-        try db.createIndex(keyIndex, withName: "KeyIndex")
-        XCTAssertEqual(db.indexes.count, 1)
+        try defaultCol!.createIndex(keyIndex, name: "KeyIndex")
+        XCTAssertEqual(try defaultCol!.indexes().count, 1)
         
         // Check if the index is used:
         let q = QueryBuilder
             .select(SelectResult.expression(key))
-            .from(DataSource.database(db))
+            .from(DataSource.collection(defaultCol!))
             .where(key.greaterThan(Expression.int(9)))
         
         var explain = try q.explain() as NSString
@@ -183,7 +184,7 @@ class DatabaseTest: CBLTestCase {
         try db.performMaintenance(type: .reindex)
         
         // Check if the index is still there and used:
-        XCTAssertEqual(db.indexes.count, 1)
+        XCTAssertEqual(try defaultCol!.indexes().count, 1)
         explain = try q.explain() as NSString
         XCTAssertNotEqual(explain.range(of: "USING INDEX KeyIndex").location, NSNotFound)
     }
@@ -198,32 +199,32 @@ class DatabaseTest: CBLTestCase {
                 for i in 0...25{
                     let mdoc = doc.toMutable()
                     mdoc.setValue(i, forKey: "number")
-                    try db.saveDocument(mdoc)
+                    try defaultCol!.save(document: mdoc)
                 }
             }
         }
         
         // Add each doc with a blob object:
         for doc in docs {
-            let mdoc = db.document(withID: doc.id)!.toMutable()
+            let mdoc = try defaultCol!.document(id: doc.id)!.toMutable()
             let data = doc.id.data(using: .utf8)
             let blob = Blob.init(contentType: "text/plain", data: data!)
             mdoc.setValue(blob, forKey: "blob")
-            try db.saveDocument(mdoc)
+            try defaultCol!.save(document: mdoc)
         }
         
-        XCTAssertEqual(db.count, 20)
+        XCTAssertEqual(defaultCol!.count, 20)
         
         // Integrity Check:
         try db.performMaintenance(type: .integrityCheck)
         
         // Delete all docs:
         for doc in docs {
-            let doc = db.document(withID: doc.id)!
-            try db.deleteDocument(doc)
-            XCTAssertNil(db.document(withID: doc.id))
+            let doc = try defaultCol!.document(id: doc.id)!
+            try defaultCol!.delete(document: doc)
+            XCTAssertNil(try defaultCol!.document(id: doc.id))
         }
-        XCTAssertEqual(db.count, 0)
+        XCTAssertEqual(defaultCol!.count, 0)
         
         // Integrity Check:
         try db.performMaintenance(type: .integrityCheck)
@@ -233,11 +234,11 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch {
             for i in 0...9{
                 let doc = MutableDocument(id: "doc\(i)")
-                try db.saveDocument(doc)
+                try defaultCol!.save(document: doc)
             }
         }
         for _ in 0...9 {
-            XCTAssertNotNil(db.document(withID: "doc1"))
+            XCTAssertNotNil(try defaultCol!.document(id: "doc1"))
         }
     }
     
@@ -267,15 +268,16 @@ class DatabaseTest: CBLTestCase {
         // Verify:
         XCTAssert(Database.exists(withName: dbName, inDirectory: dir))
         let nudb = try Database.init(name: dbName, config: config)
-        XCTAssertEqual(nudb.count, 10)
+        let nudb_defaultCol = try nudb.defaultCollection()
+        XCTAssertEqual(nudb_defaultCol.count, 10)
         
         let query = QueryBuilder
             .select(SelectResult.expression(Meta.id))
-            .from(DataSource.database(self.db))
+            .from(DataSource.collection(nudb_defaultCol))
         let rs = try query.execute()
         for r in rs {
             let docID = r.string(at: 0)!
-            let doc = nudb.document(withID: docID)!
+            let doc = try nudb_defaultCol.document(id: docID)!
             XCTAssertEqual(doc.string(forKey: "name"), docID)
             
             let blob = doc.blob(forKey: "data")!
@@ -292,21 +294,21 @@ class DatabaseTest: CBLTestCase {
     
     func testSaveDocWithID() throws {
         let doc = try generateDocument(withID: "doc1")
-        XCTAssertEqual(db.count, 1)
-        verifyDocument(withID: doc.id, data: doc.toDictionary())
+        XCTAssertEqual(defaultCol!.count, 1)
+        try verifyDocument(withID: doc.id, data: doc.toDictionary())
     }
     
     func testSaveDocWithSpecialCharactersDocID() throws {
         let docID = "`~@#$%^&*()_+{}|\\][=-/.,<>?\":;'"
         let doc = try generateDocument(withID: docID)
-        XCTAssertEqual(db.count, 1)
-        verifyDocument(withID: doc.id, data: doc.toDictionary())
+        XCTAssertEqual(defaultCol!.count, 1)
+        try verifyDocument(withID: doc.id, data: doc.toDictionary())
     }
     
     func testSaveDocWIthAutoGeneratedID() throws {
         let doc = try generateDocument(withID: nil)
-        XCTAssertEqual(db.count, 1)
-        verifyDocument(withID: doc.id, data: doc.toDictionary())
+        XCTAssertEqual(defaultCol!.count, 1)
+        try verifyDocument(withID: doc.id, data: doc.toDictionary())
     }
     
     func testSaveDocInDifferenceDBInstance() throws {
@@ -314,11 +316,11 @@ class DatabaseTest: CBLTestCase {
         
         let otherDB = try self.openDB(name: db.name)
         XCTAssertNotNil(otherDB)
-        XCTAssertEqual(otherDB.count, 1)
+        XCTAssertEqual(try otherDB.defaultCollection().count, 1)
         
         doc.setValue(2, forKey: "key")
         expectError(domain: CBLError.domain, code: CBLError.invalidParameter) {
-            try otherDB.saveDocument(doc)
+            try otherDB.defaultCollection().save(document: doc)
         } // forbidden
         
         try otherDB.close()
@@ -329,11 +331,11 @@ class DatabaseTest: CBLTestCase {
         
         let otherDB = try self.openDB(name: "otherDB")
         XCTAssertNotNil(otherDB)
-        XCTAssertEqual(otherDB.count, 0)
+        XCTAssertEqual(try otherDB.defaultCollection().count, 0)
         
         doc.setValue(2, forKey: "key")
         expectError(domain: CBLError.domain, code: CBLError.invalidParameter) {
-            try otherDB.saveDocument(doc)
+            try otherDB.defaultCollection().save(document: doc)
         } // forbidden
         
         try otherDB.close()
@@ -343,37 +345,37 @@ class DatabaseTest: CBLTestCase {
         let doc = try generateDocument(withID: "doc1")
         try saveDocument(doc)
         
-        let doc1 = db.document(withID: doc.id)!
+        let doc1 = try defaultCol!.document(id: doc.id)!
         XCTAssertEqual(doc1.sequence, 2)
-        XCTAssertEqual(db.count, 1)
+        XCTAssertEqual(defaultCol!.count, 1)
     }
     
     func testSaveInBatch() throws {
         try db.inBatch {
             try createDocs(10)
         }
-        XCTAssertEqual(db.count, 10)
-        validateDocs(10)
+        XCTAssertEqual(defaultCol!.count, 10)
+        try validateDocs(10)
     }
     
     func testSaveWithErrorInBatch() throws {
         do {
             try self.db.inBatch {
                 try self.createDocs(10)
-                XCTAssertEqual(db.count, 10)
+                XCTAssertEqual(defaultCol!.count, 10)
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
         } catch {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(db.count, 0)
+        XCTAssertEqual(defaultCol!.count, 0)
     }
     
     func testSaveManyDocs() throws {
         try createDocs(1000)
-        XCTAssertEqual(db.count, 1000)
-        validateDocs(1000)
+        XCTAssertEqual(defaultCol!.count, 1000)
+        try validateDocs(1000)
         
         // Cleanup:
         try db.delete()
@@ -382,29 +384,29 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch {
             try createDocs(1000)
         }
-        XCTAssertEqual(db.count, 1000)
-        validateDocs(1000)
+        XCTAssertEqual(defaultCol!.count, 1000)
+        try validateDocs(1000)
     }
     
     func testAndUpdateMutableDoc() throws {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Update
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Update
         doc.setInt(20, forKey: "age")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         let expectedResult: [String : Any] =
             ["firstName": "Daniel", "lastName": "Tiger", "age": 20]
         XCTAssertTrue(doc.toDictionary() == expectedResult)
         XCTAssertEqual(doc.sequence, 3)
         
-        let savedDoc = db.document(withID: doc.id)!
+        let savedDoc = try defaultCol!.document(id: doc.id)!
         XCTAssertTrue(savedDoc.toDictionary() == expectedResult)
         XCTAssertEqual(savedDoc.sequence, 3)
     }
@@ -420,17 +422,17 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = db.document(withID: doc.id)!.toMutable()
-        let doc1b = db.document(withID: doc.id)!.toMutable()
+        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         
         // Modify doc1a:
         doc1a.setString("Scott", forKey: "firstName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         doc1a.setString("Scotty", forKey: "nickName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         XCTAssertTrue(doc1a.toDictionary() ==
             ["firstName": "Scott", "lastName": "Tiger", "nickName": "Scotty"])
         XCTAssertEqual(doc1a.sequence, 3)
@@ -438,7 +440,7 @@ class DatabaseTest: CBLTestCase {
         // Modify doc1b:
         doc1b.setString("Lion", forKey: "lastName")
         if try saveDocument(doc1b, concurrencyControl: cc) {
-            let savedDoc = db.document(withID: doc1b.id)!
+            let savedDoc = try defaultCol!.document(id: doc1b.id)!
             XCTAssertTrue(savedDoc.toDictionary() == doc1b.toDictionary())
             XCTAssertEqual(savedDoc.sequence, 4)
         }
@@ -458,16 +460,16 @@ class DatabaseTest: CBLTestCase {
         let doc1a = createDocument("doc1")
         doc1a.setString("Daniel", forKey: "firstName")
         doc1a.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         XCTAssertEqual(doc1a.sequence, 1)
-        let savedDoc = db.document(withID: "doc1")!
+        let savedDoc = try defaultCol!.document(id: "doc1")!
         XCTAssertEqual(savedDoc.sequence, 1)
         
         let doc1b = createDocument(doc1a.id)
         doc1b.setString("Scott", forKey: "firstName")
         doc1b.setString("Tiger", forKey: "lastName")
         if try saveDocument(doc1b, concurrencyControl: cc) {
-            let savedDoc = db.document(withID: doc1b.id)!
+            let savedDoc = try defaultCol!.document(id: doc1b.id)!
             XCTAssertTrue(savedDoc.toDictionary() == doc1b.toDictionary())
             XCTAssertEqual(savedDoc.sequence, 2)
         }
@@ -487,21 +489,21 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = db.document(withID: doc.id)!
-        let doc1b = db.document(withID: doc.id)!.toMutable()
+        let doc1a = try defaultCol!.document(id: doc.id)!
+        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         
         // Delete doc1a
-        try db.deleteDocument(doc1a)
+        try defaultCol!.delete(document: doc1a)
         XCTAssertEqual(doc1a.sequence, 2)
-        XCTAssertNil(db.document(withID: doc1a.id))
+        XCTAssertNil(try defaultCol!.document(id: doc1a.id))
         
         // Modify doc1b:
         doc1b.setString("Lion", forKey: "lastName")
         if try saveDocument(doc1b, concurrencyControl: cc) {
-            let savedDoc = db.document(withID: doc1b.id)!
+            let savedDoc = try defaultCol!.document(id: doc1b.id)!
             XCTAssertTrue(savedDoc.toDictionary() == doc1b.toDictionary())
             XCTAssertEqual(savedDoc.sequence, 3)
         }
@@ -516,16 +518,16 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = db.document(withID: doc.id)!.toMutable()
-        let doc1b = db.document(withID: doc.id)!.toMutable()
+        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         
         // Modify doc1a:
         doc1a.setString("Scott", forKey: "firstName")
         doc1a.setString("Scotty", forKey: "nickName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         XCTAssertTrue(doc1a.toDictionary() == ["firstName": "Scott",
                                                "lastName": "Tiger",
                                                "nickName": "Scotty"])
@@ -535,13 +537,13 @@ class DatabaseTest: CBLTestCase {
         doc1b.setString("Lion", forKey: "middleName")
         
         // merge the dictionaries, and keeping the doc1b dictionary values if duplicate comes in.
-        try db.saveDocument(doc1b) { (doc, old) -> Bool in
+        XCTAssertTrue(try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
             let merged = doc.toDictionary()
                 .merging(old!.toDictionary(), uniquingKeysWith: { (first, _) in first })
             doc.setData(merged)
             return true
-        }
-        let savedDoc = db.document(withID: doc1b.id)!
+        })
+        let savedDoc = try defaultCol!.document(id: doc1b.id)!
         XCTAssertTrue(savedDoc.toDictionary() == ["firstName": "Daniel", // kept previous key value
                                                   "nickName": "Scotty", // merged
                                                   "lastName": "Tiger",  // NA
@@ -552,54 +554,54 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // create conflict and return false
-        var doc1a = db.document(withID: doc.id)!.toMutable()
-        var doc1b = db.document(withID: doc.id)!.toMutable()
+        var doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        var doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         doc1a.setString("Scott", forKey: "firstName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         doc1b.setString("Lion", forKey: "middleName")
-        XCTAssertFalse(try db.saveDocument(doc1b) { (doc, old) -> Bool in
+        XCTAssertFalse(try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
             XCTAssert(doc1b == doc)
             XCTAssertEqual(doc1a, old)
             return false
             })
         
         // check it is same as old doc, and didn't updated the doc
-        XCTAssertEqual(db.document(withID: doc1b.id)!, doc1a)
+        XCTAssertEqual(try defaultCol!.document(id: doc1b.id)!, doc1a)
         
         // Updates to Current Mutable Document, should not save contents.
         // create conflict, update the mutable doc, and return false
-        doc1a = db.document(withID: doc.id)!.toMutable()
-        doc1b = db.document(withID: doc.id)!.toMutable()
+        doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         doc1a.setString("Sccotty", forKey: "nickname")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         doc1b.setString("Scotty", forKey: "nickname")
-        XCTAssertFalse(try db.saveDocument(doc1b) { (doc, old) -> Bool in
+        XCTAssertFalse(try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
             XCTAssert(doc1b == doc)
             XCTAssertEqual(doc1a, old)
             doc.setString("Scott", forKey: "nickname")
             return false
             })
         // check whether it is same old doc, and no update happened.
-        XCTAssertEqual(db.document(withID: doc1b.id)!, doc1a)
+        XCTAssertEqual(try defaultCol!.document(id: doc1b.id)!, doc1a)
     }
     
     func testConflictHandlerWhenDocumentIsPurged() throws {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Purge one instance
-        let doc1a = db.document(withID: doc.id)!.toMutable()
-        try db.purgeDocument(db.document(withID: doc.id)!)
+        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        try defaultCol!.purge(document: try defaultCol!.document(id: doc.id)!)
         
         doc1a.setString("Scotty", forKey: "nickName")
         ignoreException {
             do {
-                try self.db.saveDocument(doc1a) { (doc, old) -> Bool in
+                _ = try self.defaultCol!.save(document: doc1a) { (doc, old) -> Bool in
                     return true
                 }
                 XCTFail("Shouldn't reach here, it should throw an exception when saving")
@@ -612,52 +614,52 @@ class DatabaseTest: CBLTestCase {
     
     func testConflictHandlerWithDeletedOldDoc() throws {
         let doc = createDocument("doc1")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // KEEPS NEW DOC(non-deleted)
-        var doc1a = db.document(withID: doc.id)!.toMutable()
-        try db.deleteDocument(db.document(withID: doc.id)!, concurrencyControl: .failOnConflict)
+        var doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        XCTAssertTrue(try defaultCol!.delete(document: try defaultCol!.document(id: doc.id)!, concurrencyControl: .failOnConflict))
         
         doc1a.setString("Lion", forKey: "middleName")
-        try db.saveDocument(doc1a) { (doc, old) -> Bool in
+        XCTAssertTrue(try defaultCol!.save(document: doc1a) { (doc, old) -> Bool in
             XCTAssertNil(old)
             XCTAssertNotNil(doc)
             XCTAssert(doc == doc1a)
             return true
-        }
-        XCTAssert(db.document(withID: doc.id) == doc1a)
+        })
+        XCTAssert(try defaultCol!.document(id: doc.id) == doc1a)
         
         // KEEPS THE DELETED(old doc)
-        doc1a = db.document(withID: doc.id)!.toMutable()
-        try db.deleteDocument(db.document(withID: doc.id)!, concurrencyControl: .failOnConflict)
+        doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        XCTAssertTrue(try defaultCol!.delete(document: try defaultCol!.document(id: doc.id)!, concurrencyControl: .failOnConflict))
         
         doc1a.setString("Lion", forKey: "nickName")
-        try db.saveDocument(doc1a) { (doc, old) -> Bool in
+        XCTAssertFalse(try defaultCol!.save(document: doc1a) { (doc, old) -> Bool in
             XCTAssertNil(old)
             XCTAssertNotNil(doc)
             XCTAssert(doc == doc1a)
             return false
-        }
-        XCTAssertNil(db.document(withID: doc.id))
+        })
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
     }
     
     func testConflictHandlerCalledTwice() throws {
         let doc = createDocument("doc1")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
-        let doc1a = db.document(withID: doc.id)!.toMutable()
-        let doc1b = db.document(withID: doc.id)!.toMutable()
+        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         doc1a.setString("Scott", forKey: "firstName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         
         doc1b.setString("Lion", forKey: "middleName")
         var count = 0
-        try db.saveDocument(doc1b) { (doc, old) -> Bool in
+        _ = try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
             count += 1
-            let doc1c = self.db.document(withID: doc.id)!.toMutable()
+            let doc1c = try! self.defaultCol!.document(id: doc.id)!.toMutable()
             if !doc1c.boolean(forKey: "secondUpdate") {
                 doc1c.setBoolean(true, forKey: "secondUpdate")
-                try! self.db.saveDocument(doc1c)
+                try! self.defaultCol!.save(document: doc1c)
             }
             
             // merge contents
@@ -671,12 +673,12 @@ class DatabaseTest: CBLTestCase {
         }
         
         XCTAssertEqual(count, 2) // make sure the save handler called twice
-        XCTAssertEqual(db.count, 1)
+        XCTAssertEqual(defaultCol!.count, 1)
         let dict: [String: Any] = ["middleName": "Lion", // old doc contents - merged
             "firstName": "Scott", // savedDoc contents
             "secondUpdate": true, // second update did.
             "edit": "local"] // new prop added during resolve.
-        XCTAssert(db.document(withID: doc1b.id)!.toDictionary() == dict)
+        XCTAssert(try defaultCol!.document(id: doc1b.id)!.toDictionary() == dict)
     }
     
     /// disabling since, exceptions inside conflict handler will leak, since objc doesn't perform release
@@ -685,17 +687,17 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
-        let doc1a = db.document(withID: doc.id)!.toMutable()
-        let doc1b = db.document(withID: doc.id)!.toMutable()
+        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         doc1a.setString("Scott", forKey: "firstName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         
         // conflicting save
         doc1b.setString("Lion", forKey: "middleName")
         ignoreException {
-            XCTAssertFalse(try self.db.saveDocument(doc1b) { (cur, old) -> Bool in
+            XCTAssertFalse(try self.defaultCol!.save(document: doc1b) { (cur, old) -> Bool in
                 NSException(name: .internalInconsistencyException,
                             reason: "some exception happened inside save handler",
                             userInfo: nil).raise()
@@ -710,54 +712,54 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setValue(1, forKey: "key")
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.deleteDocument(doc)
+            try self.defaultCol!.delete(document: doc)
         }
     }
     
     func testDeleteDoc() throws {
         let doc = try generateDocument(withID: "doc1")
-        try db.deleteDocument(doc)
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: doc.id))
+        try defaultCol!.delete(document: doc)
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
     }
     
     func testDeleteSameDocTwice() throws {
         let doc = try generateDocument(withID: "doc1")
         
         // First time deletion:
-        try db.deleteDocument(doc)
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: doc.id))
+        try defaultCol!.delete(document: doc)
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
         XCTAssertEqual(doc.sequence, 2)
         
         // Second time deletion:
-        try db.deleteDocument(doc)
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: doc.id))
+        try defaultCol!.delete(document: doc)
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
         XCTAssertEqual(doc.sequence, 3)
     }
     
     func testDeleteNoneExistingDoc() throws {
         let doc1a = try generateDocument(withID: "doc1")
-        let doc1b = db.document(withID: doc1a.id)!
+        let doc1b = try defaultCol!.document(id: doc1a.id)!
         
         // Purge doc:
-        try db.purgeDocument(doc1a)
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: doc1a.id))
+        try defaultCol!.purge(document: doc1a)
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: doc1a.id))
         
         // Delete doc1a, 404 error:
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.deleteDocument(doc1a)
+            try self.defaultCol!.delete(document: doc1a)
         }
         
         // Delete doc, 404 error:
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.deleteDocument(doc1b)
+            try self.defaultCol!.delete(document: doc1b)
         }
         
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: doc1b.id))
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: doc1b.id))
     }
     
     func testDeleteDocInBatch() throws {
@@ -765,12 +767,12 @@ class DatabaseTest: CBLTestCase {
         let docs = try createDocs(10)
         try db.inBatch {
             for i in 0...9 {
-                let doc = db.document(withID: docs[i].id)!
-                try db.deleteDocument(doc)
-                XCTAssertEqual(db.count, UInt64(9 - i))
+                let doc = try defaultCol!.document(id: docs[i].id)!
+                try defaultCol!.delete(document: doc)
+                XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
             }
         }
-        XCTAssertEqual(db.count, 0)
+        XCTAssertEqual(defaultCol!.count, 0)
     }
     
     func testDeleteWithErrorInBatch() throws {
@@ -778,9 +780,9 @@ class DatabaseTest: CBLTestCase {
         do {
             try self.db.inBatch {
                 for i in 0...9 {
-                    let doc = db.document(withID: docs[i].id)!
-                    try db.deleteDocument(doc)
-                    XCTAssertEqual(db.count, UInt64(9 - i))
+                    let doc = try defaultCol!.document(id: docs[i].id)!
+                    try defaultCol!.delete(document: doc)
+                    XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
                 }
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
@@ -788,26 +790,26 @@ class DatabaseTest: CBLTestCase {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(db.count, 10)
+        XCTAssertEqual(defaultCol!.count, 10)
     }
     
     func testDeleteDocOnDeletedDB() throws {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
-        try db.deleteDocument(doc)
+        try defaultCol!.delete(document: doc)
         XCTAssertEqual(doc.sequence, 2)
-        XCTAssertNil(db.document(withID: doc.id))
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
         
         doc.setString("Scott", forKey: "firstName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         XCTAssertEqual(doc.sequence, 3)
         XCTAssertTrue(doc.toDictionary() ==
             ["firstName": "Scott", "lastName": "Tiger"])
         
-        let savedDoc = db.document(withID: doc.id)!
+        let savedDoc = try defaultCol!.document(id: doc.id)!
         XCTAssertTrue(savedDoc.toDictionary() == doc.toDictionary())
     }
     
@@ -815,18 +817,18 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
-        try db.deleteDocument(doc)
+        try defaultCol!.delete(document: doc)
         XCTAssertEqual(doc.sequence, 2)
-        XCTAssertNil(db.document(withID: doc.id))
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
         
         doc.setString("Scott", forKey: "firstName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         XCTAssertEqual(doc.sequence, 3)
         XCTAssertTrue(doc.toDictionary() == ["firstName": "Scott", "lastName": "Tiger"])
         
-        let savedDoc = db.document(withID: doc.id)!
+        let savedDoc = try defaultCol!.document(id: doc.id)!
         XCTAssertTrue(savedDoc.toDictionary() == doc.toDictionary())
     }
     
@@ -834,21 +836,21 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = db.document(withID: doc.id)!
-        let doc1b = db.document(withID: doc.id)!.toMutable()
+        let doc1a = try defaultCol!.document(id: doc.id)!
+        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         
         // Delete doc1a:
-        try db.deleteDocument(doc1a)
+        try defaultCol!.delete(document: doc1a)
         XCTAssertEqual(doc1a.sequence, 2)
-        XCTAssertNil(db.document(withID: doc.id))
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
         
         // Delete doc1b:
-        try db.deleteDocument(doc1b)
+        try defaultCol!.delete(document: doc1b)
         XCTAssertEqual(doc1a.sequence, 2)
-        XCTAssertNil(db.document(withID: doc.id))
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
     }
     
     func testDeleteDocWithConflict() throws {
@@ -861,15 +863,15 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try db.saveDocument(doc)
+        try defaultCol!.save(document: doc)
         
         // Get two document objects (doc1a and doc1b):
-        let doc1a = db.document(withID: doc.id)!.toMutable()
-        let doc1b = db.document(withID: doc.id)!.toMutable()
+        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
         
         // Modify doc1a
         doc1a.setString("Scott", forKey: "firstName")
-        try db.saveDocument(doc1a)
+        try defaultCol!.save(document: doc1a)
         XCTAssertTrue(doc1a.toDictionary() == ["firstName": "Scott", "lastName": "Tiger"])
         XCTAssertEqual(doc1a.sequence, 2)
         
@@ -877,7 +879,7 @@ class DatabaseTest: CBLTestCase {
         doc1b.setString("Lion", forKey: "lastName")
         if try deleteDocument(doc1b, concurrencyControl: cc) {
             XCTAssertEqual(doc1b.sequence, 3)
-            XCTAssertNil(db.document(withID: doc1b.id))
+            XCTAssertNil(try defaultCol!.document(id: doc1b.id))
         }
         XCTAssertTrue(doc1b.toDictionary() == ["firstName": "Daniel", "lastName": "Lion"])
         
@@ -890,24 +892,24 @@ class DatabaseTest: CBLTestCase {
     func testPurgePreSaveDoc() throws {
         let doc = createDocument("doc1")
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.purgeDocument(doc)
+            try self.defaultCol!.purge(document: doc)
         }
     }
     
     func testPurgeDoc() throws {
         let doc = try generateDocument(withID: "doc1")
-        try db.purgeDocument(doc)
-        XCTAssertNil(db.document(withID: "doc1"))
-        XCTAssertEqual(db.count, 0)
+        try defaultCol!.purge(document: doc)
+        XCTAssertNil(try defaultCol!.document(id: "doc1"))
+        XCTAssertEqual(defaultCol!.count, 0)
     }
     
     func testPurgeDocInDifferentDBInstance() throws {
         let doc = try generateDocument(withID: "doc1")
         let otherDB = try openDB(name: db.name)
-        XCTAssertNotNil(otherDB.document(withID: doc.id))
-        XCTAssertEqual(otherDB.count, 1)
+        XCTAssertNotNil(try otherDB.defaultCollection().document(id: doc.id))
+        XCTAssertEqual(try otherDB.defaultCollection().count, 1)
         expectError(domain: CBLError.domain, code: CBLErrorInvalidParameter) {
-            try otherDB.purgeDocument(doc)
+            try otherDB.defaultCollection().purge(document: doc)
         }
         try otherDB.close()
     }
@@ -916,19 +918,19 @@ class DatabaseTest: CBLTestCase {
         let doc = try generateDocument(withID: "doc1")
         let otherDB = try openDB(name: "otherDB")
         expectError(domain: CBLError.domain, code: CBLErrorInvalidParameter) {
-            try otherDB.purgeDocument(doc)
+            try otherDB.defaultCollection().purge(document: doc)
         }
         try otherDB.delete()
     }
     
     func testPurgeSameDocTwice() throws {
         let doc = try generateDocument(withID: "doc1")
-        try db.purgeDocument(doc)
-        XCTAssertNil(db.document(withID: "doc1"))
-        XCTAssertEqual(db.count, 0)
+        try defaultCol!.purge(document: doc)
+        XCTAssertNil(try defaultCol!.document(id: "doc1"))
+        XCTAssertEqual(defaultCol!.count, 0)
         
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.purgeDocument(doc)
+            try self.defaultCol!.purge(document: doc)
         }
     }
     
@@ -937,13 +939,13 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch {
             for i in 0..<10 {
                 let docID = String(format: "doc_%03d", i)
-                let doc = db.document(withID: docID)!
-                try self.db.purgeDocument(doc)
-                XCTAssertNil(db.document(withID: docID))
-                XCTAssertEqual(self.db.count, UInt64(9 - i))
+                let doc = try defaultCol!.document(id: docID)!
+                try self.defaultCol!.purge(document: doc)
+                XCTAssertNil(try defaultCol!.document(id: docID))
+                XCTAssertEqual(self.defaultCol!.count, UInt64(9 - i))
             }
         }
-        XCTAssertEqual(db.count, 0)
+        XCTAssertEqual(defaultCol!.count, 0)
     }
     
     func testPurgeWithErrorInBatch() throws {
@@ -951,9 +953,9 @@ class DatabaseTest: CBLTestCase {
         do {
             try self.db.inBatch {
                 for i in 0...9 {
-                    let doc = db.document(withID: docs[i].id)!
-                    try db.purgeDocument(doc)
-                    XCTAssertEqual(db.count, UInt64(9 - i))
+                    let doc = try defaultCol!.document(id: docs[i].id)!
+                    try defaultCol!.purge(document: doc)
+                    XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
                 }
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
@@ -961,19 +963,19 @@ class DatabaseTest: CBLTestCase {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(db.count, 10)
+        XCTAssertEqual(defaultCol!.count, 10)
     }
     
     func testPurgeDocumentOnADeletedDocument() throws {
         let document = try generateDocument(withID: nil)
         
         // Delete document
-        try self.db.deleteDocument(document)
+        try self.defaultCol!.delete(document: document)
         
         // Purge doc
-        try db.purgeDocument(document)
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: document.id))
+        try defaultCol!.purge(document: document)
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: document.id))
     }
     
     // MARK: Purge Document With ID
@@ -982,28 +984,28 @@ class DatabaseTest: CBLTestCase {
         let documentID = "\(Date().timeIntervalSince1970)"
         let _ = createDocument(documentID)
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.purgeDocument(withID: documentID)
+            try self.defaultCol!.purge(id: documentID)
         }
     }
     
     func testPurgeDocumentWithID() throws {
         let doc = try generateDocument(withID: nil)
         
-        try self.db.purgeDocument(doc)
+        try self.defaultCol!.purge(document: doc)
         
-        XCTAssertNil(db.document(withID: doc.id))
-        XCTAssertEqual(db.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        XCTAssertEqual(defaultCol!.count, 0)
     }
     
     func testPurgeDocumentWithIDInDifferentDBInstance() throws {
         let document = try generateDocument(withID: nil)
         let documentID = document.id
         let otherDB = try openDB(name: db.name)
-        XCTAssertNotNil(otherDB.document(withID: documentID))
-        XCTAssertEqual(otherDB.count, 1)
+        XCTAssertNotNil(try otherDB.defaultCollection().document(id: documentID))
+        XCTAssertEqual(try otherDB.defaultCollection().count, 1)
         
         // should delete it without any errors
-        try otherDB.purgeDocument(withID: documentID)
+        try otherDB.defaultCollection().purge(id: documentID)
         
         try otherDB.close()
     }
@@ -1013,7 +1015,7 @@ class DatabaseTest: CBLTestCase {
         let documentID = document.id
         let otherDB = try openDB(name: "otherDB")
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try otherDB.purgeDocument(withID: documentID)
+            try otherDB.defaultCollection().purge(id: documentID)
         }
         try otherDB.delete()
     }
@@ -1021,12 +1023,12 @@ class DatabaseTest: CBLTestCase {
     func testCallPurgeDocumentWithIDTwice() throws {
         let document = try generateDocument(withID: nil)
         let documentID = document.id
-        try db.purgeDocument(withID: documentID)
-        XCTAssertNil(db.document(withID: documentID))
-        XCTAssertEqual(db.count, 0)
+        try defaultCol!.purge(id: documentID)
+        XCTAssertNil(try defaultCol!.document(id: documentID))
+        XCTAssertEqual(defaultCol!.count, 0)
         
         expectError(domain: CBLError.domain, code: CBLError.notFound) { [unowned self] in
-            try self.db.purgeDocument(withID: documentID)
+            try self.defaultCol!.purge(id: documentID)
         }
     }
     
@@ -1036,12 +1038,12 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch { [unowned self] in
             for i in 0..<totalDocumentsCount {
                 let documentID = String(format: "doc_%03d", i)
-                try self.db.purgeDocument(withID: documentID)
-                XCTAssertNil(db.document(withID: documentID))
-                XCTAssertEqual(self.db.count, UInt64((totalDocumentsCount - 1) - i))
+                try self.defaultCol!.purge(id: documentID)
+                XCTAssertNil(try defaultCol!.document(id: documentID))
+                XCTAssertEqual(self.defaultCol!.count, UInt64((totalDocumentsCount - 1) - i))
             }
         }
-        XCTAssertEqual(db.count, 0)
+        XCTAssertEqual(defaultCol!.count, 0)
     }
     
     func testPurgeDocIDWithErrorInBatch() throws {
@@ -1049,8 +1051,8 @@ class DatabaseTest: CBLTestCase {
         do {
             try self.db.inBatch {
                 for i in 0...9 {
-                    try self.db.purgeDocument(withID: docs[i].id)
-                    XCTAssertEqual(db.count, UInt64(9 - i))
+                    try self.defaultCol!.purge(id: docs[i].id)
+                    XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
                 }
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
@@ -1058,29 +1060,29 @@ class DatabaseTest: CBLTestCase {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(db.count, 10)
+        XCTAssertEqual(defaultCol!.count, 10)
     }
     
     func testDeletePurgedDocumentWithID() throws {
         let document = try generateDocument(withID: nil)
         let documentID = document.id
-        let anotherDocumentReference = db.document(withID: documentID)!
+        let anotherDocumentReference = try defaultCol!.document(id: documentID)!
         
         // Purge doc
-        try db.purgeDocument(withID: documentID)
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: documentID))
+        try defaultCol!.purge(id: documentID)
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: documentID))
         
         // Delete document & anotherDocumentReference -> 404 NotFound
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.deleteDocument(document)
+            try self.defaultCol!.delete(document: document)
         }
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.db.deleteDocument(anotherDocumentReference)
+            try self.defaultCol!.delete(document: anotherDocumentReference)
         }
         
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: documentID))
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: documentID))
     }
     
     func testPurgeDocumentWithIDOnADeletedDocument() throws {
@@ -1088,45 +1090,45 @@ class DatabaseTest: CBLTestCase {
         let documentID = document.id
         
         // Delete document
-        try self.db.deleteDocument(document)
+        try self.defaultCol!.delete(document: document)
         
         // Purge doc
-        try db.purgeDocument(withID: documentID)
-        XCTAssertEqual(db.count, 0)
-        XCTAssertNil(db.document(withID: documentID))
+        try defaultCol!.purge(id: documentID)
+        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCol!.document(id: documentID))
     }
     
     // MARK: Index
     
     func testCreateIndex() throws {
         // Precheck:
-        XCTAssertEqual(db.indexes.count, 0)
+        XCTAssertEqual(try defaultCol!.indexes().count, 0)
 
         // Create value index:
         let fNameItem = ValueIndexItem.expression(Expression.property("firstName"))
         let lNameItem = ValueIndexItem.expression(Expression.property("lastName"))
 
         let index1 = IndexBuilder.valueIndex(items: fNameItem, lNameItem)
-        try db.createIndex(index1, withName: "index1")
+        try defaultCol!.createIndex(index1, name: "index1")
 
         let index2 = IndexBuilder.valueIndex(items: [fNameItem, lNameItem])
-        try db.createIndex(index2, withName: "index2")
+        try defaultCol!.createIndex(index2, name: "index2")
 
         // Create FTS index:
         let detailItem = FullTextIndexItem.property("detail")
         let index3 = IndexBuilder.fullTextIndex(items: detailItem)
-        try db.createIndex(index3, withName: "index3")
+        try defaultCol!.createIndex(index3, name: "index3")
 
         let detailItem2 = FullTextIndexItem.property("es-detail")
         let index4 = IndexBuilder.fullTextIndex(items: detailItem2).language("es").ignoreAccents(true)
-        try db.createIndex(index4, withName: "index4")
+        try defaultCol!.createIndex(index4, name: "index4")
 
         let nameItem = FullTextIndexItem.property("name")
         let index5 = IndexBuilder.fullTextIndex(items: [nameItem, detailItem])
-        try db.createIndex(index5, withName: "index5")
+        try defaultCol!.createIndex(index5, name: "index5")
 
-        XCTAssertEqual(db.indexes.count, 5)
-        XCTAssertEqual(db.indexes, ["index1", "index2", "index3", "index4", "index5"])
+        XCTAssertEqual(try defaultCol!.indexes().count, 5)
+        XCTAssertEqual(try defaultCol!.indexes(), ["index1", "index2", "index3", "index4", "index5"])
     }
     
     func testCreateCollectionIndex() throws {
@@ -1252,30 +1254,30 @@ class DatabaseTest: CBLTestCase {
     }
     
     func testN1QLCreateIndexSanity() throws {
-        XCTAssertEqual(db.indexes.count, 0)
+        XCTAssertEqual(try defaultCol!.indexes().count, 0)
         
         let config1 = ValueIndexConfiguration(["firstName", "lastName"])
-        try db.createIndex(config1, name: "index1")
+        try defaultCol!.createIndex(withName: "index1", config: config1)
         
         let config2 = FullTextIndexConfiguration(["detail"])
-        try db.createIndex(config2, name: "index2")
+        try defaultCol!.createIndex(withName: "index2", config: config2)
         
         let config3 = FullTextIndexConfiguration(["es_detail"], ignoreAccents: true, language: "es")
-        try db.createIndex(config3, name: "index3")
+        try defaultCol!.createIndex(withName: "index3", config: config3)
         
         let config4 = FullTextIndexConfiguration(["name"], ignoreAccents: false, language: "en")
-        try db.createIndex(config4, name: "index4")
+        try defaultCol!.createIndex(withName: "index4", config: config4)
         
         // use backtick in case of property name with hyphen
         let config5 = FullTextIndexConfiguration(["`es-detail`"], ignoreAccents: true, language: "es")
-        try db.createIndex(config5, name: "index5")
+        try defaultCol!.createIndex(withName: "index5", config: config5)
         
         // same index twice: no-op
         let config6 = FullTextIndexConfiguration(["detail"])
-        try db.createIndex(config6, name: "index2")
+        try defaultCol!.createIndex(withName: "index2", config: config6)
         
-        XCTAssertEqual(db.indexes.count, 5)
-        XCTAssertEqual(db.indexes, ["index1", "index2", "index3", "index4", "index5"])
+        XCTAssertEqual(try defaultCol!.indexes().count, 5)
+        XCTAssertEqual(try defaultCol!.indexes(), ["index1", "index2", "index3", "index4", "index5"])
     }
     
     func testCreateSameIndexTwice() throws {
@@ -1283,89 +1285,89 @@ class DatabaseTest: CBLTestCase {
         
         // Create index with first name:
         let index = IndexBuilder.valueIndex(items: item)
-        try db.createIndex(index, withName: "myindex")
+        try defaultCol!.createIndex(index, name: "myindex")
         
         // Call create index again:
-        try db.createIndex(index, withName: "myindex")
+        try defaultCol!.createIndex(index, name: "myindex")
         
-        XCTAssertEqual(db.indexes.count, 1)
-        XCTAssertEqual(db.indexes, ["myindex"])
+        XCTAssertEqual(try defaultCol!.indexes().count, 1)
+        XCTAssertEqual(try defaultCol!.indexes(), ["myindex"])
     }
     
     func failingTestCreateSameNameIndexes() throws {
         // Create value index with first name:
         let fNameItem = ValueIndexItem.expression(Expression.property("firstName"))
         let fNameIndex = IndexBuilder.valueIndex(items: fNameItem)
-        try db.createIndex(fNameIndex, withName: "myindex")
+        try defaultCol!.createIndex(fNameIndex, name: "myindex")
         
         // Create value index with last name:
         let lNameItem = ValueIndexItem.expression(Expression.property("lastName"))
         let lNameIndex = IndexBuilder.valueIndex(items: lNameItem)
-        try db.createIndex(lNameIndex, withName: "myindex")
+        try defaultCol!.createIndex(lNameIndex, name: "myindex")
         
         // Check:
-        XCTAssertEqual(db.indexes.count, 1)
-        XCTAssertEqual(db.indexes, ["myindex"])
+        XCTAssertEqual(try defaultCol!.indexes().count, 1)
+        XCTAssertEqual(try defaultCol!.indexes(), ["myindex"])
         
         // Create FTS index:
         let detailItem = FullTextIndexItem.property("detail")
         let detailIndex = IndexBuilder.fullTextIndex(items: detailItem)
-        try db.createIndex(detailIndex, withName: "myindex")
+        try defaultCol!.createIndex(detailIndex, name: "myindex")
         
         // Check:
-        XCTAssertEqual(db.indexes.count, 1)
-        XCTAssertEqual(db.indexes, ["myindex"])
+        XCTAssertEqual(try defaultCol!.indexes().count, 1)
+        XCTAssertEqual(try defaultCol!.indexes(), ["myindex"])
     }
     
     func testDeleteIndex() throws {
         // Precheck:
-        XCTAssertEqual(db.indexes.count, 0)
+        XCTAssertEqual(try defaultCol!.indexes().count, 0)
         
         // Create value index:
         let fNameItem = ValueIndexItem.expression(Expression.property("firstName"))
         let lNameItem = ValueIndexItem.expression(Expression.property("lastName"))
         
         let index1 = IndexBuilder.valueIndex(items: fNameItem, lNameItem)
-        try db.createIndex(index1, withName: "index1")
+        try defaultCol!.createIndex(index1, name: "index1")
         
         // Create FTS index:
         let detailItem = FullTextIndexItem.property("detail")
         let index2 = IndexBuilder.fullTextIndex(items: detailItem)
-        try db.createIndex(index2, withName: "index2")
+        try defaultCol!.createIndex(index2, name: "index2")
         
         let detailItem2 = FullTextIndexItem.property("es-detail")
         let index3 = IndexBuilder.fullTextIndex(items: detailItem2).language("es").ignoreAccents(true)
-        try db.createIndex(index3, withName: "index3")
+        try defaultCol!.createIndex(index3, name: "index3")
         
-        XCTAssertEqual(db.indexes.count, 3)
-        XCTAssertEqual(db.indexes, ["index1", "index2", "index3"])
+        XCTAssertEqual(try defaultCol!.indexes().count, 3)
+        XCTAssertEqual(try defaultCol!.indexes(), ["index1", "index2", "index3"])
         
         // Delete indexes:
-        try db.deleteIndex(forName: "index1")
-        XCTAssertEqual(db.indexes.count, 2)
-        XCTAssertEqual(db.indexes, ["index2", "index3"])
+        try defaultCol!.deleteIndex(forName: "index1")
+        XCTAssertEqual(try defaultCol!.indexes().count, 2)
+        XCTAssertEqual(try defaultCol!.indexes(), ["index2", "index3"])
         
-        try db.deleteIndex(forName: "index2")
-        XCTAssertEqual(db.indexes.count, 1)
-        XCTAssertEqual(db.indexes, ["index3"])
+        try defaultCol!.deleteIndex(forName: "index2")
+        XCTAssertEqual(try defaultCol!.indexes().count, 1)
+        XCTAssertEqual(try defaultCol!.indexes(), ["index3"])
         
-        try db.deleteIndex(forName: "index3")
-        XCTAssertEqual(db.indexes.count, 0)
+        try defaultCol!.deleteIndex(forName: "index3")
+        XCTAssertEqual(try defaultCol!.indexes().count, 0)
         
         // Delete non existing index:
-        try db.deleteIndex(forName: "dummy")
+        try defaultCol!.deleteIndex(forName: "dummy")
         
         // Delete deleted indexes:
-        try db.deleteIndex(forName: "index1")
-        try db.deleteIndex(forName: "index2")
-        try db.deleteIndex(forName: "index3")
+        try defaultCol!.deleteIndex(forName: "index1")
+        try defaultCol!.deleteIndex(forName: "index2")
+        try defaultCol!.deleteIndex(forName: "index3")
     }
     
     func testCloseWithActiveLiveQueries() throws {
         let change1 = expectation(description: "changes 1")
         let change2 = expectation(description: "changes 2")
         
-        let ds = DataSource.database(db)
+        let ds = DataSource.collection(defaultCol!)
         
         let q1 = QueryBuilder.select().from(ds)
         q1.addChangeListener { (ch) in change1.fulfill() }

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -23,7 +23,7 @@ import CouchbaseLiteSwift
 class DatabaseTest: CBLTestCase {
 
     func verifyDocument(withID id: String, data: Dictionary<String, Any>) throws {
-        let doc = try defaultCol!.document(id: id )
+        let doc = try defaultCollection!.document(id: id )
         XCTAssertNotNil(doc)
         XCTAssertEqual(doc!.id, id)
         XCTAssertTrue(doc!.toDictionary() == data)
@@ -54,14 +54,14 @@ class DatabaseTest: CBLTestCase {
         
         var success = true
         if let cc = concurrencyControl {
-            success = try defaultCol!.save(document: document, concurrencyControl: cc)
+            success = try defaultCollection!.save(document: document, concurrencyControl: cc)
             if cc == .failOnConflict {
                 XCTAssertFalse(success)
             } else {
                 XCTAssertTrue(success)
             }
         } else {
-            try defaultCol!.save(document: document)
+            try defaultCollection!.save(document: document)
         }
         return success
     }
@@ -71,14 +71,14 @@ class DatabaseTest: CBLTestCase {
     {
         var success = true
         if let cc = concurrencyControl {
-            success = try defaultCol!.delete(document: document, concurrencyControl: cc)
+            success = try defaultCollection!.delete(document: document, concurrencyControl: cc)
             if cc == .failOnConflict {
                 XCTAssertFalse(success)
             } else {
                 XCTAssertTrue(success)
             }
         } else {
-            try defaultCol!.delete(document: document)
+            try defaultCollection!.delete(document: document)
         }
         return success
     }
@@ -96,13 +96,13 @@ class DatabaseTest: CBLTestCase {
     }
     
     func testCreateNamedDocument() throws {
-        XCTAssertNil(try defaultCol!.document(id: "doc1"))
+        XCTAssertNil(try defaultCollection!.document(id: "doc1"))
 
         let doc = MutableDocument(id: "doc1")
         XCTAssertEqual(doc.id, "doc1")
         XCTAssertTrue(doc.toDictionary() == [:] as [String: Any])
         
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
     }
     
     
@@ -116,21 +116,21 @@ class DatabaseTest: CBLTestCase {
                 for i in 0...25{
                     let mdoc = doc.toMutable()
                     mdoc.setValue(i, forKey: "number")
-                    try defaultCol!.save(document:mdoc)
+                    try defaultCollection!.save(document:mdoc)
                 }
             }
         }
         
         // Add each doc with a blob object:
         for doc in docs {
-            let mdoc = try defaultCol!.document(id: doc.id)!.toMutable()
+            let mdoc = try defaultCollection!.document(id: doc.id)!.toMutable()
             let data = doc.id.data(using: .utf8)
             let blob = Blob.init(contentType: "text/plain", data: data!)
             mdoc.setValue(blob, forKey: "blob")
-            try defaultCol!.save(document:mdoc)
+            try defaultCollection!.save(document:mdoc)
         }
         
-        XCTAssertEqual(defaultCol!.count, 20)
+        XCTAssertEqual(defaultCollection!.count, 20)
         
         let attachmentDir = (db.path! as NSString).appendingPathComponent("Attachments")
         var attachments = try FileManager.default.contentsOfDirectory(atPath: attachmentDir)
@@ -141,11 +141,11 @@ class DatabaseTest: CBLTestCase {
         
         // Delete all docs:
         for doc in docs {
-            let doc = try defaultCol!.document(id: doc.id)!
-            try defaultCol!.delete(document: doc)
-            XCTAssertNil(try defaultCol!.document(id: doc.id))
+            let doc = try defaultCollection!.document(id: doc.id)!
+            try defaultCollection!.delete(document: doc)
+            XCTAssertNil(try defaultCollection!.document(id: doc.id))
         }
-        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertEqual(defaultCollection!.count, 0)
         
         attachments = try FileManager.default.contentsOfDirectory(atPath: attachmentDir)
         XCTAssertEqual(attachments.count, 20)
@@ -168,13 +168,13 @@ class DatabaseTest: CBLTestCase {
         let key = Expression.property("key")
         let keyItem = ValueIndexItem.expression(key)
         let keyIndex = IndexBuilder.valueIndex(items: keyItem)
-        try defaultCol!.createIndex(keyIndex, name: "KeyIndex")
-        XCTAssertEqual(try defaultCol!.indexes().count, 1)
+        try defaultCollection!.createIndex(keyIndex, name: "KeyIndex")
+        XCTAssertEqual(try defaultCollection!.indexes().count, 1)
         
         // Check if the index is used:
         let q = QueryBuilder
             .select(SelectResult.expression(key))
-            .from(DataSource.collection(defaultCol!))
+            .from(DataSource.collection(defaultCollection!))
             .where(key.greaterThan(Expression.int(9)))
         
         var explain = try q.explain() as NSString
@@ -184,7 +184,7 @@ class DatabaseTest: CBLTestCase {
         try db.performMaintenance(type: .reindex)
         
         // Check if the index is still there and used:
-        XCTAssertEqual(try defaultCol!.indexes().count, 1)
+        XCTAssertEqual(try defaultCollection!.indexes().count, 1)
         explain = try q.explain() as NSString
         XCTAssertNotEqual(explain.range(of: "USING INDEX KeyIndex").location, NSNotFound)
     }
@@ -199,32 +199,32 @@ class DatabaseTest: CBLTestCase {
                 for i in 0...25{
                     let mdoc = doc.toMutable()
                     mdoc.setValue(i, forKey: "number")
-                    try defaultCol!.save(document: mdoc)
+                    try defaultCollection!.save(document: mdoc)
                 }
             }
         }
         
         // Add each doc with a blob object:
         for doc in docs {
-            let mdoc = try defaultCol!.document(id: doc.id)!.toMutable()
+            let mdoc = try defaultCollection!.document(id: doc.id)!.toMutable()
             let data = doc.id.data(using: .utf8)
             let blob = Blob.init(contentType: "text/plain", data: data!)
             mdoc.setValue(blob, forKey: "blob")
-            try defaultCol!.save(document: mdoc)
+            try defaultCollection!.save(document: mdoc)
         }
         
-        XCTAssertEqual(defaultCol!.count, 20)
+        XCTAssertEqual(defaultCollection!.count, 20)
         
         // Integrity Check:
         try db.performMaintenance(type: .integrityCheck)
         
         // Delete all docs:
         for doc in docs {
-            let doc = try defaultCol!.document(id: doc.id)!
-            try defaultCol!.delete(document: doc)
-            XCTAssertNil(try defaultCol!.document(id: doc.id))
+            let doc = try defaultCollection!.document(id: doc.id)!
+            try defaultCollection!.delete(document: doc)
+            XCTAssertNil(try defaultCollection!.document(id: doc.id))
         }
-        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertEqual(defaultCollection!.count, 0)
         
         // Integrity Check:
         try db.performMaintenance(type: .integrityCheck)
@@ -234,11 +234,11 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch {
             for i in 0...9{
                 let doc = MutableDocument(id: "doc\(i)")
-                try defaultCol!.save(document: doc)
+                try defaultCollection!.save(document: doc)
             }
         }
         for _ in 0...9 {
-            XCTAssertNotNil(try defaultCol!.document(id: "doc1"))
+            XCTAssertNotNil(try defaultCollection!.document(id: "doc1"))
         }
     }
     
@@ -294,20 +294,20 @@ class DatabaseTest: CBLTestCase {
     
     func testSaveDocWithID() throws {
         let doc = try generateDocument(withID: "doc1")
-        XCTAssertEqual(defaultCol!.count, 1)
+        XCTAssertEqual(defaultCollection!.count, 1)
         try verifyDocument(withID: doc.id, data: doc.toDictionary())
     }
     
     func testSaveDocWithSpecialCharactersDocID() throws {
         let docID = "`~@#$%^&*()_+{}|\\][=-/.,<>?\":;'"
         let doc = try generateDocument(withID: docID)
-        XCTAssertEqual(defaultCol!.count, 1)
+        XCTAssertEqual(defaultCollection!.count, 1)
         try verifyDocument(withID: doc.id, data: doc.toDictionary())
     }
     
     func testSaveDocWIthAutoGeneratedID() throws {
         let doc = try generateDocument(withID: nil)
-        XCTAssertEqual(defaultCol!.count, 1)
+        XCTAssertEqual(defaultCollection!.count, 1)
         try verifyDocument(withID: doc.id, data: doc.toDictionary())
     }
     
@@ -345,16 +345,16 @@ class DatabaseTest: CBLTestCase {
         let doc = try generateDocument(withID: "doc1")
         try saveDocument(doc)
         
-        let doc1 = try defaultCol!.document(id: doc.id)!
+        let doc1 = try defaultCollection!.document(id: doc.id)!
         XCTAssertEqual(doc1.sequence, 2)
-        XCTAssertEqual(defaultCol!.count, 1)
+        XCTAssertEqual(defaultCollection!.count, 1)
     }
     
     func testSaveInBatch() throws {
         try db.inBatch {
             try createDocs(10)
         }
-        XCTAssertEqual(defaultCol!.count, 10)
+        XCTAssertEqual(defaultCollection!.count, 10)
         try validateDocs(10)
     }
     
@@ -362,19 +362,19 @@ class DatabaseTest: CBLTestCase {
         do {
             try self.db.inBatch {
                 try self.createDocs(10)
-                XCTAssertEqual(defaultCol!.count, 10)
+                XCTAssertEqual(defaultCollection!.count, 10)
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
         } catch {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertEqual(defaultCollection!.count, 0)
     }
     
     func testSaveManyDocs() throws {
         try createDocs(1000)
-        XCTAssertEqual(defaultCol!.count, 1000)
+        XCTAssertEqual(defaultCollection!.count, 1000)
         try validateDocs(1000)
         
         // Cleanup:
@@ -384,29 +384,29 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch {
             try createDocs(1000)
         }
-        XCTAssertEqual(defaultCol!.count, 1000)
+        XCTAssertEqual(defaultCollection!.count, 1000)
         try validateDocs(1000)
     }
     
     func testAndUpdateMutableDoc() throws {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Update
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Update
         doc.setInt(20, forKey: "age")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         let expectedResult: [String : Any] =
             ["firstName": "Daniel", "lastName": "Tiger", "age": 20]
         XCTAssertTrue(doc.toDictionary() == expectedResult)
         XCTAssertEqual(doc.sequence, 3)
         
-        let savedDoc = try defaultCol!.document(id: doc.id)!
+        let savedDoc = try defaultCollection!.document(id: doc.id)!
         XCTAssertTrue(savedDoc.toDictionary() == expectedResult)
         XCTAssertEqual(savedDoc.sequence, 3)
     }
@@ -422,17 +422,17 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         
         // Modify doc1a:
         doc1a.setString("Scott", forKey: "firstName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         doc1a.setString("Scotty", forKey: "nickName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         XCTAssertTrue(doc1a.toDictionary() ==
             ["firstName": "Scott", "lastName": "Tiger", "nickName": "Scotty"])
         XCTAssertEqual(doc1a.sequence, 3)
@@ -440,7 +440,7 @@ class DatabaseTest: CBLTestCase {
         // Modify doc1b:
         doc1b.setString("Lion", forKey: "lastName")
         if try saveDocument(doc1b, concurrencyControl: cc) {
-            let savedDoc = try defaultCol!.document(id: doc1b.id)!
+            let savedDoc = try defaultCollection!.document(id: doc1b.id)!
             XCTAssertTrue(savedDoc.toDictionary() == doc1b.toDictionary())
             XCTAssertEqual(savedDoc.sequence, 4)
         }
@@ -460,16 +460,16 @@ class DatabaseTest: CBLTestCase {
         let doc1a = createDocument("doc1")
         doc1a.setString("Daniel", forKey: "firstName")
         doc1a.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         XCTAssertEqual(doc1a.sequence, 1)
-        let savedDoc = try defaultCol!.document(id: "doc1")!
+        let savedDoc = try defaultCollection!.document(id: "doc1")!
         XCTAssertEqual(savedDoc.sequence, 1)
         
         let doc1b = createDocument(doc1a.id)
         doc1b.setString("Scott", forKey: "firstName")
         doc1b.setString("Tiger", forKey: "lastName")
         if try saveDocument(doc1b, concurrencyControl: cc) {
-            let savedDoc = try defaultCol!.document(id: doc1b.id)!
+            let savedDoc = try defaultCollection!.document(id: doc1b.id)!
             XCTAssertTrue(savedDoc.toDictionary() == doc1b.toDictionary())
             XCTAssertEqual(savedDoc.sequence, 2)
         }
@@ -489,21 +489,21 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = try defaultCol!.document(id: doc.id)!
-        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1a = try defaultCollection!.document(id: doc.id)!
+        let doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         
         // Delete doc1a
-        try defaultCol!.delete(document: doc1a)
+        try defaultCollection!.delete(document: doc1a)
         XCTAssertEqual(doc1a.sequence, 2)
-        XCTAssertNil(try defaultCol!.document(id: doc1a.id))
+        XCTAssertNil(try defaultCollection!.document(id: doc1a.id))
         
         // Modify doc1b:
         doc1b.setString("Lion", forKey: "lastName")
         if try saveDocument(doc1b, concurrencyControl: cc) {
-            let savedDoc = try defaultCol!.document(id: doc1b.id)!
+            let savedDoc = try defaultCollection!.document(id: doc1b.id)!
             XCTAssertTrue(savedDoc.toDictionary() == doc1b.toDictionary())
             XCTAssertEqual(savedDoc.sequence, 3)
         }
@@ -518,16 +518,16 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         
         // Modify doc1a:
         doc1a.setString("Scott", forKey: "firstName")
         doc1a.setString("Scotty", forKey: "nickName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         XCTAssertTrue(doc1a.toDictionary() == ["firstName": "Scott",
                                                "lastName": "Tiger",
                                                "nickName": "Scotty"])
@@ -537,13 +537,13 @@ class DatabaseTest: CBLTestCase {
         doc1b.setString("Lion", forKey: "middleName")
         
         // merge the dictionaries, and keeping the doc1b dictionary values if duplicate comes in.
-        XCTAssertTrue(try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
+        XCTAssertTrue(try defaultCollection!.save(document: doc1b) { (doc, old) -> Bool in
             let merged = doc.toDictionary()
                 .merging(old!.toDictionary(), uniquingKeysWith: { (first, _) in first })
             doc.setData(merged)
             return true
         })
-        let savedDoc = try defaultCol!.document(id: doc1b.id)!
+        let savedDoc = try defaultCollection!.document(id: doc1b.id)!
         XCTAssertTrue(savedDoc.toDictionary() == ["firstName": "Daniel", // kept previous key value
                                                   "nickName": "Scotty", // merged
                                                   "lastName": "Tiger",  // NA
@@ -554,54 +554,54 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // create conflict and return false
-        var doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        var doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        var doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        var doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         doc1a.setString("Scott", forKey: "firstName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         doc1b.setString("Lion", forKey: "middleName")
-        XCTAssertFalse(try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
+        XCTAssertFalse(try defaultCollection!.save(document: doc1b) { (doc, old) -> Bool in
             XCTAssert(doc1b == doc)
             XCTAssertEqual(doc1a, old)
             return false
             })
         
         // check it is same as old doc, and didn't updated the doc
-        XCTAssertEqual(try defaultCol!.document(id: doc1b.id)!, doc1a)
+        XCTAssertEqual(try defaultCollection!.document(id: doc1b.id)!, doc1a)
         
         // Updates to Current Mutable Document, should not save contents.
         // create conflict, update the mutable doc, and return false
-        doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         doc1a.setString("Sccotty", forKey: "nickname")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         doc1b.setString("Scotty", forKey: "nickname")
-        XCTAssertFalse(try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
+        XCTAssertFalse(try defaultCollection!.save(document: doc1b) { (doc, old) -> Bool in
             XCTAssert(doc1b == doc)
             XCTAssertEqual(doc1a, old)
             doc.setString("Scott", forKey: "nickname")
             return false
             })
         // check whether it is same old doc, and no update happened.
-        XCTAssertEqual(try defaultCol!.document(id: doc1b.id)!, doc1a)
+        XCTAssertEqual(try defaultCollection!.document(id: doc1b.id)!, doc1a)
     }
     
     func testConflictHandlerWhenDocumentIsPurged() throws {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Purge one instance
-        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        try defaultCol!.purge(document: try defaultCol!.document(id: doc.id)!)
+        let doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        try defaultCollection!.purge(document: try defaultCollection!.document(id: doc.id)!)
         
         doc1a.setString("Scotty", forKey: "nickName")
         ignoreException {
             do {
-                _ = try self.defaultCol!.save(document: doc1a) { (doc, old) -> Bool in
+                _ = try self.defaultCollection!.save(document: doc1a) { (doc, old) -> Bool in
                     return true
                 }
                 XCTFail("Shouldn't reach here, it should throw an exception when saving")
@@ -614,52 +614,52 @@ class DatabaseTest: CBLTestCase {
     
     func testConflictHandlerWithDeletedOldDoc() throws {
         let doc = createDocument("doc1")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // KEEPS NEW DOC(non-deleted)
-        var doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        XCTAssertTrue(try defaultCol!.delete(document: try defaultCol!.document(id: doc.id)!, concurrencyControl: .failOnConflict))
+        var doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        XCTAssertTrue(try defaultCollection!.delete(document: try defaultCollection!.document(id: doc.id)!, concurrencyControl: .failOnConflict))
         
         doc1a.setString("Lion", forKey: "middleName")
-        XCTAssertTrue(try defaultCol!.save(document: doc1a) { (doc, old) -> Bool in
+        XCTAssertTrue(try defaultCollection!.save(document: doc1a) { (doc, old) -> Bool in
             XCTAssertNil(old)
             XCTAssertNotNil(doc)
             XCTAssert(doc == doc1a)
             return true
         })
-        XCTAssert(try defaultCol!.document(id: doc.id) == doc1a)
+        XCTAssert(try defaultCollection!.document(id: doc.id) == doc1a)
         
         // KEEPS THE DELETED(old doc)
-        doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        XCTAssertTrue(try defaultCol!.delete(document: try defaultCol!.document(id: doc.id)!, concurrencyControl: .failOnConflict))
+        doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        XCTAssertTrue(try defaultCollection!.delete(document: try defaultCollection!.document(id: doc.id)!, concurrencyControl: .failOnConflict))
         
         doc1a.setString("Lion", forKey: "nickName")
-        XCTAssertFalse(try defaultCol!.save(document: doc1a) { (doc, old) -> Bool in
+        XCTAssertFalse(try defaultCollection!.save(document: doc1a) { (doc, old) -> Bool in
             XCTAssertNil(old)
             XCTAssertNotNil(doc)
             XCTAssert(doc == doc1a)
             return false
         })
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
     }
     
     func testConflictHandlerCalledTwice() throws {
         let doc = createDocument("doc1")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
-        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         doc1a.setString("Scott", forKey: "firstName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         
         doc1b.setString("Lion", forKey: "middleName")
         var count = 0
-        _ = try defaultCol!.save(document: doc1b) { (doc, old) -> Bool in
+        _ = try defaultCollection!.save(document: doc1b) { (doc, old) -> Bool in
             count += 1
-            let doc1c = try! self.defaultCol!.document(id: doc.id)!.toMutable()
+            let doc1c = try! self.defaultCollection!.document(id: doc.id)!.toMutable()
             if !doc1c.boolean(forKey: "secondUpdate") {
                 doc1c.setBoolean(true, forKey: "secondUpdate")
-                try! self.defaultCol!.save(document: doc1c)
+                try! self.defaultCollection!.save(document: doc1c)
             }
             
             // merge contents
@@ -673,12 +673,12 @@ class DatabaseTest: CBLTestCase {
         }
         
         XCTAssertEqual(count, 2) // make sure the save handler called twice
-        XCTAssertEqual(defaultCol!.count, 1)
+        XCTAssertEqual(defaultCollection!.count, 1)
         let dict: [String: Any] = ["middleName": "Lion", // old doc contents - merged
             "firstName": "Scott", // savedDoc contents
             "secondUpdate": true, // second update did.
             "edit": "local"] // new prop added during resolve.
-        XCTAssert(try defaultCol!.document(id: doc1b.id)!.toDictionary() == dict)
+        XCTAssert(try defaultCollection!.document(id: doc1b.id)!.toDictionary() == dict)
     }
     
     /// disabling since, exceptions inside conflict handler will leak, since objc doesn't perform release
@@ -687,17 +687,17 @@ class DatabaseTest: CBLTestCase {
         let doc = createDocument("doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
-        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         doc1a.setString("Scott", forKey: "firstName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         
         // conflicting save
         doc1b.setString("Lion", forKey: "middleName")
         ignoreException {
-            XCTAssertFalse(try self.defaultCol!.save(document: doc1b) { (cur, old) -> Bool in
+            XCTAssertFalse(try self.defaultCollection!.save(document: doc1b) { (cur, old) -> Bool in
                 NSException(name: .internalInconsistencyException,
                             reason: "some exception happened inside save handler",
                             userInfo: nil).raise()
@@ -712,54 +712,54 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setValue(1, forKey: "key")
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.delete(document: doc)
+            try self.defaultCollection!.delete(document: doc)
         }
     }
     
     func testDeleteDoc() throws {
         let doc = try generateDocument(withID: "doc1")
-        try defaultCol!.delete(document: doc)
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        try defaultCollection!.delete(document: doc)
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
     }
     
     func testDeleteSameDocTwice() throws {
         let doc = try generateDocument(withID: "doc1")
         
         // First time deletion:
-        try defaultCol!.delete(document: doc)
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        try defaultCollection!.delete(document: doc)
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
         XCTAssertEqual(doc.sequence, 2)
         
         // Second time deletion:
-        try defaultCol!.delete(document: doc)
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        try defaultCollection!.delete(document: doc)
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
         XCTAssertEqual(doc.sequence, 3)
     }
     
     func testDeleteNoneExistingDoc() throws {
         let doc1a = try generateDocument(withID: "doc1")
-        let doc1b = try defaultCol!.document(id: doc1a.id)!
+        let doc1b = try defaultCollection!.document(id: doc1a.id)!
         
         // Purge doc:
-        try defaultCol!.purge(document: doc1a)
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: doc1a.id))
+        try defaultCollection!.purge(document: doc1a)
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: doc1a.id))
         
         // Delete doc1a, 404 error:
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.delete(document: doc1a)
+            try self.defaultCollection!.delete(document: doc1a)
         }
         
         // Delete doc, 404 error:
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.delete(document: doc1b)
+            try self.defaultCollection!.delete(document: doc1b)
         }
         
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: doc1b.id))
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: doc1b.id))
     }
     
     func testDeleteDocInBatch() throws {
@@ -767,12 +767,12 @@ class DatabaseTest: CBLTestCase {
         let docs = try createDocs(10)
         try db.inBatch {
             for i in 0...9 {
-                let doc = try defaultCol!.document(id: docs[i].id)!
-                try defaultCol!.delete(document: doc)
-                XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
+                let doc = try defaultCollection!.document(id: docs[i].id)!
+                try defaultCollection!.delete(document: doc)
+                XCTAssertEqual(defaultCollection!.count, UInt64(9 - i))
             }
         }
-        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertEqual(defaultCollection!.count, 0)
     }
     
     func testDeleteWithErrorInBatch() throws {
@@ -780,9 +780,9 @@ class DatabaseTest: CBLTestCase {
         do {
             try self.db.inBatch {
                 for i in 0...9 {
-                    let doc = try defaultCol!.document(id: docs[i].id)!
-                    try defaultCol!.delete(document: doc)
-                    XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
+                    let doc = try defaultCollection!.document(id: docs[i].id)!
+                    try defaultCollection!.delete(document: doc)
+                    XCTAssertEqual(defaultCollection!.count, UInt64(9 - i))
                 }
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
@@ -790,26 +790,26 @@ class DatabaseTest: CBLTestCase {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(defaultCol!.count, 10)
+        XCTAssertEqual(defaultCollection!.count, 10)
     }
     
     func testDeleteDocOnDeletedDB() throws {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
-        try defaultCol!.delete(document: doc)
+        try defaultCollection!.delete(document: doc)
         XCTAssertEqual(doc.sequence, 2)
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
         
         doc.setString("Scott", forKey: "firstName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         XCTAssertEqual(doc.sequence, 3)
         XCTAssertTrue(doc.toDictionary() ==
             ["firstName": "Scott", "lastName": "Tiger"])
         
-        let savedDoc = try defaultCol!.document(id: doc.id)!
+        let savedDoc = try defaultCollection!.document(id: doc.id)!
         XCTAssertTrue(savedDoc.toDictionary() == doc.toDictionary())
     }
     
@@ -817,18 +817,18 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
-        try defaultCol!.delete(document: doc)
+        try defaultCollection!.delete(document: doc)
         XCTAssertEqual(doc.sequence, 2)
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
         
         doc.setString("Scott", forKey: "firstName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         XCTAssertEqual(doc.sequence, 3)
         XCTAssertTrue(doc.toDictionary() == ["firstName": "Scott", "lastName": "Tiger"])
         
-        let savedDoc = try defaultCol!.document(id: doc.id)!
+        let savedDoc = try defaultCollection!.document(id: doc.id)!
         XCTAssertTrue(savedDoc.toDictionary() == doc.toDictionary())
     }
     
@@ -836,21 +836,21 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Get two doc1 document objects (doc1a and doc1b):
-        let doc1a = try defaultCol!.document(id: doc.id)!
-        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1a = try defaultCollection!.document(id: doc.id)!
+        let doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         
         // Delete doc1a:
-        try defaultCol!.delete(document: doc1a)
+        try defaultCollection!.delete(document: doc1a)
         XCTAssertEqual(doc1a.sequence, 2)
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
         
         // Delete doc1b:
-        try defaultCol!.delete(document: doc1b)
+        try defaultCollection!.delete(document: doc1b)
         XCTAssertEqual(doc1a.sequence, 2)
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
     }
     
     func testDeleteDocWithConflict() throws {
@@ -863,15 +863,15 @@ class DatabaseTest: CBLTestCase {
         let doc = MutableDocument(id: "doc1")
         doc.setString("Daniel", forKey: "firstName")
         doc.setString("Tiger", forKey: "lastName")
-        try defaultCol!.save(document: doc)
+        try defaultCollection!.save(document: doc)
         
         // Get two document objects (doc1a and doc1b):
-        let doc1a = try defaultCol!.document(id: doc.id)!.toMutable()
-        let doc1b = try defaultCol!.document(id: doc.id)!.toMutable()
+        let doc1a = try defaultCollection!.document(id: doc.id)!.toMutable()
+        let doc1b = try defaultCollection!.document(id: doc.id)!.toMutable()
         
         // Modify doc1a
         doc1a.setString("Scott", forKey: "firstName")
-        try defaultCol!.save(document: doc1a)
+        try defaultCollection!.save(document: doc1a)
         XCTAssertTrue(doc1a.toDictionary() == ["firstName": "Scott", "lastName": "Tiger"])
         XCTAssertEqual(doc1a.sequence, 2)
         
@@ -879,7 +879,7 @@ class DatabaseTest: CBLTestCase {
         doc1b.setString("Lion", forKey: "lastName")
         if try deleteDocument(doc1b, concurrencyControl: cc) {
             XCTAssertEqual(doc1b.sequence, 3)
-            XCTAssertNil(try defaultCol!.document(id: doc1b.id))
+            XCTAssertNil(try defaultCollection!.document(id: doc1b.id))
         }
         XCTAssertTrue(doc1b.toDictionary() == ["firstName": "Daniel", "lastName": "Lion"])
         
@@ -892,15 +892,15 @@ class DatabaseTest: CBLTestCase {
     func testPurgePreSaveDoc() throws {
         let doc = createDocument("doc1")
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.purge(document: doc)
+            try self.defaultCollection!.purge(document: doc)
         }
     }
     
     func testPurgeDoc() throws {
         let doc = try generateDocument(withID: "doc1")
-        try defaultCol!.purge(document: doc)
-        XCTAssertNil(try defaultCol!.document(id: "doc1"))
-        XCTAssertEqual(defaultCol!.count, 0)
+        try defaultCollection!.purge(document: doc)
+        XCTAssertNil(try defaultCollection!.document(id: "doc1"))
+        XCTAssertEqual(defaultCollection!.count, 0)
     }
     
     func testPurgeDocInDifferentDBInstance() throws {
@@ -925,12 +925,12 @@ class DatabaseTest: CBLTestCase {
     
     func testPurgeSameDocTwice() throws {
         let doc = try generateDocument(withID: "doc1")
-        try defaultCol!.purge(document: doc)
-        XCTAssertNil(try defaultCol!.document(id: "doc1"))
-        XCTAssertEqual(defaultCol!.count, 0)
+        try defaultCollection!.purge(document: doc)
+        XCTAssertNil(try defaultCollection!.document(id: "doc1"))
+        XCTAssertEqual(defaultCollection!.count, 0)
         
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.purge(document: doc)
+            try self.defaultCollection!.purge(document: doc)
         }
     }
     
@@ -939,13 +939,13 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch {
             for i in 0..<10 {
                 let docID = String(format: "doc_%03d", i)
-                let doc = try defaultCol!.document(id: docID)!
-                try self.defaultCol!.purge(document: doc)
-                XCTAssertNil(try defaultCol!.document(id: docID))
-                XCTAssertEqual(self.defaultCol!.count, UInt64(9 - i))
+                let doc = try defaultCollection!.document(id: docID)!
+                try self.defaultCollection!.purge(document: doc)
+                XCTAssertNil(try defaultCollection!.document(id: docID))
+                XCTAssertEqual(self.defaultCollection!.count, UInt64(9 - i))
             }
         }
-        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertEqual(defaultCollection!.count, 0)
     }
     
     func testPurgeWithErrorInBatch() throws {
@@ -953,9 +953,9 @@ class DatabaseTest: CBLTestCase {
         do {
             try self.db.inBatch {
                 for i in 0...9 {
-                    let doc = try defaultCol!.document(id: docs[i].id)!
-                    try defaultCol!.purge(document: doc)
-                    XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
+                    let doc = try defaultCollection!.document(id: docs[i].id)!
+                    try defaultCollection!.purge(document: doc)
+                    XCTAssertEqual(defaultCollection!.count, UInt64(9 - i))
                 }
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
@@ -963,19 +963,19 @@ class DatabaseTest: CBLTestCase {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(defaultCol!.count, 10)
+        XCTAssertEqual(defaultCollection!.count, 10)
     }
     
     func testPurgeDocumentOnADeletedDocument() throws {
         let document = try generateDocument(withID: nil)
         
         // Delete document
-        try self.defaultCol!.delete(document: document)
+        try self.defaultCollection!.delete(document: document)
         
         // Purge doc
-        try defaultCol!.purge(document: document)
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: document.id))
+        try defaultCollection!.purge(document: document)
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: document.id))
     }
     
     // MARK: Purge Document With ID
@@ -984,17 +984,17 @@ class DatabaseTest: CBLTestCase {
         let documentID = "\(Date().timeIntervalSince1970)"
         let _ = createDocument(documentID)
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.purge(id: documentID)
+            try self.defaultCollection!.purge(id: documentID)
         }
     }
     
     func testPurgeDocumentWithID() throws {
         let doc = try generateDocument(withID: nil)
         
-        try self.defaultCol!.purge(document: doc)
+        try self.defaultCollection!.purge(document: doc)
         
-        XCTAssertNil(try defaultCol!.document(id: doc.id))
-        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: doc.id))
+        XCTAssertEqual(defaultCollection!.count, 0)
     }
     
     func testPurgeDocumentWithIDInDifferentDBInstance() throws {
@@ -1023,12 +1023,12 @@ class DatabaseTest: CBLTestCase {
     func testCallPurgeDocumentWithIDTwice() throws {
         let document = try generateDocument(withID: nil)
         let documentID = document.id
-        try defaultCol!.purge(id: documentID)
-        XCTAssertNil(try defaultCol!.document(id: documentID))
-        XCTAssertEqual(defaultCol!.count, 0)
+        try defaultCollection!.purge(id: documentID)
+        XCTAssertNil(try defaultCollection!.document(id: documentID))
+        XCTAssertEqual(defaultCollection!.count, 0)
         
         expectError(domain: CBLError.domain, code: CBLError.notFound) { [unowned self] in
-            try self.defaultCol!.purge(id: documentID)
+            try self.defaultCollection!.purge(id: documentID)
         }
     }
     
@@ -1038,12 +1038,12 @@ class DatabaseTest: CBLTestCase {
         try db.inBatch { [unowned self] in
             for i in 0..<totalDocumentsCount {
                 let documentID = String(format: "doc_%03d", i)
-                try self.defaultCol!.purge(id: documentID)
-                XCTAssertNil(try defaultCol!.document(id: documentID))
-                XCTAssertEqual(self.defaultCol!.count, UInt64((totalDocumentsCount - 1) - i))
+                try self.defaultCollection!.purge(id: documentID)
+                XCTAssertNil(try defaultCollection!.document(id: documentID))
+                XCTAssertEqual(self.defaultCollection!.count, UInt64((totalDocumentsCount - 1) - i))
             }
         }
-        XCTAssertEqual(defaultCol!.count, 0)
+        XCTAssertEqual(defaultCollection!.count, 0)
     }
     
     func testPurgeDocIDWithErrorInBatch() throws {
@@ -1051,8 +1051,8 @@ class DatabaseTest: CBLTestCase {
         do {
             try self.db.inBatch {
                 for i in 0...9 {
-                    try self.defaultCol!.purge(id: docs[i].id)
-                    XCTAssertEqual(defaultCol!.count, UInt64(9 - i))
+                    try self.defaultCollection!.purge(id: docs[i].id)
+                    XCTAssertEqual(defaultCollection!.count, UInt64(9 - i))
                 }
                 throw NSError(domain: "someDomain", code: 500, userInfo: nil)
             }
@@ -1060,29 +1060,29 @@ class DatabaseTest: CBLTestCase {
             XCTAssertNotNil(error);
             XCTAssertEqual((error as NSError).code, CBLErrorUnexpectedError);
         }
-        XCTAssertEqual(defaultCol!.count, 10)
+        XCTAssertEqual(defaultCollection!.count, 10)
     }
     
     func testDeletePurgedDocumentWithID() throws {
         let document = try generateDocument(withID: nil)
         let documentID = document.id
-        let anotherDocumentReference = try defaultCol!.document(id: documentID)!
+        let anotherDocumentReference = try defaultCollection!.document(id: documentID)!
         
         // Purge doc
-        try defaultCol!.purge(id: documentID)
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: documentID))
+        try defaultCollection!.purge(id: documentID)
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: documentID))
         
         // Delete document & anotherDocumentReference -> 404 NotFound
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.delete(document: document)
+            try self.defaultCollection!.delete(document: document)
         }
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
-            try self.defaultCol!.delete(document: anotherDocumentReference)
+            try self.defaultCollection!.delete(document: anotherDocumentReference)
         }
         
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: documentID))
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: documentID))
     }
     
     func testPurgeDocumentWithIDOnADeletedDocument() throws {
@@ -1090,45 +1090,45 @@ class DatabaseTest: CBLTestCase {
         let documentID = document.id
         
         // Delete document
-        try self.defaultCol!.delete(document: document)
+        try self.defaultCollection!.delete(document: document)
         
         // Purge doc
-        try defaultCol!.purge(id: documentID)
-        XCTAssertEqual(defaultCol!.count, 0)
-        XCTAssertNil(try defaultCol!.document(id: documentID))
+        try defaultCollection!.purge(id: documentID)
+        XCTAssertEqual(defaultCollection!.count, 0)
+        XCTAssertNil(try defaultCollection!.document(id: documentID))
     }
     
     // MARK: Index
     
     func testCreateIndex() throws {
         // Precheck:
-        XCTAssertEqual(try defaultCol!.indexes().count, 0)
+        XCTAssertEqual(try defaultCollection!.indexes().count, 0)
 
         // Create value index:
         let fNameItem = ValueIndexItem.expression(Expression.property("firstName"))
         let lNameItem = ValueIndexItem.expression(Expression.property("lastName"))
 
         let index1 = IndexBuilder.valueIndex(items: fNameItem, lNameItem)
-        try defaultCol!.createIndex(index1, name: "index1")
+        try defaultCollection!.createIndex(index1, name: "index1")
 
         let index2 = IndexBuilder.valueIndex(items: [fNameItem, lNameItem])
-        try defaultCol!.createIndex(index2, name: "index2")
+        try defaultCollection!.createIndex(index2, name: "index2")
 
         // Create FTS index:
         let detailItem = FullTextIndexItem.property("detail")
         let index3 = IndexBuilder.fullTextIndex(items: detailItem)
-        try defaultCol!.createIndex(index3, name: "index3")
+        try defaultCollection!.createIndex(index3, name: "index3")
 
         let detailItem2 = FullTextIndexItem.property("es-detail")
         let index4 = IndexBuilder.fullTextIndex(items: detailItem2).language("es").ignoreAccents(true)
-        try defaultCol!.createIndex(index4, name: "index4")
+        try defaultCollection!.createIndex(index4, name: "index4")
 
         let nameItem = FullTextIndexItem.property("name")
         let index5 = IndexBuilder.fullTextIndex(items: [nameItem, detailItem])
-        try defaultCol!.createIndex(index5, name: "index5")
+        try defaultCollection!.createIndex(index5, name: "index5")
 
-        XCTAssertEqual(try defaultCol!.indexes().count, 5)
-        XCTAssertEqual(try defaultCol!.indexes(), ["index1", "index2", "index3", "index4", "index5"])
+        XCTAssertEqual(try defaultCollection!.indexes().count, 5)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["index1", "index2", "index3", "index4", "index5"])
     }
     
     func testCreateCollectionIndex() throws {
@@ -1254,30 +1254,30 @@ class DatabaseTest: CBLTestCase {
     }
     
     func testN1QLCreateIndexSanity() throws {
-        XCTAssertEqual(try defaultCol!.indexes().count, 0)
+        XCTAssertEqual(try defaultCollection!.indexes().count, 0)
         
         let config1 = ValueIndexConfiguration(["firstName", "lastName"])
-        try defaultCol!.createIndex(withName: "index1", config: config1)
+        try defaultCollection!.createIndex(withName: "index1", config: config1)
         
         let config2 = FullTextIndexConfiguration(["detail"])
-        try defaultCol!.createIndex(withName: "index2", config: config2)
+        try defaultCollection!.createIndex(withName: "index2", config: config2)
         
         let config3 = FullTextIndexConfiguration(["es_detail"], ignoreAccents: true, language: "es")
-        try defaultCol!.createIndex(withName: "index3", config: config3)
+        try defaultCollection!.createIndex(withName: "index3", config: config3)
         
         let config4 = FullTextIndexConfiguration(["name"], ignoreAccents: false, language: "en")
-        try defaultCol!.createIndex(withName: "index4", config: config4)
+        try defaultCollection!.createIndex(withName: "index4", config: config4)
         
         // use backtick in case of property name with hyphen
         let config5 = FullTextIndexConfiguration(["`es-detail`"], ignoreAccents: true, language: "es")
-        try defaultCol!.createIndex(withName: "index5", config: config5)
+        try defaultCollection!.createIndex(withName: "index5", config: config5)
         
         // same index twice: no-op
         let config6 = FullTextIndexConfiguration(["detail"])
-        try defaultCol!.createIndex(withName: "index2", config: config6)
+        try defaultCollection!.createIndex(withName: "index2", config: config6)
         
-        XCTAssertEqual(try defaultCol!.indexes().count, 5)
-        XCTAssertEqual(try defaultCol!.indexes(), ["index1", "index2", "index3", "index4", "index5"])
+        XCTAssertEqual(try defaultCollection!.indexes().count, 5)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["index1", "index2", "index3", "index4", "index5"])
     }
     
     func testCreateSameIndexTwice() throws {
@@ -1285,89 +1285,89 @@ class DatabaseTest: CBLTestCase {
         
         // Create index with first name:
         let index = IndexBuilder.valueIndex(items: item)
-        try defaultCol!.createIndex(index, name: "myindex")
+        try defaultCollection!.createIndex(index, name: "myindex")
         
         // Call create index again:
-        try defaultCol!.createIndex(index, name: "myindex")
+        try defaultCollection!.createIndex(index, name: "myindex")
         
-        XCTAssertEqual(try defaultCol!.indexes().count, 1)
-        XCTAssertEqual(try defaultCol!.indexes(), ["myindex"])
+        XCTAssertEqual(try defaultCollection!.indexes().count, 1)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["myindex"])
     }
     
     func failingTestCreateSameNameIndexes() throws {
         // Create value index with first name:
         let fNameItem = ValueIndexItem.expression(Expression.property("firstName"))
         let fNameIndex = IndexBuilder.valueIndex(items: fNameItem)
-        try defaultCol!.createIndex(fNameIndex, name: "myindex")
+        try defaultCollection!.createIndex(fNameIndex, name: "myindex")
         
         // Create value index with last name:
         let lNameItem = ValueIndexItem.expression(Expression.property("lastName"))
         let lNameIndex = IndexBuilder.valueIndex(items: lNameItem)
-        try defaultCol!.createIndex(lNameIndex, name: "myindex")
+        try defaultCollection!.createIndex(lNameIndex, name: "myindex")
         
         // Check:
-        XCTAssertEqual(try defaultCol!.indexes().count, 1)
-        XCTAssertEqual(try defaultCol!.indexes(), ["myindex"])
+        XCTAssertEqual(try defaultCollection!.indexes().count, 1)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["myindex"])
         
         // Create FTS index:
         let detailItem = FullTextIndexItem.property("detail")
         let detailIndex = IndexBuilder.fullTextIndex(items: detailItem)
-        try defaultCol!.createIndex(detailIndex, name: "myindex")
+        try defaultCollection!.createIndex(detailIndex, name: "myindex")
         
         // Check:
-        XCTAssertEqual(try defaultCol!.indexes().count, 1)
-        XCTAssertEqual(try defaultCol!.indexes(), ["myindex"])
+        XCTAssertEqual(try defaultCollection!.indexes().count, 1)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["myindex"])
     }
     
     func testDeleteIndex() throws {
         // Precheck:
-        XCTAssertEqual(try defaultCol!.indexes().count, 0)
+        XCTAssertEqual(try defaultCollection!.indexes().count, 0)
         
         // Create value index:
         let fNameItem = ValueIndexItem.expression(Expression.property("firstName"))
         let lNameItem = ValueIndexItem.expression(Expression.property("lastName"))
         
         let index1 = IndexBuilder.valueIndex(items: fNameItem, lNameItem)
-        try defaultCol!.createIndex(index1, name: "index1")
+        try defaultCollection!.createIndex(index1, name: "index1")
         
         // Create FTS index:
         let detailItem = FullTextIndexItem.property("detail")
         let index2 = IndexBuilder.fullTextIndex(items: detailItem)
-        try defaultCol!.createIndex(index2, name: "index2")
+        try defaultCollection!.createIndex(index2, name: "index2")
         
         let detailItem2 = FullTextIndexItem.property("es-detail")
         let index3 = IndexBuilder.fullTextIndex(items: detailItem2).language("es").ignoreAccents(true)
-        try defaultCol!.createIndex(index3, name: "index3")
+        try defaultCollection!.createIndex(index3, name: "index3")
         
-        XCTAssertEqual(try defaultCol!.indexes().count, 3)
-        XCTAssertEqual(try defaultCol!.indexes(), ["index1", "index2", "index3"])
+        XCTAssertEqual(try defaultCollection!.indexes().count, 3)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["index1", "index2", "index3"])
         
         // Delete indexes:
-        try defaultCol!.deleteIndex(forName: "index1")
-        XCTAssertEqual(try defaultCol!.indexes().count, 2)
-        XCTAssertEqual(try defaultCol!.indexes(), ["index2", "index3"])
+        try defaultCollection!.deleteIndex(forName: "index1")
+        XCTAssertEqual(try defaultCollection!.indexes().count, 2)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["index2", "index3"])
         
-        try defaultCol!.deleteIndex(forName: "index2")
-        XCTAssertEqual(try defaultCol!.indexes().count, 1)
-        XCTAssertEqual(try defaultCol!.indexes(), ["index3"])
+        try defaultCollection!.deleteIndex(forName: "index2")
+        XCTAssertEqual(try defaultCollection!.indexes().count, 1)
+        XCTAssertEqual(try defaultCollection!.indexes(), ["index3"])
         
-        try defaultCol!.deleteIndex(forName: "index3")
-        XCTAssertEqual(try defaultCol!.indexes().count, 0)
+        try defaultCollection!.deleteIndex(forName: "index3")
+        XCTAssertEqual(try defaultCollection!.indexes().count, 0)
         
         // Delete non existing index:
-        try defaultCol!.deleteIndex(forName: "dummy")
+        try defaultCollection!.deleteIndex(forName: "dummy")
         
         // Delete deleted indexes:
-        try defaultCol!.deleteIndex(forName: "index1")
-        try defaultCol!.deleteIndex(forName: "index2")
-        try defaultCol!.deleteIndex(forName: "index3")
+        try defaultCollection!.deleteIndex(forName: "index1")
+        try defaultCollection!.deleteIndex(forName: "index2")
+        try defaultCollection!.deleteIndex(forName: "index3")
     }
     
     func testCloseWithActiveLiveQueries() throws {
         let change1 = expectation(description: "changes 1")
         let change2 = expectation(description: "changes 2")
         
-        let ds = DataSource.collection(defaultCol!)
+        let ds = DataSource.collection(defaultCollection!)
         
         let q1 = QueryBuilder.select().from(ds)
         q1.addChangeListener { (ch) in change1.fulfill() }


### PR DESCRIPTION
- add defaultCollection within CBLTestCase so it can be accessed in every test
- update calls in:
    - DatabaseEncryptionTest
    - DatabaseTest 

defaultCollection should be optional such that it gets released and set to nil prior to database reset/deletion. Otherwise, some tests which involve the operations above would fail.