### PR TITLE
Set iOS deployment target version to 10.0

### DIFF
--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -23,9 +23,9 @@ CBL_EXPORTED_SYMBOLS_FILE          = Objective-C/CouchbaseLite.exp
 CBL_SWIFT_MODULEMAP_FILE           = Swift/CouchbaseLiteSwift.modulemap
 CBL_COPYRIGHT_YEAR                 = 2021
 
-IPHONEOS_DEPLOYMENT_TARGET         = 11.0
+IPHONEOS_DEPLOYMENT_TARGET         = 10.0
 MACOSX_DEPLOYMENT_TARGET           = 10.12
-TVOS_DEPLOYMENT_TARGET             = 11.0
+TVOS_DEPLOYMENT_TARGET             = 10.0
 
 CODE_SIGN_IDENTITY                 =
 


### PR DESCRIPTION
According to the support matrix, the iOS 10.0 is deprecated but is still supported.