### PR TITLE
CBL-4440 : Fix collection leaks when not removing document change listener token

### DIFF
--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -496,6 +496,10 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     return { .name = name, .scope = scopeName };
 }
 
+- (NSString*) fullName {
+    return $sprintf(@"%@.%@", _scope.name, _name);
+}
+
 - (BOOL) isEqual: (id)object {
     if (self == object)
         return YES;
@@ -617,15 +621,13 @@ static void colObserverCallback(C4CollectionObserver* obs, void* context) {
         
         CBLDocumentChangeNotifier* docNotifier = _docChangeNotifiers[documentID];
         if (!docNotifier) {
-            docNotifier = [[CBLDocumentChangeNotifier alloc] initWithCollection: self
-                                                                     documentID: documentID];
+            docNotifier = [[CBLDocumentChangeNotifier alloc] initWithCollection: self documentID: documentID];
             _docChangeNotifiers[documentID] = docNotifier;
         }
         
         CBLChangeListenerToken* token = [docNotifier addChangeListenerWithQueue: queue
                                                                        listener: listener
                                                                        delegate: self];
-        
         token.context = documentID;
         return token;
     }

--- a/Objective-C/Internal/CBLCollection+Internal.h
+++ b/Objective-C/Internal/CBLCollection+Internal.h
@@ -47,6 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) C4CollectionSpec c4spec;
 
+@property (nonatomic, readonly) NSString* fullName;
+
 /** This constructor will return CBLCollection for the c4collection. */
 - (instancetype) initWithDB: (CBLDatabase*)db
                c4collection: (C4Collection*)c4collection;

--- a/Objective-C/Internal/CBLDocumentChangeNotifier.h
+++ b/Objective-C/Internal/CBLDocumentChangeNotifier.h
@@ -23,15 +23,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-
 /**
  A subclass of CBLChangeNotifier that manages document change notifications.
  It manages the underlying C4DocumentObserver and posts the CBLDocumentChange notifications itself.
 */
 @interface CBLDocumentChangeNotifier : CBLChangeNotifier<CBLDocumentChange*>
 
-- (instancetype) initWithCollection: (CBLCollection*)collection
-                         documentID: (NSString*)documentID;
+@property (nonatomic, weak, nullable) CBLCollection* collection;
+
+- (instancetype) initWithCollection: (CBLCollection*)collection documentID: (NSString*)documentID;
 
 /** Immediately stops the C4DocumentObserver. No more notifications will be sent. */
 - (void) stop;

--- a/Objective-C/Tests/CollectionTest.m
+++ b/Objective-C/Tests/CollectionTest.m
@@ -648,6 +648,23 @@
     AssertEqual(changeListenerFired, 0);
 }
 
+- (void) testCollectionChangeListenerWithoutRemoveToken {
+    @autoreleasepool {
+        NSError* error = nil;
+        CBLCollection* colA = [self.db createCollectionWithName: @"colA"
+                                                          scope: @"scopeA" error: &error];
+        
+        XCTestExpectation* exp1 = [self expectationWithDescription: @"change listener 1"];
+        [colA addChangeListener: ^(CBLCollectionChange* change) {
+            [exp1 fulfill];
+        }];
+        
+        [self createDocNumbered: colA start: 0 num: 1];
+        
+        [self waitForExpectations: @[exp1] timeout: 10.0];
+    }
+}
+
 - (void) testCollectionDocumentChangeListener {
     NSError* error = nil;
     CBLCollection* col1 = [self.db createCollectionWithName: @"colA"
@@ -731,6 +748,25 @@
     
     [self createDocNumbered: col2 start: 10 num: 10];
     AssertEqual(changeListenerFired, 0);
+}
+
+- (void) testCollectionDocumentChangeListenerWithoutRemoveToken {
+    @autoreleasepool {
+        NSError* error = nil;
+        CBLCollection* colA = [self.db createCollectionWithName: @"colA" scope: @"scopeA" error: &error];
+        AssertNotNil(colA);
+        
+        XCTestExpectation* exp1 = [self expectationWithDescription: @"doc change listener 1"];
+        [colA addDocumentChangeListenerWithID: @"doc-1" listener: ^(CBLDocumentChange* change) {
+            [exp1 fulfill];
+        }];
+        
+        CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: @"doc-1"];
+        [doc setString: @"str" forKey: @"key"];
+        [colA saveDocument: doc error: &error];
+        
+        [self waitForExpectations: @[exp1] timeout: 10.0];
+    }
 }
 
 #pragma mark - 8.5-6 Use collection APIs on deleted/closed scenarios

--- a/Objective-C/Tests/CollectionTest.m
+++ b/Objective-C/Tests/CollectionTest.m
@@ -648,6 +648,8 @@
     AssertEqual(changeListenerFired, 0);
 }
 
+/** Test that there is no collection or c4 object leak when the listener token is not removed.
+    The actual check for the object leak is in the test's tear down. */
 - (void) testCollectionChangeListenerWithoutRemoveToken {
     @autoreleasepool {
         NSError* error = nil;
@@ -750,6 +752,8 @@
     AssertEqual(changeListenerFired, 0);
 }
 
+/** Test that there is no collection or c4 object leak when the listener token is not removed.
+    The actual check for the object leak is in the test's tear down. */
 - (void) testCollectionDocumentChangeListenerWithoutRemoveToken {
     @autoreleasepool {
         NSError* error = nil;

--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -513,6 +513,8 @@ class CollectionTest: CBLTestCase {
         XCTAssertEqual(changeListenerFired, 0)
     }
     
+    /** Test that there is no collection or c4 object leak when the listener token is not removed.
+        The actual check for the object leak is in the test's tear down. */
     func testCollectionChangeListenerWithoutRemoveToken() throws {
         try autoreleasepool {
             let colA = try self.db.createCollection(name: "colA", scope: "scopeA")
@@ -617,6 +619,8 @@ class CollectionTest: CBLTestCase {
         XCTAssertEqual(changeListenerFired, 0)
     }
     
+    /** Test that there is no collection or c4 object leak when the listener token is not removed.
+        The actual check for the object leak is in the test's tear down. */
     func testCollectionDocumentChangeListenerWithoutRemoveToken() throws {
         try autoreleasepool {
             let colA = try self.db.createCollection(name: "colA", scope: "scopeA")

--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -513,6 +513,21 @@ class CollectionTest: CBLTestCase {
         XCTAssertEqual(changeListenerFired, 0)
     }
     
+    func testCollectionChangeListenerWithoutRemoveToken() throws {
+        try autoreleasepool {
+            let colA = try self.db.createCollection(name: "colA", scope: "scopeA")
+            
+            let exp1 = expectation(description: "doc change listener 1")
+            _ = colA.addChangeListener { change in
+                exp1.fulfill()
+            }
+            
+            try createDocNumbered(colA, start: 0, num: 1)
+            
+            waitForExpectations(timeout: 10.0)
+        }
+    }
+    
     func testCollectionDocumentChangeListener() throws {
         let colA = try self.db.createCollection(name: "colA", scope: "scopeA")
         let colB = try self.db.createCollection(name: "colB", scope: "scopeA")
@@ -600,6 +615,23 @@ class CollectionTest: CBLTestCase {
         
         try createDocNumbered(colB, start: 10, num: 10)
         XCTAssertEqual(changeListenerFired, 0)
+    }
+    
+    func testCollectionDocumentChangeListenerWithoutRemoveToken() throws {
+        try autoreleasepool {
+            let colA = try self.db.createCollection(name: "colA", scope: "scopeA")
+            
+            let exp1 = expectation(description: "doc change listener 1")
+            _ = colA.addDocumentChangeListener(id: "doc-1") { change in
+                exp1.fulfill()
+            }
+            
+            let doc = MutableDocument(id: "doc-1")
+            doc.setString("str", forKey: "key")
+            try colA.save(document: doc)
+            
+            waitForExpectations(timeout: 10.0)
+        }
     }
     
     // MARK: Index


### PR DESCRIPTION
* Made collection weak reference in CBLDocumentChangeNotifier so that there is no cirular reference b/w colletion and its CBLDocumentChangeNotifier objects.

* Added warning when skipping the notification as the collection object has been released and improved warning logs in CBLDocumentChangeNotifier.

* Added tests to ensure that there is no memory leak when not removing listener token in collection (Note : we have checked for C4 Object Leaks in Tests’ teardown).