### PR TITLE
Re-enable some query tests

### DIFF
--- a/Objective-C/Tests/QueryTest+Meta.m
+++ b/Objective-C/Tests/QueryTest+Meta.m
@@ -254,7 +254,7 @@
     Assert([self.db saveDocument: doc error: &error], @"Error when creating a document: %@", error);
     AssertNil(error);
     
-    NSTimeInterval expiryTime = 120;
+    NSTimeInterval expiryTime = 50;
     NSDate* expiryDate = [NSDate dateWithTimeIntervalSinceNow: expiryTime];
     Assert([self.db setDocumentExpirationWithID: docID expiration: expiryDate error: &error]);
     AssertNil(error);

--- a/Objective-C/Tests/QueryTest+Meta.m
+++ b/Objective-C/Tests/QueryTest+Meta.m
@@ -195,8 +195,7 @@
     AssertEqual([[rs allObjects] count], 0u);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-2454
-- (void) _testExpiryLessThanDate {
+- (void) testExpiryLessThanDate {
     NSError* error;
     CBLMutableDocument* doc = [[CBLMutableDocument alloc] init];
     NSString* docID = doc.id;
@@ -247,8 +246,7 @@
     AssertEqual([[rs allObjects] count], 0u);
 }
 
-// TODO: https://issues.couchbase.com/browse/CBL-2454
-- (void) _testExpiryGreaterThanDate {
+- (void) testExpiryGreaterThanDate {
     NSError* error;
     CBLMutableDocument* doc = [[CBLMutableDocument alloc] init];
     NSString* docID = doc.id;


### PR DESCRIPTION
Todo has been fixed a while back and these have not been re-enabled since