### PR TITLE
CBL-4428 : Fix crash when starting multiple live queries concurrently

### DIFF
--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -206,15 +206,6 @@ using namespace fleece;
     }];
 }
 
-- (NSString*) description {
-    if (_language == kC4JSONQuery) {
-        NSString* desc = [[NSString alloc] initWithData: _json encoding: NSUTF8StringEncoding];
-        return [NSString stringWithFormat: @"%@[json=%@]", self.class, desc];
-    } else {
-        return [NSString stringWithFormat: @"%@[n1ql=%@]", self.class, _expressions];
-    }
-}
-
 #pragma mark - Parameters
 
 - (CBLQueryParameters*) parameters {
@@ -263,7 +254,7 @@ using namespace fleece;
     }];
     
     if (!e) {
-        CBLWarnError(Query, @"CBLQuery failed: %d/%d", c4Err.domain, c4Err.code);
+        CBLWarnError(Query, @"%@: Failed to execute with error: %d/%d", self, c4Err.domain, c4Err.code);
         convertError(c4Err, outError);
         return nullptr;
     }
@@ -283,20 +274,25 @@ using namespace fleece;
     CBLAssertNotNil(listener);
     
     CBL_LOCK(self) {
-        if (!_changeNotifier)
+        // Only use CBLChangeNotifier for creating and maintaining the tokens. The CBLQueryObserver object will
+        // be created per token and will post change to its token directly instead of using the CBLChangeNotifier.
+        if (!_changeNotifier) {
             _changeNotifier = [CBLChangeNotifier new];
+        }
         
-        CBLChangeListenerToken* token = [_changeNotifier addChangeListenerWithQueue: queue
-                                                                           listener: listener
-                                                                           delegate: self];
+        CBLChangeListenerToken<CBLQueryChange*>* token = [_changeNotifier addChangeListenerWithQueue: queue
+                                                                                            listener: listener
+                                                                                            delegate: self];
         
-        // create c4queryobs & start immediately
-        CBLQueryObserver* obs = [[CBLQueryObserver alloc] initWithQuery: self
-                                                            columnNames: _columnNames
-                                                                  token: token];
+        // The CBLQueryObserver retains both query (self) and the token. Two circular retain references will happen:
+        //  * query (self) -> _changeNotifier -> obs ->  query
+        //  * obs -> token -> obs (_token.context)
+        // With the current design which is not obvious, the two circular retain references will be broken when the
+        // obs is stopped. An alternative more obvious approach would be using a stopped callback or delegate to
+        // break the circles.
+        CBLQueryObserver* obs = [[CBLQueryObserver alloc] initWithQuery: self columnNames: _columnNames token: token];
         [obs start];
         token.context = obs;
-        
         return token;
     }
 }
@@ -306,8 +302,7 @@ using namespace fleece;
     
     CBL_LOCK(self) {
         CBLChangeListenerToken* t = (CBLChangeListenerToken*)token;
-        [(CBLQueryObserver*)t.context stopAndFree];
-        
+        [(CBLQueryObserver*)t.context stop];
         [_changeNotifier removeChangeListenerWithToken: token];
     }
 }

--- a/Objective-C/Internal/CBLQueryObserver.h
+++ b/Objective-C/Internal/CBLQueryObserver.h
@@ -20,8 +20,9 @@
 #import <Foundation/Foundation.h>
 
 @protocol CBLListenerToken;
-@class CBLQuery;
+@class CBLChangeListenerToken;
 @class CBLChangeNotifier;
+@class CBLQuery;
 @class CBLQueryChange;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,14 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Initialize with a Query. */
 - (instancetype) initWithQuery: (CBLQuery*)query
-                   columnNames: (NSDictionary *)columnNames
-                         token: (id<CBLListenerToken>)token;
+                   columnNames: (NSDictionary*)columnNames
+                         token: (CBLChangeListenerToken*)token;
 
 /** Starts the observer */
 - (void) start;
 
 /** Stops and frees the observer */
-- (void) stopAndFree;
+- (void) stop;
 
 @end
 

--- a/Objective-C/Tests/QueryTest+Main.m
+++ b/Objective-C/Tests/QueryTest+Main.m
@@ -1878,6 +1878,35 @@
     [q removeChangeListenerWithToken: token];
 }
 
+// CBSE-15957: Crash when creating multiple live queries concurrently
+- (void) testCreateLiveQueriesConcurrently {
+    // Create 1000 docs:
+    [self loadNumbers: 1000];
+    
+    // Create two live queries then remove them concurrently:
+    XCTestExpectation* remExp = [self expectationWithDescription: @"Listener Removed"];
+    remExp.expectedFulfillmentCount = 2;
+    
+    dispatch_queue_t queue = dispatch_queue_create("query-queue", DISPATCH_QUEUE_CONCURRENT);
+    for (int i = 0; i < 2; i++) {
+        dispatch_async(queue, ^{
+            XCTestExpectation* exp = [self expectationWithDescription: @"Change Received"];
+            NSError* error;
+            NSString* str = [NSString stringWithFormat: @"select * from _ where number1 < %d", (i * 200)];
+            CBLQuery* query = [self.db createQuery: str error: &error];
+            AssertNotNil(query);
+            id token = [query addChangeListener:^(CBLQueryChange* change) {
+                [exp fulfill];
+            }];
+            [self waitForExpectations: @[exp] timeout: 5.0];
+            [token remove];
+            [remExp fulfill];
+        });
+    }
+    
+    [self waitForExpectations: @[remExp] timeout: 5.0];
+}
+
 /**
  When adding a second listener after the first listener is notified, the second listener
  should get the change (current result).
@@ -1921,9 +1950,7 @@
     CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult property: @"number1"]]
                                      from: [CBLQueryDataSource database: self.db]];
     XCTestExpectation* first = [self expectationWithDescription: @"1st change"];
-    __block int count = 0;
     id token = [q addChangeListener: ^(CBLQueryChange* change) {
-        count++;
         NSArray<CBLQueryResult*>* rows = [change.results allObjects];
         AssertEqual(rows.count, 0);
         [first fulfill];

--- a/Swift/ListenerToken.swift
+++ b/Swift/ListenerToken.swift
@@ -26,14 +26,23 @@ public class ListenerToken {
     /// Remove the listener associated with the token.
     public func remove() {
         impl.remove()
+        
+        if let removedBlock = self.removedBlock {
+            removedBlock(self)
+        }
     }
     
     // MARK: Internal
     
-    init(_ impl: CBLListenerToken) {
+    typealias RemovedBlock = (_ token: ListenerToken) -> Void
+    
+    init(_ impl: CBLListenerToken, removeBlock: RemovedBlock? = nil) {
         self.impl = impl
+        self.removedBlock = removeBlock
     }
     
     let impl: CBLListenerToken
+    
+    let removedBlock: RemovedBlock?
     
 }

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1815,6 +1815,31 @@ class QueryTest: CBLTestCase {
         try testLiveQuery(query: q)
     }
     
+    // CBSE-15957 : Crash when creating multiple live queries concurrently
+    func testCreateLiveQueriesConcurrently() throws {
+        // Create 1000 docs:
+        try loadNumbers(1000)
+        
+        // Create two live queries then remove them concurrently:
+        let remExp = self.expectation(description: "Listener Removed")
+        remExp.expectedFulfillmentCount = 2
+        let queue = DispatchQueue(label: "query-queue", attributes: .concurrent)
+        for i in 0..<2 {
+            queue.async {
+                let exp = self.expectation(description: "Change Received")
+                let query = try! self.db.createQuery("select * from _ where number1 < \(i * 200)")
+                let token = query.addChangeListener {
+                    change in exp.fulfill()
+                }
+                self.wait(for: [exp], timeout: 5.0)
+                token.remove()
+                remExp.fulfill()
+            }
+        }
+        
+        wait(for: [remExp], timeout: 5.0)
+    }
+    
     func testLiveQuery(query: Query) throws {
         try loadNumbers(100)
         var count = 0;


### PR DESCRIPTION
* Background: Based on LiteCore’s thread safety doc, c4queryobs_* (except c4queryobs_create which is thread-safe) functions should be called under database-exclusive lock. Without doing that, when creating and starting multiple live queries concurrently, there could be a race condition as each live queries try to get the background database at the same time. The result of the race is that multiple background databases could be created but only the lastone stays and the rest will be freed. Therefore, some live queries will hold on to the bad background database which will cause the crash when the database is used.

* Fixed CBLQueryObserver to follow thread-safety instruction by calling c4queryobs_* functions under the database exclusive lock.

* Fixed Swift Query’s ListenerToken’s remove() function. After calling the objective-c CBLListenerToken’s remove() function, it will need to do some additional cleanup as well.

* Removed CBLQuery and CBLQueryObserver’s description function to use the default description. Currently they are used for some logging but those excessive information is redundant with what LiteCore is currently logging. More importantly, they could cause some crashes as they don’t handle null objects properly.