### PR TITLE
CBL-5291 : Fix Replicator ListenerToken.remove()

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -413,7 +413,7 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
 - (id<CBLListenerToken>) addChangeListenerWithQueue: (dispatch_queue_t)queue
                                            listener: (void (^)(CBLReplicatorChange*))listener
 {
-    return [_changeNotifier addChangeListenerWithQueue: queue listener: listener delegate: nil];
+    return [_changeNotifier addChangeListenerWithQueue: queue listener: listener delegate: self];
 }
 
 - (id<CBLListenerToken>) addDocumentReplicationListener: (void (^)(CBLDocumentReplication*))listener {
@@ -425,7 +425,7 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
 {
     CBL_LOCK(self) {
         [self setProgressLevel: kCBLProgressLevelPerDocument];
-        return [_docReplicationNotifier addChangeListenerWithQueue: queue listener: listener delegate: nil];
+        return [_docReplicationNotifier addChangeListenerWithQueue: queue listener: listener delegate: self];
     }
 }
 

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -971,6 +971,28 @@
     [replicator removeChangeListenerWithToken: token];
 }
 
+- (void) testRemoveDocumentReplicationListener {
+    NSError* error;
+    CBLMutableDocument* doc1 = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc1 setString: @"Tiger" forKey: @"species"];
+    [doc1 setString: @"Star" forKey: @"pattern"];
+    Assert([self.db saveDocument: doc1 error: &error]);
+    
+    XCTestExpectation* exp = [self expectationWithDescription: @"Document Replication - Inverted"];
+    exp.inverted = YES;
+    
+    id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
+    id config = [self configWithTarget: target type: kCBLReplicatorTypePush continuous: NO];
+    [self run: config reset: NO errorCode: 0 errorDomain: nil onReplicatorReady: ^(CBLReplicator* r) {
+        id<CBLListenerToken> token = [r addDocumentReplicationListener: ^(CBLDocumentReplication *docReplication) {
+            [exp fulfill];
+        }];
+        [token remove];
+    }];
+    
+    [self waitForExpectations: @[exp] timeout: 5];
+}
+
 - (void) testSingleShotPushFilter {
     [self testPushFilter: NO];
 }
@@ -1931,20 +1953,45 @@
     AssertNil(replicatedDoc.error);
 }
 
-- (void) testListenerAddRemoveAfterReplicatorStart {
-    NSError* error;
-    CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: @"doc"];
-    [doc setString: @"Tiger" forKey: @"species"];
-    [doc setString: @"Hobbes" forKey: @"pattern"];
-    Assert([self.db saveDocument: doc error: &error]);
+# pragma mark - Change Listener
+
+- (void) testRemoveChangeListnener {
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Replicator Stopped"];
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Replicator Stopped - Inverted"];
+    exp2.inverted = YES;
     
-    XCTestExpectation* exp1 = [self expectationWithDescription: @"#1 replicator finish"];
-    XCTestExpectation* exp3 = [self expectationWithDescription: @"#3 replicator finish"];
     CBLReplicatorConfiguration* config = [self configWithTarget: kConnRefusedTarget
                                                            type: kCBLReplicatorTypePush
                                                      continuous: NO];
-    config.maxAttemptWaitTime = 2;
+    config.maxAttempts = 1;
+    repl = [[CBLReplicator alloc] initWithConfig: config];
+    id token1 = [repl addChangeListener: ^(CBLReplicatorChange * c) {
+        if (c.status.activity == kCBLReplicatorStopped) {
+            [exp1 fulfill];
+        }
+    }];
+    
+    id<CBLListenerToken> token2 = [repl addChangeListener: ^(CBLReplicatorChange * c) {
+        [exp2 fulfill];
+    }];
+    [token2 remove];
+    
+    [repl start];
+    [self waitForExpectations: @[exp1, exp2] timeout: timeout];
+    [token1 remove];
+}
+
+- (void) testAddRemoveChangeListenerAfterReplicatorStart {
+    XCTestExpectation* exp1 = [self expectationWithDescription: @"Replicator Stopped 1"];
+    XCTestExpectation* exp2 = [self expectationWithDescription: @"Replicator Stopped 2 - Inverted"];
+    XCTestExpectation* exp3 = [self expectationWithDescription: @"Replicator Stopped 3"];
+    exp2.inverted = YES;
+    
+    CBLReplicatorConfiguration* config = [self configWithTarget: kConnRefusedTarget
+                                                           type: kCBLReplicatorTypePush
+                                                     continuous: NO];
     config.maxAttempts = 4;
+    config.maxAttemptWaitTime = 2;
     repl = [[CBLReplicator alloc] initWithConfig: config];
     id token1 = [repl addChangeListener: ^(CBLReplicatorChange * c) {
         if (c.status.activity == kCBLReplicatorStopped) {
@@ -1952,10 +1999,10 @@
         }
     }];
     [repl start];
+    
     id token2 = [repl addChangeListener: ^(CBLReplicatorChange * c) {
         if (c.status.activity == kCBLReplicatorStopped) {
-            // remove after the start should work
-            XCTFail("shouldn't have called");
+            [exp2 fulfill];
         }
     }];
     
@@ -1967,8 +2014,7 @@
         }
     }];
     
-    
-    [self waitForExpectations: @[exp1, exp3] timeout: timeout];
+    [self waitForExpectations: @[exp1, exp2, exp3] timeout: timeout];
     [repl removeChangeListenerWithToken: token1];
     [repl removeChangeListenerWithToken: token3];
 }

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -318,6 +318,29 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertEqual(docs.count, 3)
     }
     
+    func testRemoveDocumentReplicationListener() throws {
+        let doc1 = MutableDocument(id: "doc1")
+        doc1.setString("Tiger", forKey: "species")
+        doc1.setString("Hobbes", forKey: "pattern")
+        try defaultCollection!.save(document: doc1)
+        
+        // Push:
+        let target = DatabaseEndpoint(database: otherDB!)
+        var config = self.config(target: target, type: .push)
+        config.addCollection(defaultCollection!)
+        
+        let x = self.expectation(description: "Document Replication - Inverted")
+        x.isInverted = true
+        
+        self.run(config: config, reset: false, expectedError: nil) { (r) in
+            let token = r.addDocumentReplicationListener { doc in
+                x.fulfill()
+            }
+            token.remove()
+        }
+        wait(for: [x], timeout: 5)
+    }
+    
     func testDocumentReplicationEventWithPushConflict() throws {
         let doc1a = MutableDocument(id: "doc1")
         doc1a.setString("Tiger", forKey: "species")
@@ -1089,7 +1112,6 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertThrowsError(try expectException(-1))
     }
     
-    // todo - currently failing on assert
     func testMaxAttemptWaitTimeOfReplicator() {
         timeout = 12 // already it takes 8 secs of retry, hence 12secs timeout. 
         let x = self.expectation(description: "repl finish")
@@ -1118,19 +1140,42 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssert(abs(diff - config.maxAttemptWaitTime) < 1.0)
     }
     
-    // todo: refactor - currently failing
-    func testListenerAddRemoveAfterReplicatorStart() throws {
-        timeout = 15
-        let x1 = self.expectation(description: "#1 repl finish")
-        let x2 = self.expectation(description: "#2 repl finish")
+    // MARK: Change Listener
+    
+    func testRemoveChangeListener() throws {
+        let x1 = self.expectation(description: "Replicator Stopped")
+        let x2 = self.expectation(description: "Replicator Stopped - Inverted")
+        x2.isInverted = true
         
-        let doc1 = MutableDocument(id: "doc1")
-        doc1.setString("pass", forKey: "name")
-        try defaultCollection!.save(document: doc1)
+        var config: ReplicatorConfiguration = self.config(target: kConnRefusedTarget)
+        config.maxAttempts = 1
+        config.addCollection(defaultCollection!)
         
-        var config: ReplicatorConfiguration = self.config(target: kConnRefusedTarget,
-                                                          type: .pushAndPull,
-                                                          continuous: false)
+        repl = Replicator(config: config)
+        let token1 = repl.addChangeListener { (change) in
+            if change.status.activity == .stopped {
+                x1.fulfill()
+            }
+        }
+        
+        let token2 = repl.addChangeListener { (change) in
+            x2.fulfill()
+        }
+        token2.remove()
+        
+        repl.start()
+        wait(for: [x1, x2], timeout: timeout)
+        token1.remove()
+    }
+
+    
+    func testAddRemoveChangeListenerAfterReplicatorStart() throws {
+        let x1 = self.expectation(description: "Replicator Stopped 1")
+        let x2 = self.expectation(description: "Replicator Stopped 2 - Inverted")
+        let x3 = self.expectation(description: "Replicator Stopped 3")
+        x2.isInverted = true
+        
+        var config: ReplicatorConfiguration = self.config(target: kConnRefusedTarget)
         config.maxAttempts = 4
         config.maxAttemptWaitTime = 2
         config.addCollection(defaultCollection!)
@@ -1143,24 +1188,24 @@ class ReplicatorTest_Main: ReplicatorTest {
         }
         
         repl.start()
+        
         let token2 = repl.addChangeListener { (change) in
             if change.status.activity == .stopped {
-                // validate the remove change listener after the replicator-start
-                XCTFail("shouldn't have called")
+                x2.fulfill()
             }
         }
         
         let token3 = repl.addChangeListener { (change) in
             if change.status.activity == .offline {
-                change.replicator.removeChangeListener(withToken: token2)
+                token2.remove()
             } else if change.status.activity == .stopped {
-                x2.fulfill()
+                x3.fulfill()
             }
         }
         
-        wait(for: [x1, x2], timeout: timeout)
-        repl.removeChangeListener(withToken: token1)
-        repl.removeChangeListener(withToken: token3)
+        wait(for: [x1, x2, x3], timeout: timeout)
+        token1.remove()
+        token3.remove()
     }
     
     // MARK: ReplicatorConfig


### PR DESCRIPTION
Fixed the bug that the Replicator’s ListenerToken was created without the CBLRemovableListenerToken delegate being set.