### PR TITLE
CBL-4580 : Fix Document’s contains(key:) returning wrong result

### DIFF
--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -359,7 +359,7 @@ using namespace fleece;
 }
 
 - (BOOL) containsValueForKey: (nonnull NSString *)key {
-    return [_dict booleanForKey: key];
+    return [_dict containsValueForKey: key];
 }
 
 - (CBLFragment *) objectForKeyedSubscript: (NSString *)key {

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -1342,16 +1342,20 @@
 - (void) testContainsKey {
     CBLMutableDocument* doc = [self createDocument: @"doc1"];
     [doc setData: @{ @"type": @"profile",
-                           @"name": @"Jason",
-                           @"age": @"30",
-                           @"address": @{
-                                   @"street": @"1 milky way.",
-                                   }
-                           }];
+                     @"name": @"Jason",
+                     @"age": @"30",
+                     @"remote": @NO,
+                     @"active": @YES,
+                     @"address": @{
+                         @"street": @"1 milky way.",
+                     }
+                  }];
     
     Assert([doc containsValueForKey: @"type"]);
     Assert([doc containsValueForKey: @"name"]);
     Assert([doc containsValueForKey: @"age"]);
+    Assert([doc containsValueForKey: @"remote"]);
+    Assert([doc containsValueForKey: @"active"]);
     Assert([doc containsValueForKey: @"address"]);
     AssertFalse([doc containsValueForKey: @"weight"]);
 }

--- a/Swift/Tests/DocumentTest.swift
+++ b/Swift/Tests/DocumentTest.swift
@@ -1165,13 +1165,28 @@ class DocumentTest: CBLTestCase {
         let dict: [String: Any] = ["type": "profile",
                                    "name": "Jason",
                                    "age": "30",
+                                   "remote": false,
+                                   "active": true,
                                    "address": ["street": "1 milky way."]]
         doc.setData(dict)
+        
+        // Swift Sequence Protocol
         XCTAssert(doc.contains("type"))
         XCTAssert(doc.contains("name"))
         XCTAssert(doc.contains("age"))
+        XCTAssert(doc.contains("remote"))
+        XCTAssert(doc.contains("active"))
         XCTAssert(doc.contains("address"))
         XCTAssertFalse(doc.contains("weight"))
+        
+        // DictionaryProtocol
+        XCTAssert(doc.contains(key: "type"))
+        XCTAssert(doc.contains(key: "name"))
+        XCTAssert(doc.contains(key: "age"))
+        XCTAssert(doc.contains(key: "remote"))
+        XCTAssert(doc.contains(key: "active"))
+        XCTAssert(doc.contains(key: "address"))
+        XCTAssertFalse(doc.contains(key: "weight"))
     }
     
     func testRemoveKeys() throws {


### PR DESCRIPTION
Fixed CBLDocument’s containsValueForKey: to call the right function when checking if the key exists in the document.