### PR TITLE
CBL-5374 : Use struct for all index configuration types

### DIFF
--- a/Objective-C/CBLFullTextIndexConfiguration.h
+++ b/Objective-C/CBLFullTextIndexConfiguration.h
@@ -22,6 +22,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** 
+ Configuration for creating full-text indexes.
+ */
 @interface CBLFullTextIndexConfiguration : CBLIndexConfiguration
 
 /**

--- a/Objective-C/CBLValueIndexConfiguration.h
+++ b/Objective-C/CBLValueIndexConfiguration.h
@@ -22,6 +22,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Configuration for creating value indexes.
+ */
 @interface CBLValueIndexConfiguration : CBLIndexConfiguration
 
 /**

--- a/Swift/IndexConfiguration.swift
+++ b/Swift/IndexConfiguration.swift
@@ -19,65 +19,52 @@
 
 import Foundation
 
+/// Configuration for creating indexes.
 public protocol IndexConfiguration { }
 
-public class FullTextIndexConfiguration: IndexConfiguration, IndexConfigConvertable {
-    
+/// Configuration for creating full-text indexes.
+public struct FullTextIndexConfiguration: IndexConfiguration, IndexConfigConvertable {
     /// Gets the expressions to use to create the index.
-    public var expressions: [String] {
-        return self.impl.expressions
-    }
+    public let expressions: [String]
     
     /// Set the true value to ignore accents/diacritical marks.
     /// The default value is ``FullTextIndexConfiguration.defaultIgnoreAccents``.
-    public var ignoreAccents: Bool {
-        return self.impl.ignoreAccents
-    }
+    public let ignoreAccents: Bool
 
     /// The language code which is an ISO-639 language such as "en", "fr", etc.
     /// Setting the language code affects how word breaks and word stems are parsed.
     /// Without setting the value, the current locale's language will be used. Setting
     /// a nil or "" value to disable the language features.
-    public var language: String? {
-        return self.impl.language
-    }
+    public var language: String?
     
     /// Constructor for creating a full-text index by using an array of N1QL expression strings
-    public init(_ expressions: [String],
-                ignoreAccents: Bool? = FullTextIndexConfiguration.defaultIgnoreAccents,
-                language: String? = nil) {
-        self.impl = CBLFullTextIndexConfiguration(expression: expressions,
-                                                  ignoreAccents: ignoreAccents ?? FullTextIndexConfiguration.defaultIgnoreAccents,
-                                                  language: language)
+    public init(_ expressions: [String], ignoreAccents: Bool? = FullTextIndexConfiguration.defaultIgnoreAccents, language: String? = nil) {
+        self.expressions = expressions
+        self.ignoreAccents = ignoreAccents ?? FullTextIndexConfiguration.defaultIgnoreAccents
+        self.language = language
     }
     
     // MARK: Internal
-
-    private let impl: CBLFullTextIndexConfiguration
     
     func toImpl() -> CBLIndexConfiguration {
-        return impl
+        return CBLFullTextIndexConfiguration(expression: expressions, ignoreAccents: ignoreAccents, language: language)
     }
 }
 
-public class ValueIndexConfiguration: IndexConfiguration, IndexConfigConvertable {
-    
+/// Configuration for creating value indexes.
+public struct ValueIndexConfiguration: IndexConfiguration, IndexConfigConvertable {
     /// Gets the expressions to use to create the index.
-    public var expressions: [String] {
-        return self.impl.expressions
-    }
+    public let expressions: [String]
     
     /// Constructor for creating a value index by using an array of N1QL expression strings.
-    public  init(_ expressions: [String]) {
-        self.impl = CBLValueIndexConfiguration(expression: expressions)
+    public init(_ expressions: [String]) {
+        self.expressions = expressions
     }
     
     // MARK: Internal
     
-    private let impl: CBLValueIndexConfiguration
-    
     func toImpl() -> CBLIndexConfiguration {
-        return self.impl
+        return CBLValueIndexConfiguration(expression: expressions)
     }
 }
 
@@ -88,12 +75,10 @@ protocol IndexConfigConvertable {
 }
 
 extension IndexConfiguration {
-    
     func toImpl() -> CBLIndexConfiguration {
         if let index = self as? IndexConfigConvertable {
             return index.toImpl()
         }
-        
-        fatalError("Unsupported index.")
+        fatalError("Unsupported Index")
     }
 }


### PR DESCRIPTION
* Instead of using class, use struct for all index configuration types.
* Update API doc.