### PR TITLE
Detect Vector Search Extension and Set Extension Path

### DIFF
--- a/Objective-C/Internal/CBLDatabase+Swift.h
+++ b/Objective-C/Internal/CBLDatabase+Swift.h
@@ -21,8 +21,6 @@
 
 @interface CBLDatabase ()
 
-+ (void) checkFileLogging: (BOOL)swift;
-
 - (BOOL) inBatch: (NSError**)error usingBlockWithError: (void (NS_NOESCAPE ^)(NSError**))block NS_REFINED_FOR_SWIFT;
 
 @end

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -59,7 +59,6 @@ public final class Database {
     ///   - config: The database options, or nil for the default options.
     /// - Throws: An error when the database cannot be opened.
     public init(name: String, config: DatabaseConfiguration = DatabaseConfiguration()) throws {
-        CBLDatabase.checkFileLogging(true);
         self.config = DatabaseConfiguration(config: config)
         self.impl = try CBLDatabase(name: name, config: self.config.toImpl())
     }


### PR DESCRIPTION
* Detect vector search extension framework with bundle id “com.couchbase.vectorSearchExtension”.
* Set the extension path to the vector search extension bundle’s path.
* Group checkFileLogging and setExtensionPath call together in CBLInit and remove checkFileLogging call from Swift code.