### PR TITLE
CBL-5035 : Fix missing pending conflict array initialization.

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -104,6 +104,7 @@ typedef enum {
         _progressLevel = kCBLProgressLevelOverall;
         _changeNotifier = [CBLChangeNotifier new];
         _docReplicationNotifier = [CBLChangeNotifier new];
+        _pendingConflicts = [NSMutableArray array];
         _status = [[CBLReplicatorStatus alloc] initWithStatus: {kC4Stopped, {}, {}}];
         
         NSString* qName = self.description;
@@ -670,7 +671,7 @@ static void onDocsEnded(C4Replicator* repl,
 
 // Called inside the lock
 - (void) scheduleConflictResolutionForDocument: (CBLReplicatedDocument*)doc {
-    if (_conflictResolutionSuspended) {
+    if (_conflictResolutionSuspended || _state == kCBLStateStopped) {
         return;
     }
     


### PR DESCRIPTION
* Fix bad bug of missing the array initialization.

* Added additional check to ensure that there are no more conflicts scheduled after the replicator is stopped. This is not expected to happen as LiteCore will not be stopped event before sending the doc ended notification but to be sure.