### PR TITLE
Fix Jenkins release build

### DIFF
--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -53,11 +53,7 @@
 #elif TARGET_OS_IOS
         publicKeyRef = SecCertificateCopyPublicKey(certRef);
 #elif TARGET_OS_OSX
-        if (@available(macOS 10.3, *)) {
-            OSStatus status = SecCertificateCopyPublicKey(certRef, &publicKeyRef);
-            Assert(status == errSecSuccess);
-        } else
-            Assert(false, @"OSX:SecCertificateCopyPublicKey is not supported, macOS < 10.3");
+        Assert(false, @"OSX:SecCertificateCopyPublicKey is not supported, macOS < 10.14");
 #endif
     }
     Assert(publicKeyRef);


### PR DESCRIPTION
https://mobile.jenkins.couchbase.com/job/couchbase-lite-ios-objc-edition-build/4756/console
`'SecCertificateCopyPublicKey' is deprecated: first deprecated in macOS 10.14`

- will port to `release/3.1` for 3.1.1 once merged and Jenkins is green