### PR TITLE
CBL-4428 : Fix database exclusive calls to c4queryobs* functions

### DIFF
--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -306,7 +306,7 @@ using namespace fleece;
     
     CBL_LOCK(self) {
         CBLChangeListenerToken* t = (CBLChangeListenerToken*)token;
-        [(CBLQueryObserver*)t.context stopAndFree];
+        [(CBLQueryObserver*)t.context stop];
         
         [_changeNotifier removeChangeListenerWithToken: token];
     }

--- a/Objective-C/Internal/CBLQueryObserver.h
+++ b/Objective-C/Internal/CBLQueryObserver.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) start;
 
 /** Stops and frees the observer */
-- (void) stopAndFree;
+- (void) stop;
 
 @end
 


### PR DESCRIPTION
* As c4queryobs_* (except c4queryobs_create) functions need to be callded under database-exclusive lock, made sure those function calls are under database’s lock.

* Combined stop() and stopAndFree() together to have only stop().

* Ensured not call to get the query result in postQueryChange() when the observer is already stopped.