### PR TITLE
CBL-4981: Remap Changes LiteCore Log Domain to Database Domain (port)

### DIFF
--- a/Objective-C/CBLLog.mm
+++ b/Objective-C/CBLLog.mm
@@ -84,7 +84,7 @@ static CBLLogDomain toCBLLogDomain(C4LogDomain domain) {
                               @"Query": @(kCBLLogDomainQuery),
                               @"Sync": @(kCBLLogDomainReplicator),
                               @"SyncBusy": @(kCBLLogDomainReplicator),
-                              @"Changes": @(kCBLLogDomainReplicator),
+                              @"Changes": @(kCBLLogDomainDatabase),
                               @"BLIP": @(kCBLLogDomainNetwork),
                               @"WS": @(kCBLLogDomainNetwork),
                               @"BLIPMessages": @(kCBLLogDomainNetwork),


### PR DESCRIPTION
- port of f616eec318a7070be484ea3be415c6396eec65b1