### PR TITLE
Fix Jenkins release build (#3166)

### DIFF
--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -57,11 +57,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
         else
             Assert(false, @"IOS:SecCertificateCopyPublicKey is not supported, iOS < 10.3");
 #elif TARGET_OS_OSX
-        if (@available(macOS 10.3, *)) {
-            OSStatus status = SecCertificateCopyPublicKey(certRef, &publicKeyRef);
-            Assert(status == errSecSuccess);
-        } else
-            Assert(false, @"OSX:SecCertificateCopyPublicKey is not supported, macOS < 10.3");
+        Assert(false, @"OSX:SecCertificateCopyPublicKey is not supported, macOS < 10.14");
 #endif
     }
     Assert(publicKeyRef);


### PR DESCRIPTION
https://mobile.jenkins.couchbase.com/job/couchbase-lite-ios-objc-edition-build/4760/

- port from master
- due to version bump of macos