### PR TITLE
CBL-4486 : Remove bitcode flag from the build scripts

### DIFF
--- a/Scripts/build_framework.sh
+++ b/Scripts/build_framework.sh
@@ -128,7 +128,7 @@ for SDK in "${SDKS[@]}"
       ARCH="-arch x86_64 -arch i386"
     fi
 
-    xcodebuild -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -sdk ${SDK} ${ARCH} ${BUILD_VERSION} ${BUILD_NUMBER} "ONLY_ACTIVE_ARCH=NO" "BITCODE_GENERATION_MODE=bitcode" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGN_IDENTITY=" ${ACTION} ${QUIET}
+    xcodebuild -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -sdk ${SDK} ${ARCH} ${BUILD_VERSION} ${BUILD_NUMBER} "ONLY_ACTIVE_ARCH=NO" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGN_IDENTITY=" ${ACTION} ${QUIET}
 
     # Get the XCode built framework and dsym file path:
     PRODUCTS_DIR=`xcodebuild -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -sdk "${SDK}" -showBuildSettings|grep -w BUILT_PRODUCTS_DIR|head -n 1|awk '{ print $3 }'`

--- a/Scripts/build_xcframework.sh
+++ b/Scripts/build_xcframework.sh
@@ -118,7 +118,7 @@ function xcarchive
     -destination "${DESTINATION}" \
     ${BUILD_VERSION} ${BUILD_NUMBER} "${CBL_COPYRIGHT_YEAR}" "${EDITION}" \
     -archivePath "${ARCHIVE_PATH}/${BIN_NAME}.xcarchive" \
-    "ONLY_ACTIVE_ARCH=NO" "BITCODE_GENERATION_MODE=bitcode" \
+    "ONLY_ACTIVE_ARCH=NO" \
     "CODE_SIGNING_REQUIRED=NO" "CODE_SIGN_IDENTITY=" \
     "SKIP_INSTALL=NO" ${QUIET}
   

--- a/Scripts/pull_request_build.sh
+++ b/Scripts/pull_request_build.sh
@@ -2,8 +2,10 @@
 
 cd couchbase-lite-ios
 
+TEST_SIMULATOR=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | sed 's/Simulator//g' | awk '{$1=$1;print}')
 SCHEMES=("CBL_EE_ObjC" "CBL_EE_Swift")
+
 for SCHEME in "${SCHEMES[@]}"
 do
-  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 8"
+  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEME" -sdk iphonesimulator -destination "platform=iOS Simulator,name=${TEST_SIMULATOR}"
 done


### PR DESCRIPTION
* Apple doesn’t allow to include bitcode in the binary and framework anymore. Also when using XCode 14, bitcode is not generated by default.

* Removed the BITCODE_GENERATION_MODE from the build scripts.

* Used the same command as the command used in Github Action to get the lowest version of the simulator to run the test on Jenkins's PR validation.

* Ported from 84018f18375a6b5e5cbcc6f9b08767b0d49620cd in master branch.