### PR TITLE
CBL-4438 : Prevent crash when notifying doc change for already-released collection

### DIFF
--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -253,8 +253,12 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     public func addDocumentChangeListener(id: String, queue: DispatchQueue?,
                                    listener: @escaping (DocumentChange) -> Void) -> ListenerToken {
         let token = impl.addDocumentChangeListener(withID: id, queue: queue)
-        { [unowned self] (change) in
-            listener(DocumentChange(database: db,
+        { [weak self] (change) in
+            guard let self = self else {
+                Log.log(domain: .database, level: .warning, message: "Unable to notify changes as the collection object was released")
+                return
+            }
+            listener(DocumentChange(database: self.db,
                                     documentID: change.documentID,
                                     collection: self))
         }


### PR DESCRIPTION
* Ported the fix b48ba0e524b884d6455b3f4fab171fdaa3373784 from master branch.

* Changed to weak self and added warning log when collection ref has been released.