### PR TITLE
CBL-4626:  Update Deployment Target to iOS 11.0 and macOS 10.14

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -6808,7 +6808,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
@@ -6859,7 +6858,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
 				PRODUCT_NAME = CouchbaseLiteSwiftTests;
@@ -6910,7 +6908,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = CBLPerfTests;
@@ -6954,7 +6951,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = CBLPerfTests;
 				SDKROOT = macosx;
@@ -7071,7 +7067,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
@@ -7124,7 +7119,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = CBLPerfTests;
@@ -7242,7 +7236,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
 				PRODUCT_NAME = CouchbaseLiteSwiftTests;
@@ -7287,7 +7280,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = CBLPerfTests;
 				SDKROOT = macosx;
@@ -7625,7 +7617,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -7697,7 +7688,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -7763,7 +7753,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -7828,7 +7817,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -8106,7 +8094,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
@@ -8162,7 +8149,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
@@ -8213,7 +8199,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
 				PRODUCT_NAME = CouchbaseLiteSwiftTests;
@@ -8262,7 +8247,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Swift/Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.couchbase.CouchbaseLiteSwiftTests;
 				PRODUCT_NAME = CouchbaseLiteSwiftTests;
@@ -8313,7 +8297,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = CBLPerfTests;
@@ -8363,7 +8346,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = CBLPerfTests;
@@ -8407,7 +8389,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = CBLPerfTests;
 				SDKROOT = macosx;
@@ -8450,7 +8431,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = CBLPerfTests;
 				SDKROOT = macosx;
@@ -8627,7 +8607,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -8699,7 +8678,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -8765,7 +8743,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -8830,7 +8807,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -271,16 +271,12 @@ static void doDispose(C4Socket* s) {
             C4Cert* c4cert = c4cert_fromData(certData, &err);
             if (c4cert) {
                 NSError* error;
-                if (@available(macOS 10.12, iOS 10.0, *)) {
-                    _clientIdentity = toSecIdentityWithCertChain(c4cert, &error);
-                    if (_clientIdentity) {
-                        c4cert_release(c4cert);
-                        return;
-                    }
-                    CBLWarnError(Sync, @"%@: Couldn't lookup the identity from the KeyChain: %@", self, error);
-                } else {
-                    CBLWarnError(Sync, @"%@: Client Cert Auth is not supported by macOS < 10.12 and iOS < 10.0", self);
+                _clientIdentity = toSecIdentityWithCertChain(c4cert, &error);
+                if (_clientIdentity) {
+                    c4cert_release(c4cert);
+                    return;
                 }
+                CBLWarnError(Sync, @"%@: Couldn't lookup the identity from the KeyChain: %@", self, error);
                 c4cert_release(c4cert);
             } else {
                 NSError* error;

--- a/Objective-C/Tests/PredictiveQueryTest+CoreML.m
+++ b/Objective-C/Tests/PredictiveQueryTest+CoreML.m
@@ -19,7 +19,6 @@
 #import "CBLTestCase.h"
 #import "CBLCoreMLPredictiveModel+Internal.h"
 
-API_AVAILABLE(macos(10.13), ios(11.0))
 @interface PredictiveQueryWithCoreMLTest : CBLTestCase
 
 @end
@@ -303,7 +302,7 @@ API_AVAILABLE(macos(10.13), ios(11.0))
 }
 
 - (void) testSequenceDataConversion {
-    if (@available(macOS 10.14, iOS 12.0, *)) {
+    if (@available(iOS 12.0, *)) {
         NSArray* types = @[@(MLFeatureTypeInt64), @(MLFeatureTypeString)];
         NSArray* tests = @[@[@1, @2, @3, @4, @5], @[@"1", @"2", @"3", @"4", @"5"]];
         

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -204,13 +204,9 @@
 
 - (NSString*) getCertificateID: (SecCertificateRef)cert {
     CFErrorRef* errRef = NULL;
-    if (@available(macOS 10.13, iOS 11.0, *)) {
         NSData* data = (NSData*)CFBridgingRelease(SecCertificateCopySerialNumberData(cert, errRef));
         Assert(errRef == NULL);
         return [NSString stringWithFormat: @"%lu", (unsigned long)[data hash]];
-    } else {
-        return (NSString*) CFBridgingRelease(SecCertificateCopySubjectSummary(cert));
-    }
 }
 
 #pragma mark - Configs

--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -20,7 +20,6 @@
 #import "CBLTestCase.h"
 #import "CBLTLSIdentity+Internal.h"
 
-API_AVAILABLE(macos(10.12), ios(10.0))
 @interface TLSIdentityTest : CBLTestCase
 
 @end
@@ -46,16 +45,13 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 - (NSData*) publicKeyHashFromCert: (SecCertificateRef)certRef {
     // Get public key from the certificate:
     SecKeyRef publicKeyRef;
-    if (@available(iOS 12, macOS 10.14, *)) {
+    if (@available(iOS 12, *)) {
         publicKeyRef = SecCertificateCopyKey(certRef);
     } else {
 #if TARGET_OS_MACCATALYST
         Assert(false, @"Catalyst:SecCertificateCopyKey is not supported, iOS < 12, macOS < 10.14");
 #elif TARGET_OS_IOS
-        if (@available(iOS 10.3, *))
-            publicKeyRef = SecCertificateCopyPublicKey(certRef);
-        else
-            Assert(false, @"IOS:SecCertificateCopyPublicKey is not supported, iOS < 10.3");
+        publicKeyRef = SecCertificateCopyPublicKey(certRef);
 #elif TARGET_OS_OSX
         if (@available(macOS 10.3, *)) {
             OSStatus status = SecCertificateCopyPublicKey(certRef, &publicKeyRef);
@@ -65,14 +61,8 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 #endif
     }
     Assert(publicKeyRef);
-                
-    if (@available(iOS 10.0, macOS 10.12, *)) {
-        NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(publicKeyRef));
-        return [attrs objectForKey: (id)kSecAttrApplicationLabel];
-    } else {
-        Assert(false, @"SecKeyCopyAttributes is not supported, iOS < 10.0, macOS < 10.12");
-    }
-    return nil;
+    NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(publicKeyRef));
+    return [attrs objectForKey: (id)kSecAttrApplicationLabel];
 }
 
 - (void) checkIdentityInKeyChain: (CBLTLSIdentity*)identity {

--- a/Objective-C/Tests/URLEndpointListenerTest+Main.m
+++ b/Objective-C/Tests/URLEndpointListenerTest+Main.m
@@ -665,7 +665,7 @@
     
 }
 
-- (void) testClientCertAuthWithCallback API_AVAILABLE(macos(10.12), ios(10.3)) {
+- (void) testClientCertAuthWithCallback {
     if (!self.keyChainAccessAllowed) return;
     
     // Listener:
@@ -700,7 +700,7 @@
     [self stopListener: listener];
 }
 
-- (void) testClientCertAuthWithCallbackError API_AVAILABLE(macos(10.12), ios(10.3)) {
+- (void) testClientCertAuthWithCallbackError {
     if (!self.keyChainAccessAllowed) return;
     
     // Listener:

--- a/Objective-C/Tests/URLEndpointListenerTest.h
+++ b/Objective-C/Tests/URLEndpointListenerTest.h
@@ -27,10 +27,8 @@
 #define kServerCertLabel @"CBL-Server-Cert"
 #define kClientCertLabel @"CBL-Client-Cert"
 
-API_AVAILABLE(macos(10.12), ios(10.0))
 typedef CBLURLEndpointListenerConfiguration Config;
 
-API_AVAILABLE(macos(10.12), ios(10.0))
 typedef CBLURLEndpointListener Listener;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void) checkEqualForCert: (SecCertificateRef)cert1 andCert: (SecCertificateRef)cert2 {
-    if (@available(macOS 10.5, iOS 10.3, *)) {
+    if (@available(macOS 10.5, *)) {
         CFStringRef cnRef1, cnRef2;
         AssertEqual(SecCertificateCopyCommonName(cert1, &cnRef1), errSecSuccess);
         AssertEqual(SecCertificateCopyCommonName(cert2, &cnRef2), errSecSuccess);

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Couchbase Lite implementation is on top of [Couchbase Lite Core](https://github.
 
 
 ## Requirements
-- iOS 9.0+ | macOS 10.11+
-- Xcode 10.3+
+- iOS 11.0+ | macOS 10.14+
 
 
 ## Installation

--- a/Swift/Tests/PredictiveQueryTest+CoreML.swift
+++ b/Swift/Tests/PredictiveQueryTest+CoreML.swift
@@ -20,7 +20,6 @@ import XCTest
 import CoreML
 import CouchbaseLiteSwift
 
-@available(macOS 10.13, iOS 11.0, *)
 class PredictiveQueryWithCoreMLTest: CBLTestCase {
     
     func coreMLModel(name: String, mustExist: Bool = true) throws -> MLModel? {

--- a/Swift/Tests/TLSIdentityTest.swift
+++ b/Swift/Tests/TLSIdentityTest.swift
@@ -19,7 +19,6 @@
 import XCTest
 import CouchbaseLiteSwift
 
-@available(macOS 10.12, iOS 10.3, *)
 class TLSIdentityTest: CBLTestCase {
     let serverCertLabel = "CBL-Swift-Server-Cert"
     let clientCertLabel = "CBL-Swift-Client-Cert"

--- a/Swift/Tests/URLEndpointListenerTest+Collection.swift
+++ b/Swift/Tests/URLEndpointListenerTest+Collection.swift
@@ -20,7 +20,6 @@
 import XCTest
 import CouchbaseLiteSwift
 
-@available(macOS 10.12, iOS 10.3, *)
 class URLEndpointListenerTest_Collection: URLEndpointListenerTest {
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -19,7 +19,6 @@
 import XCTest
 @testable import CouchbaseLiteSwift
 
-@available(macOS 10.12, iOS 10.3, *)
 class URLEndpointListenerTest: ReplicatorTest {
     let wsPort: UInt16 = 4084
     let wssPort: UInt16 = 4085
@@ -126,7 +125,6 @@ class URLEndpointListenerTest: ReplicatorTest {
     }
 }
 
-@available(macOS 10.12, iOS 10.3, *)
 class URLEndpointListenerTest_Main: URLEndpointListenerTest {
     override func setUp() {
         super.setUp()
@@ -1429,7 +1427,6 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
 
 }
 
-@available(macOS 10.12, iOS 10.3, *)
 extension URLEndpointListener {
     var localURL: URL {
         assert(self.port != nil && self.port! > UInt16(0))

--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -23,9 +23,9 @@ CBL_EXPORTED_SYMBOLS_FILE          = Objective-C/CouchbaseLite.exp
 CBL_SWIFT_MODULEMAP_FILE           = Swift/CouchbaseLiteSwift.modulemap
 CBL_COPYRIGHT_YEAR                 = 2021
 
-IPHONEOS_DEPLOYMENT_TARGET         = 10.0
-MACOSX_DEPLOYMENT_TARGET           = 10.12
-TVOS_DEPLOYMENT_TARGET             = 10.0
+IPHONEOS_DEPLOYMENT_TARGET         = 11.0
+MACOSX_DEPLOYMENT_TARGET           = 10.14
+TVOS_DEPLOYMENT_TARGET             = 11.0
 
 CODE_SIGN_IDENTITY                 =
 


### PR DESCRIPTION
- ported #3162 from `release/3.1`
- removals of redundant api availability checks