### PR TITLE
CBL-5209 : Implement Collection and Scope Database Accessor

### DIFF
--- a/Objective-C/CBLBlob.mm
+++ b/Objective-C/CBLBlob.mm
@@ -391,13 +391,7 @@ static NSString* const kCBLBlobDataProperty = @kC4BlobDataProperty;
         *outHasAttachment = true;
     
     if (encContext->document) {
-        CBLDatabase* database = encContext->document.collection.db;
-        if (!database) {
-            CBLWarn(Database, @"Unable to encode the blob, as the db has been released.");
-            [encContext->document setEncodingError: CBLDatabaseErrorNotOpen];
-            return;
-        }
-        
+        CBLDatabase* database = encContext->document.collection.database;
         [self checkBlobFromSameDatabase: database];
 
         CBL_LOCK(self) {

--- a/Objective-C/CBLCollection.h
+++ b/Objective-C/CBLCollection.h
@@ -21,6 +21,7 @@
 #import "CBLIndexable.h"
 #import "CBLCollectionTypes.h"
 
+@class CBLDatabase;
 @class CBLDocument;
 @class CBLDocumentChange;
 @class CBLDocumentFragment;
@@ -76,8 +77,11 @@ extern NSString* const kCBLDefaultCollectionName;
 /** Collection's fully qualified name in the '<scope-name>.<collection-name>' format. */
 @property (readonly, nonatomic) NSString* fullName;
 
-/** The scope of the collection. */
+/** Collection's scope. */
 @property (readonly, nonatomic) CBLScope* scope;
+
+/** Collection's database. */
+@property (readonly, nonatomic) CBLDatabase* database;
 
 #pragma mark - Document Management
 

--- a/Objective-C/CBLDocumentChange.m
+++ b/Objective-C/CBLDocumentChange.m
@@ -32,13 +32,7 @@
 {
     self = [super init];
     if (self) {
-        CBLDatabase* db = collection.db;
-        if (!db) {
-            if (error)
-                *error = CBLDatabaseErrorNotOpen;
-            return nil;
-        }
-        _database = db;
+        _database = collection.database;;
         _collection = collection;
         _documentID = documentID;
     }

--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -189,7 +189,7 @@ using namespace fleece;
     if ([from.source isKindOfClass: [CBLDatabase class]]) {
         db = ((CBLDatabase*)from.source);
     } else if ([from.source isKindOfClass: [CBLCollection class]]) {
-        db = ((CBLCollection*)from.source).db;
+        db = ((CBLCollection*)from.source).database;
     }
      
     if (!db) {

--- a/Objective-C/CBLScope.h
+++ b/Objective-C/CBLScope.h
@@ -20,6 +20,7 @@
 #import <Foundation/Foundation.h>
 
 @class CBLCollection;
+@class CBLDatabase;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,6 +42,9 @@ extern NSString* const kCBLDefaultScopeName;
 
 /** Scope name. */
 @property (readonly, nonatomic) NSString* name;
+
+/** Scope name. */
+@property (readonly, nonatomic) CBLDatabase* database;
 
 /** Not available */
 - (instancetype) init NS_UNAVAILABLE;

--- a/Objective-C/Internal/CBLCollection+Internal.h
+++ b/Objective-C/Internal/CBLCollection+Internal.h
@@ -38,8 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 /** dispatch queue */
 @property (readonly, nonatomic) dispatch_queue_t dispatchQueue;
 
-/** The database associated with the collection. */
-@property (nonatomic, readonly, weak) CBLDatabase* db;
+/** The database associated with the collection. When the (internal default) collection is cached in the database,
+    the database will be set to the weakdb to avoid circular retain references. */
+@property (nonatomic, readonly, weak) CBLDatabase* weakdb;
+@property (nonatomic, readonly, nullable) CBLDatabase* strongdb;
 
 @property (nonatomic, readonly) BOOL isValid;
 
@@ -47,9 +49,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) C4CollectionSpec c4spec;
 
-/** This constructor will return CBLCollection for the c4collection. */
+/** The cached mode indicates that the collection object will be cached in the database or not.
+    When the collection is cached, the collection will not retain the database inside
+    the collection object to avoid the circular refererences. */
 - (instancetype) initWithDB: (CBLDatabase*)db
-               c4collection: (C4Collection*)c4collection;
+               c4collection: (C4Collection*)c4collection
+                     cached: (BOOL)cached;
 
 - (bool) resolveConflictInDocument: (NSString*)docID
               withConflictResolver: (nullable id<CBLConflictResolver>)conflictResolver
@@ -60,7 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface CBLCollectionChange ()
-
 
 /** check whether the changes are from the current collection or not. */
 @property (readonly, nonatomic) BOOL isExternal;

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable) CBLCollection* collection;
 
-@property (nonatomic, readonly, nullable) C4Database* c4db;
+@property (nonatomic, readonly) C4Database* c4db;
 
 @property (atomic, nullable) CBLC4Document* c4Doc;
 

--- a/Objective-C/Internal/CBLScope+Internal.h
+++ b/Objective-C/Internal/CBLScope+Internal.h
@@ -26,10 +26,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLScope ()
 
-@property (nonatomic, readonly, weak) CBLDatabase* db;
+/** The database associated with the scope. When the (internal default) collection is cached in the database,
+    the database of the collection's scope will be set to the weakdb to avoid circular retain references. */
+@property (nonatomic, readonly, weak) CBLDatabase* weakdb;
+@property (nonatomic, readonly, nullable) CBLDatabase* strongdb;
 
-- (instancetype) initWithDB: (CBLDatabase*)db
-                       name: (NSString*)name;
+/** The cached mode indicates that the scope object will be cached (via the collection object) inside the database or not.
+    When the collection is cached, the collection will not retain the database inside the collection object to avoid
+    the circular refererences. */
+- (instancetype) initWithDB: (CBLDatabase*)db name: (NSString*)name cached: (BOOL)cached;
 
 @end
 

--- a/Objective-C/Tests/CollectionTest.m
+++ b/Objective-C/Tests/CollectionTest.m
@@ -503,6 +503,38 @@
     AssertEqualObjects(col5.fullName, @"scopeA.colA");
 }
 
+#pragma mark - Collection and Scope Database
+
+// Spec: https://docs.google.com/document/d/1kA78r1aRbbaJVepseSjdzqxgCQjjC5NWU449O3l33U8
+
+- (void) testCollectionDatabase {
+    NSError* error;
+        
+    // 3.1 TestGetDatabaseFromNewCollection
+    CBLCollection* col1 = [self.db createCollectionWithName: @"colA" scope: @"scopeA" error: &error];
+    AssertNotNil(col1);
+    AssertEqual(col1.database, self.db);
+    
+    // 3.2 TestGetDatabaseFromExistingCollection
+    CBLCollection* col2 = [self.db collectionWithName: @"colA" scope: @"scopeA" error: &error];
+    AssertNotNil(col2);
+    AssertEqual(col2.database, self.db);
+}
+
+- (void) testScopeDatabase {
+    NSError* error;
+        
+    // 3.3 TestGetDatabaseFromScopeObtainedFromCollection
+    CBLCollection* col1 = [self.db createCollectionWithName: @"colA" scope: @"scopeA" error: &error];
+    AssertNotNil(col1);
+    AssertEqual(col1.scope.database, self.db);
+    
+    // 3.4 TestGetDatabaseFromScopeObtainedFromDatabase
+    CBLScope* scope = [self.db scopeWithName: @"scopeA" error: &error];
+    AssertNotNil(scope);
+    AssertEqual(scope.database, self.db);
+}
+
 #pragma mark - 8.3 Collections and Cross Database Instance
 
 - (void) testCreateThenGetCollectionFromDifferentDatabaseInstance {

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -64,8 +64,11 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     /// Collection's fully qualified name in the '<scope-name>.<collection-name>' format.
     public var fullName: String { impl.fullName }
     
-    /// The scope of the collection.
+    /// Collection's scope.
     public let scope: Scope
+    
+    /// Collection's database
+    public let database: Database
     
     // MARK: Document Management
     
@@ -261,7 +264,7 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
                 Log.log(domain: .database, level: .warning, message: "Unable to notify changes as the collection object was released")
                 return
             }
-            listener(DocumentChange(database: self.db,
+            listener(DocumentChange(database: self.database,
                                     documentID: change.documentID,
                                     collection: self))
         }
@@ -328,12 +331,11 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     
     init(_ impl: CBLCollection, db: Database) {
         self.impl = impl
-        self.db = db
+        self.database = db
         self.scope = Scope(impl.scope, db: db)
     }
     
     var isValid: Bool { impl.isValid }
     
     let impl: CBLCollection
-    let db: Database
 } 

--- a/Swift/DataSource.swift
+++ b/Swift/DataSource.swift
@@ -122,7 +122,7 @@ extension DataSourceProtocol {
         }
         
         if let colSource = o.source() as? Collection {
-            return colSource.db
+            return colSource.database
         } else if let s = o.source() as? Database {
             return s
         }

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -317,7 +317,7 @@ public struct ReplicatorConfiguration {
             fatalError("Attempt to add an invalid collection.")
         }
         
-        let db = collection.db
+        let db = collection.database
         if let db1 = self.db {
             if db1.impl != db.impl {
                 fatalError("Attempt to add collection from different databases.")

--- a/Swift/Scope.swift
+++ b/Swift/Scope.swift
@@ -33,28 +33,30 @@ public final class Scope {
     /// The default scope name constant
     public static let defaultScopeName: String = kCBLDefaultScopeName
     
-    /// Scope name
+    /// Scope's name
     public var name: String {
         return impl.name
     }
+    
+    /// Collection's database
+    public let database: Database
     
     // MARK: Collections
     
     /// Get all collections in the scope.
     public func collections() throws -> [Collection] {
-        return try db.collections(scope: impl.name)
+        return try self.database.collections(scope: impl.name)
     }
     
     /// Get a collection in the scope by name. If the collection doesn't exist, a nil value will be returned.
     public func collection(name: String) throws -> Collection? {
-        return try db.collection(name: name, scope: impl.name)
+        return try self.database.collection(name: name, scope: impl.name)
     }
     
     init(_ scope: CBLScope, db: Database) {
         self.impl = scope
-        self.db = db
+        self.database = db
     }
     
     let impl: CBLScope
-    let db: Database
 }

--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -131,6 +131,34 @@ class CollectionTest: CBLTestCase {
         XCTAssertEqual(col5!.fullName, "scopeA.colA")
     }
     
+    // MARK: Collection and Scope Database
+    
+    // Spec: https://docs.google.com/document/d/1kA78r1aRbbaJVepseSjdzqxgCQjjC5NWU449O3l33U8
+    
+    func testCollectionDatabase() throws {
+        // 3.1 TestGetDatabaseFromNewCollection
+        let col1 = try self.db.createCollection(name: "colA", scope: "scopeA")
+        XCTAssertNotNil(col1)
+        XCTAssertTrue(col1.database === self.db)
+        
+        // 3.2 TestGetDatabaseFromExistingCollection
+        let col2 = try self.db.collection(name: "colA", scope: "scopeA")
+        XCTAssertNotNil(col2)
+        XCTAssertTrue(col2!.database === self.db)
+    }
+    
+    func testScopeDatabase() throws {
+        // 3.3 TestGetDatabaseFromScopeObtainedFromCollection
+        let col1 = try self.db.createCollection(name: "colA", scope: "scopeA")
+        XCTAssertNotNil(col1)
+        XCTAssertTrue(col1.scope.database === self.db)
+        
+        // 3.2 TestGetDatabaseFromExistingCollection
+        let scope = try self.db.scope(name: "scopeA")
+        XCTAssertNotNil(scope)
+        XCTAssertTrue(scope!.database === self.db)
+    }
+    
     // MARK: 8.2 Collections
     
     func testCreateAndGetCollectionsInDefaultScope() throws {


### PR DESCRIPTION
* Implemented Collection and Scope Database Accessor.
* The database object is retained in the collection and scope object unless the collection object is cached in the database object to avoid the circular reference.
* Only the default collection is cached in the database object as it’s commonly used in the old decrecated functions that are redirected to the default collection.
* Refactor the code as now the database object from collection will not be null. This made a lot of code simpler.
* Additonal : fixed collection's hash function.
* Companion PR: https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/190