### PR TITLE
Check collection equality using isEqual:

### DIFF
--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -525,7 +525,8 @@ NSString* const kCBLDefaultCollectionName = @"_default";
     
     if (!(other && [self.name isEqual: other.name] &&
           [self.scope.name isEqual: other.scope.name] &&
-          [self.database.path isEqual: other.database.path])) {
+          // don't use isEqual: here!  The database must be the exact same instance.
+          self.database == other.database)) {
         return NO;
     }
     

--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -779,7 +779,7 @@ static void colObserverCallback(C4CollectionObserver* obs, void* context) {
 - (BOOL) prepareDocument: (CBLDocument*)document error: (NSError**)error {
     if (!document.collection) {
         document.collection = self;
-    } else if (document.collection != self) {
+    } else if (![document.collection isEqual:self]) {
         return createError(CBLErrorInvalidParameter,
                            kCBLErrorMessageDocumentAnotherCollection, error);
     }
@@ -847,7 +847,7 @@ static void colObserverCallback(C4CollectionObserver* obs, void* context) {
                         resolvedDoc.id, docID);
             }
             
-            if (resolvedDoc && resolvedDoc.collection && resolvedDoc.collection != self) {
+            if (resolvedDoc && resolvedDoc.collection && ![resolvedDoc.collection isEqual:self]) {
                 [NSException raise: NSInternalInconsistencyException
                             format: kCBLErrorMessageResolvedDocWrongDb,
                  resolvedDoc.collection.name, self.name];


### PR DESCRIPTION
Use `CBLCollection isEqual:` for collection equality checks in order to allow separate references to the same collection. This aligns with the behavior in the Java and C SDKs, which allow this.

Also check `CBLCollection` database instances are equal for equality check, [similar to Java SDK](https://github.com/couchbase/couchbase-lite-java-common/blob/b94e70d55289539f966057438ad22d2874310321/common/main/java/com/couchbase/lite/Collection.java#L513-L514).