### PR TITLE
CBL-4603 : Ignore exception breakpoint in tests

### DIFF
--- a/Objective-C/Tests/CBLTestCase.h
+++ b/Objective-C/Tests/CBLTestCase.h
@@ -182,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) mayHaveException: (NSString*)name in: (void (^) (void))block;
 
 - (void) ignoreException: (void (^) (void))block;
-- (void) ignoreExceptionBreakPointOnly: (void (^) (void))block;
+- (void) ignoreExceptionBreakPoint: (void (^) (void))block;
 
 - (uint64_t) verifyQuery: (CBLQuery*)query
             randomAccess: (BOOL)randomAccess

--- a/Objective-C/Tests/CBLTestCase.m
+++ b/Objective-C/Tests/CBLTestCase.m
@@ -159,7 +159,15 @@
 }
 
 - (BOOL) deleteDBNamed: (NSString*)name error: (NSError**)error {
-    return [CBLDatabase deleteDatabase: name inDirectory: self.directory error: error];
+    __block BOOL result;
+    __block NSError* err = nil;
+    [self ignoreExceptionBreakPoint: ^{
+        result = [CBLDatabase deleteDatabase: name inDirectory: self.directory error: &err];
+    }];
+    if (error) {
+        *error = err;
+    }
+    return result;
 }
 
 - (void) deleteDatabase: (CBLDatabase*)database {
@@ -372,7 +380,7 @@
     }
 }
 
-- (void) ignoreExceptionBreakPointOnly: (void (^) (void))block {
+- (void) ignoreExceptionBreakPoint: (void (^) (void))block {
     ++gC4ExpectExceptions;
     block();
     --gC4ExpectExceptions;

--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -179,16 +179,24 @@
     [super setUp];
     if (!self.keyChainAccessAllowed) return;
     
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: nil]);
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: nil]);
+    [self ignoreExceptionBreakPoint: ^{
+        Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: nil]);
+    }];
+    [self ignoreExceptionBreakPoint: ^{
+        Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: nil]);
+    }];
 }
 
 - (void) tearDown {
     [super tearDown];
     if (!self.keyChainAccessAllowed) return;
     
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: nil]);
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: nil]);
+    [self ignoreExceptionBreakPoint: ^{
+        Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: nil]);
+    }];
+    [self ignoreExceptionBreakPoint: ^{
+        Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: nil]);
+    }];
 }
 
 - (void) testCreateGetDeleteServerIdentity {
@@ -196,10 +204,6 @@
     
     NSError* error;
     CBLTLSIdentity* identity;
-    
-    // Delete:
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: &error]);
-    AssertNil(error);
     
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
@@ -277,10 +281,6 @@
     
     NSError* error;
     CBLTLSIdentity* identity;
-    
-    // Delete:
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: &error]);
-    AssertNil(error);
     
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kClientCertLabel error: &error];
@@ -399,10 +399,6 @@
     AssertNotNil(identity);
     AssertNil(error);
     AssertEqual(identity.certs.count, 2u);
-    
-    // Delete from KeyChain:
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: &error]);
-    AssertNil(error);
 }
 
 - (void) testImportIdentity {
@@ -434,7 +430,9 @@
     AssertEqual(identity.certs.count, 2);
     
     // Delete:
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: &error]);
+    [self ignoreExceptionBreakPoint: ^{
+        Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: &error]);
+    }];
     AssertNil(error);
     
     // Get:
@@ -448,10 +446,6 @@
     
     NSError* error;
     CBLTLSIdentity* identity;
-    
-    // Delete:
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: &error]);
-    AssertNil(error);
     
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
@@ -476,10 +470,6 @@
 
     NSError* error;
     CBLTLSIdentity* identity;
-    
-    // Delete:
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kServerCertLabel error: &error]);
-    AssertNil(error);
     
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];

--- a/Objective-C/Tests/URLEndpointListenerTest+Main.m
+++ b/Objective-C/Tests/URLEndpointListenerTest+Main.m
@@ -743,7 +743,9 @@
     
     // Cleanup:
     __block NSError* error;
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: &error]);
+    [self ignoreExceptionBreakPoint: ^{
+        Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: &error]);
+    }];
     
     // Create client identity:
     NSData* clientIdentityData = [self dataFromResource: @"identity/client" ofType: @"p12"];
@@ -769,8 +771,9 @@
     }];
 
     // Cleanup:
-    Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: &error]);
-    
+    [self ignoreExceptionBreakPoint: ^{
+        Assert([CBLTLSIdentity deleteIdentityWithLabel: kClientCertLabel error: &error]);
+    }];
     [self stopListener: listener];
 }
 

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -132,7 +132,9 @@ class CBLTestCase: XCTestCase {
     }
     
     func deleteDB(name: String) throws {
-        try Database.delete(withName: name, inDirectory: self.directory)
+        ignoreException {
+            try Database.delete(withName: name, inDirectory: self.directory)
+        }
     }
     
     func createDocument() -> MutableDocument {

--- a/Swift/Tests/TLSIdentityTest.swift
+++ b/Swift/Tests/TLSIdentityTest.swift
@@ -139,23 +139,28 @@ class TLSIdentityTest: CBLTestCase {
         super.setUp()
         if (!keyChainAccessAllowed) { return }
         
-        try! TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
-        try! TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
+        ignoreException {
+            try! TLSIdentity.deleteIdentity(withLabel: self.serverCertLabel)
+        }
+        ignoreException {
+            try! TLSIdentity.deleteIdentity(withLabel: self.clientCertLabel)
+        }
     }
     
     override func tearDown() {
         super.tearDown()
         if (!keyChainAccessAllowed) { return }
         
-        try! TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
-        try! TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
+        ignoreException {
+            try! TLSIdentity.deleteIdentity(withLabel: self.serverCertLabel)
+        }
+        ignoreException {
+            try! TLSIdentity.deleteIdentity(withLabel: self.clientCertLabel)
+        }
     }
     
     func testCreateGetDeleteServerIdentity() throws {
         if (!keyChainAccessAllowed) { return }
-        
-        // Delete:
-        try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
         
         // Get:
         var identity: TLSIdentity?
@@ -218,9 +223,6 @@ class TLSIdentityTest: CBLTestCase {
     
     func testCreateGetDeleteClientIdentity() throws {
         if (!keyChainAccessAllowed) { return }
-        
-        // Delete:
-        try TLSIdentity.deleteIdentity(withLabel: clientCertLabel)
         
         // Get:
         var identity: TLSIdentity?
@@ -321,16 +323,10 @@ class TLSIdentityTest: CBLTestCase {
         let identity = try TLSIdentity.identity(withIdentity: secIdentity, certs: [certs[1]])
         XCTAssertNotNil(identity)
         XCTAssertEqual(identity.certs.count, 2)
-        
-        // Delete from KeyChain:
-        try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
     }
     
     func testImportIdentity() throws {
         if (!keyChainAccessAllowed) { return }
-        
-        // Delete:
-        try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
         
         let data = try dataFromResource(name: "identity/certs", ofType: "p12")
         
@@ -355,7 +351,9 @@ class TLSIdentityTest: CBLTestCase {
         checkIdentityInKeyChain(identity: identity!)
         
         // Delete:
-        try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
+        ignoreException {
+            try TLSIdentity.deleteIdentity(withLabel: self.serverCertLabel)
+        }
         
         // Get:
         expectError(domain: CBLError.domain, code: CBLError.notFound) {
@@ -365,9 +363,6 @@ class TLSIdentityTest: CBLTestCase {
     
     func testCreateIdentityWithNoAttributes() throws {
         if (!keyChainAccessAllowed) { return }
-        
-        // Delete:
-        try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
         
         // Get:
         var identity: TLSIdentity?
@@ -388,9 +383,6 @@ class TLSIdentityTest: CBLTestCase {
     
     func testCertificateExpiration() throws {
         if (!keyChainAccessAllowed) { return }
-        
-        // Delete:
-        try TLSIdentity.deleteIdentity(withLabel: serverCertLabel)
         
         // Get:
         var identity: TLSIdentity?


### PR DESCRIPTION
* Used ignoreException to wrap the statement that could have internal C++ exception thrown as part of the logic so that it will not trigger the exception breakpoint.

* Removed the statements that delete the identity at the beginning and ending of the tests as they are already done in setup and teardown.