### PR TITLE
CBL-5074 : Fix backgrounding logic to cover conflict resolution

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -351,6 +351,12 @@
 		27F9619A1ED8D9440060F804 /* CBLReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 27F961971ED8D9440060F804 /* CBLReachability.h */; };
 		27F9619B1ED8D9440060F804 /* CBLReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F961981ED8D9440060F804 /* CBLReachability.m */; };
 		27F9619C1ED8D9440060F804 /* CBLReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F961981ED8D9440060F804 /* CBLReachability.m */; };
+		40BC51EF2AFC39ED0090EDD5 /* CouchbaseLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9343F00F207D611600F19A89 /* CouchbaseLite.framework */; };
+		40BC51F02AFC39ED0090EDD5 /* CouchbaseLite.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9343F00F207D611600F19A89 /* CouchbaseLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		40BC51F82AFC40F10090EDD5 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */; };
+		40BC51F92AFC40F40090EDD5 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */; };
+		40BC51FA2AFC56BB0090EDD5 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */; };
+		40BC51FB2AFC56BC0090EDD5 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */; };
 		69002EB9234E693F00776107 /* CBLErrorMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 69002EA9234E693F00776107 /* CBLErrorMessage.h */; };
 		69002EBA234E693F00776107 /* CBLErrorMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 69002EB8234E693F00776107 /* CBLErrorMessage.m */; };
 		69002EBB234E695400776107 /* CBLErrorMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 69002EA9234E693F00776107 /* CBLErrorMessage.h */; };
@@ -1011,7 +1017,6 @@
 		9343F144207D61EC00F19A89 /* ArrayTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 93DD9BA71EB419BB00E502A2 /* ArrayTest.m */; };
 		9343F145207D61EC00F19A89 /* FragmentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 931C14691EAAF08C0094F9B2 /* FragmentTest.m */; };
 		9343F146207D61EC00F19A89 /* QueryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9332082B1E774419000D9993 /* QueryTest.m */; };
-		9343F148207D61EC00F19A89 /* CouchbaseLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9398D9121E03434200464432 /* CouchbaseLite.framework */; };
 		9343F14A207D61EC00F19A89 /* Support in Resources */ = {isa = PBXBuildFile; fileRef = 93DECF3E200DBE5800F44953 /* Support */; };
 		9343F14B207D61EC00F19A89 /* iTunesMusicLibrary.json in Resources */ = {isa = PBXBuildFile; fileRef = 275FF6081E3FC24D005F90DD /* iTunesMusicLibrary.json */; };
 		9343F157207D62C900F19A89 /* PerfTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 275FF6381E3FFBC0005F90DD /* PerfTest.mm */; };
@@ -1738,6 +1743,13 @@
 			remoteGlobalIDString = 27DF7D631F4236500022F3DF;
 			remoteInfo = SQLite;
 		};
+		40BC51F12AFC39ED0090EDD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9398D9091E03434200464432 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9343EF2A207D611600F19A89;
+			remoteInfo = CBL_EE_ObjC;
+		};
 		9308F40D1E64B24700F53EE4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9398D9311E0347B600464432 /* LiteCore.xcodeproj */;
@@ -1954,6 +1966,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		40BC51F32AFC39ED0090EDD5 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				40BC51F02AFC39ED0090EDD5 /* CouchbaseLite.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		93095B0A246BC325005633B4 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2157,6 +2180,8 @@
 		27EF6A931E298E26004748DF /* PredicateQueryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PredicateQueryTest.m; sourceTree = "<group>"; };
 		27F961971ED8D9440060F804 /* CBLReachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLReachability.h; sourceTree = "<group>"; };
 		27F961981ED8D9440060F804 /* CBLReachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLReachability.m; sourceTree = "<group>"; };
+		40BC51F42AFC40930090EDD5 /* CBLBlockConflictResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLBlockConflictResolver.h; sourceTree = "<group>"; };
+		40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLBlockConflictResolver.m; sourceTree = "<group>"; };
 		69002EA9234E693F00776107 /* CBLErrorMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLErrorMessage.h; sourceTree = "<group>"; };
 		69002EB8234E693F00776107 /* CBLErrorMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLErrorMessage.m; sourceTree = "<group>"; };
 		6932D48B2954640000D28C18 /* CBLQueryFullTextIndexExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CBLQueryFullTextIndexExpression.h; path = ../CBLQueryFullTextIndexExpression.h; sourceTree = "<group>"; };
@@ -2702,7 +2727,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9343F148207D61EC00F19A89 /* CouchbaseLite.framework in Frameworks */,
+				40BC51EF2AFC39ED0090EDD5 /* CouchbaseLite.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2950,6 +2975,8 @@
 				930C7F8120FE4F7400C74A12 /* CBLMockConnectionErrorLogic.h */,
 				930C7F7E20FE4F7400C74A12 /* CBLMockConnectionErrorLogic.m */,
 				930C7F8020FE4F7400C74A12 /* CBLMockConnectionLifecycleLocation.h */,
+				40BC51F42AFC40930090EDD5 /* CBLBlockConflictResolver.h */,
+				40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -4926,11 +4953,13 @@
 				9343F138207D61EC00F19A89 /* Sources */,
 				9343F147207D61EC00F19A89 /* Frameworks */,
 				9343F149207D61EC00F19A89 /* Resources */,
+				40BC51F32AFC39ED0090EDD5 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				9382351A207D80490022328B /* PBXTargetDependency */,
+				40BC51F22AFC39ED0090EDD5 /* PBXTargetDependency */,
 			);
 			name = CBL_EE_ObjC_Tests;
 			productName = CouchbaseLiteTests;
@@ -6244,6 +6273,7 @@
 				1A6F0945246C78FC0097D8B5 /* URLEndpointListenerTest.m in Sources */,
 				9343F141207D61EC00F19A89 /* ConcurrentTest.m in Sources */,
 				1A961800289BF7F80037E78E /* URLEndpointListenerTest+Collection.m in Sources */,
+				40BC51FA2AFC56BB0090EDD5 /* CBLBlockConflictResolver.m in Sources */,
 				9388CBAD21BD9185005CA66D /* DocumentExpirationTest.m in Sources */,
 				93F714212490971600624296 /* ReplicatorTest+MessageEndPoint.m in Sources */,
 				1AC16CF4287D4D9B0041728F /* CollectionTest.m in Sources */,
@@ -6303,6 +6333,7 @@
 				1A93FAFC24F735250015D54D /* ReplicatorTest+PendingDocIds.m in Sources */,
 				9343F17B207D633300F19A89 /* ArrayTest.m in Sources */,
 				1A6F0951246C792A0097D8B5 /* URLEndpointListenerTest.m in Sources */,
+				40BC51FB2AFC56BC0090EDD5 /* CBLBlockConflictResolver.m in Sources */,
 				9388CC4121C1E2BA005CA66D /* LogTest.m in Sources */,
 				9343F17C207D633300F19A89 /* FragmentTest.m in Sources */,
 				1AC16CF5287D4D9C0041728F /* CollectionTest.m in Sources */,
@@ -6402,6 +6433,7 @@
 				931C146B1EAAF0960094F9B2 /* FragmentTest.m in Sources */,
 				273E555E1F79AF79000182F1 /* MiscTest.m in Sources */,
 				938CFA2E1E442B5300291631 /* CBLTestCase.m in Sources */,
+				40BC51F92AFC40F40090EDD5 /* CBLBlockConflictResolver.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6533,6 +6565,7 @@
 				9378C5911E25B3F0001BB196 /* DatabaseTest.m in Sources */,
 				1A4FE76A225ED344009D5F43 /* MiscCppTest.mm in Sources */,
 				1A908401288027EE006B1885 /* ReplicatorTest+Collection.m in Sources */,
+				40BC51F82AFC40F10090EDD5 /* CBLBlockConflictResolver.m in Sources */,
 				1AC83BC821C026D100792098 /* DateTimeQueryFunctionTest.m in Sources */,
 				938B3702200D7D1D004485D8 /* MigrationTest.m in Sources */,
 				1AA3D78422AB07C50098E16B /* CustomLogger.m in Sources */,
@@ -6614,6 +6647,11 @@
 			isa = PBXTargetDependency;
 			target = 275F92731E4D30A4007FD5A2 /* CBL_Swift */;
 			targetProxy = 27BF03371FB62933003D5BB8 /* PBXContainerItemProxy */;
+		};
+		40BC51F22AFC39ED0090EDD5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9343EF2A207D611600F19A89 /* CBL_EE_ObjC */;
+			targetProxy = 40BC51F12AFC39ED0090EDD5 /* PBXContainerItemProxy */;
 		};
 		9308F40E1E64B24700F53EE4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -7004,6 +7042,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
 					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
@@ -7178,6 +7217,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
 					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
@@ -8445,6 +8485,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
 					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",
@@ -8462,6 +8503,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9344A3611E44517B0091F581 /* CBL ObjC Tests - iOS App.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = N2Q372V7W2;
 				HEADER_SEARCH_PATHS = (
 					"${inherited}",
 					"$(SRCROOT)/vendor/couchbase-lite-core/C/include",

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -60,7 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @property (readonly, atomic) BOOL active;
-@property (nonatomic) MYBackgroundMonitor* bgMonitor;
+@property (readonly, atomic) BOOL conflictResolutionSuspended;
+@property (readonly, atomic) NSUInteger pendingConflictCount;
+@property (nonatomic, nullable) MYBackgroundMonitor* bgMonitor;
 @property (readonly, atomic) dispatch_queue_t dispatchQueue;
 
 // For CBLWebSocket to set the current server certificate

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
@@ -23,9 +23,9 @@
 
 @interface CBLReplicator (Backgrounding)
 
-- (void) setupBackgrounding;
+- (void) startBackgroundingMonitor;
 
-- (void) endBackgrounding;
+- (void) endBackgroundingMonitor;
 
 - (void) endCurrentBackgroundTask;
 

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
@@ -27,7 +27,12 @@
 
 @implementation CBLReplicator (Backgrounding)
 
-- (void) setupBackgrounding {
+- (void) startBackgroundingMonitor {
+    if (self.bgMonitor) {
+        CBLLogInfo(Sync, @"%@: Ignored starting backgrounding monitor as already started", self);
+        return;
+    }
+    
     CBLLogInfo(Sync, @"%@: Starting backgrounding monitor...", self);
     NSFileProtectionType prot = self.fileProtection;
     if ([prot isEqual: NSFileProtectionComplete] ||
@@ -59,7 +64,12 @@
 #pragma clang diagnostic pop
 }
 
-- (void) endBackgrounding {
+- (void) endBackgroundingMonitor {
+    if (!self.bgMonitor) {
+        CBLLogInfo(Sync, @"%@: Ignored ending backgrounding monitor as not started", self);
+        return;
+    }
+    
     CBLLogInfo(Sync, @"%@: Ending backgrounding monitor...", self);
     [NSNotificationCenter.defaultCenter removeObserver: self
                                                   name: UIApplicationProtectedDataWillBecomeUnavailable
@@ -68,6 +78,7 @@
                                                   name: UIApplicationProtectedDataDidBecomeAvailable
                                                 object: nil];
     [self.bgMonitor stop];
+    self.bgMonitor = nil;
 }
 
 // Called when the replicator goes idle
@@ -96,8 +107,9 @@
 
 - (void) appForegrounding {
     BOOL ended = [self.bgMonitor endBackgroundTask];
-    if (ended)
+    if (ended) {
         CBLLogInfo(Sync, @"%@: App foregrounding, ending background task.", self);
+    }
     if (_deepBackground) {
         _deepBackground = NO;
         [self updateSuspended];
@@ -112,13 +124,14 @@
 
 // Called when the app is about to lose access to files:
 - (void) fileAccessChanged: (NSNotification*)n {
-    CBLLogInfo(Sync, @"%@: Device locked, database unavailable.", self);
+    CBLLogInfo(Sync, @"%@: Device lock status and file access changed to %@", self, n.name);
     _filesystemUnavailable = [n.name isEqual: UIApplicationProtectedDataWillBecomeUnavailable];
     [self updateSuspended];
 }
 
 - (void) updateSuspended {
     BOOL suspended = (_filesystemUnavailable || _deepBackground);
+    CBLLogInfo(Sync, @"%@: Update suspended status to '%@'", self, suspended ? @"suspended" : @"resumed");
     self.suspended = suspended;
 }
 

--- a/Objective-C/Tests/CBLTestCase.m
+++ b/Objective-C/Tests/CBLTestCase.m
@@ -74,7 +74,7 @@
     }
 
     // Wait a little while for objects to be cleaned up:
-    int leaks;
+    int leaks = 0;
     for (int i = 0; i < 20; i++) {
         leaks = c4_getObjectCount() - _c4ObjectCount;
         if (leaks == 0)

--- a/Objective-C/Tests/ReplicatorTest+Collection.m
+++ b/Objective-C/Tests/ReplicatorTest+Collection.m
@@ -920,19 +920,17 @@
     
     CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
     id token = [r addDocumentReplicationListener: ^(CBLDocumentReplication* docReplication) {
-        // change with single document are the update revisions from colA & colB collections.
-        if (docReplication.documents.count == 1) {
+        if (!docReplication.isPush) {
+            // Pull will resolve the conflicts:
             CBLReplicatedDocument* doc = docReplication.documents[0];
             AssertEqualObjects(doc.id, [doc.collection isEqualToString: @"colA"] ?  @"doc1" : @"doc2");
             AssertEqual(doc.error.code, 0);
-        } else if (docReplication.documents.count == 2) {
-            // change with 2 docs, will be the conflict
+        } else {
+            // Push will have conflict errors:
             for (CBLReplicatedDocument* doc in docReplication.documents) {
                 AssertEqualObjects(doc.id, [doc.collection isEqualToString: @"colA"] ?  @"doc1" : @"doc2");
                 AssertEqual(doc.error.code, CBLErrorHTTPConflict);
             }
-        } else {
-            AssertFalse(true, @"Unexpected document change listener");
         }
     }];
     [self runWithReplicator: r errorCode: 0 errorDomain: nil];

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -18,6 +18,7 @@
 //
 
 #import "ReplicatorTest.h"
+#import "CBLBlockConflictResolver.h"
 #import "CBLDatabase+Internal.h"
 #import "CBLDocumentReplication+Internal.h"
 #import "CBLReplicator+Backgrounding.h"
@@ -374,9 +375,11 @@
     for (int i = 0; i < numRounds; i++) {
         [r appBackgrounding];
         [self waitForExpectations: @[backgroundExps[i]] timeout: 5.0];
+        Assert(r.conflictResolutionSuspended);
         
         [r appForegrounding];
         [self waitForExpectations: @[foregroundExps[i+1]] timeout: 5.0];
+        AssertFalse(r.conflictResolutionSuspended);
     }
     
     [r stop];
@@ -533,6 +536,83 @@
     CBLDocument* doc = [self.otherDB documentWithID: @"doc1"];
     CBLBlob* blob2 = [doc blobForKey: @"blob"];
     AssertEqualObjects(blob2.digest, blob.digest);
+}
+    
+- (void) testSuspendConflictResolution {
+    // Prepare conflicts:
+    NSUInteger numDocs = 1000;
+    for (NSUInteger i = 0; i < numDocs; i++) {
+        NSError* error;
+        NSString* docID = [NSString stringWithFormat: @"doc-%lu", (unsigned long)i];
+        CBLMutableDocument *doc1a = [[CBLMutableDocument alloc] initWithID: docID];
+        [doc1a setString: self.db.name forKey: @"name"];
+        Assert([self.db saveDocument: doc1a error: &error]);
+        
+        CBLMutableDocument *doc1b = [[CBLMutableDocument alloc] initWithID: docID];
+        [doc1b setString: self.otherDB.name forKey: @"name"];
+        Assert([self.otherDB saveDocument: doc1b error: &error]);
+    }
+    
+    NSLock* lock = [[NSLock alloc] init];
+    
+    __block NSUInteger resolvingCount = 0;
+    XCTestExpectation* resolving = [self allowOverfillExpectationWithDescription: @"Resolver was called"];
+    CBLBlockConflictResolver* resolver = [[CBLBlockConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* conflict) {
+        [lock lock];
+        resolvingCount++;
+        [lock unlock];
+        
+        [resolving fulfill];
+        return conflict.remoteDocument;
+    }];
+    
+    id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
+    CBLReplicatorConfiguration* config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: YES];
+    config.conflictResolver = resolver;
+    CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
+    
+    XCTestExpectation* offline = [self expectationWithDescription: @"Offline"];
+    XCTestExpectation* stopped = [self expectationWithDescription: @"Stopped"];
+    
+    id token = [r addChangeListener: ^(CBLReplicatorChange* change) {
+        NSLog(@">>> %d (%llu/%llu) %@", change.status.activity, change.status.progress.completed, change.status.progress.total, change.status.error);
+        if (change.status.activity == kCBLReplicatorOffline) {
+            [offline fulfill];
+        } else if (change.status.activity == kCBLReplicatorStopped) {
+            [stopped fulfill];
+        }
+    }];
+    
+    [r start];
+    
+    // Wait until there is at least one conflict resolver is called.
+    [self waitForExpectations: @[resolving] timeout: 10.0];
+    
+    // Now suspend.
+    [r setSuspended: YES];
+    
+    // Wait until no pending conflcit resolver:
+    NSDate* checkTimeout = [NSDate dateWithTimeIntervalSinceNow: 10.0];
+    while (r.pendingConflictCount != 0 && checkTimeout.timeIntervalSinceNow > 0.0) {
+        if (![[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.5]]) {
+            break;
+        }
+    }
+    
+    AssertEqual(r.pendingConflictCount, 0);
+    Assert(resolvingCount > 0);
+    Assert(resolvingCount < numDocs);
+    
+    // Wait until suspended:
+    [self waitForExpectations: @[offline] timeout: 10.0];
+    
+    // Stop the replicator:
+    [r stop];
+    
+    // Wait until the replicator is stopped:
+    [self waitForExpectations: @[stopped] timeout: 5.0];
+    
+    [r removeChangeListenerWithToken: token];
 }
 
 #endif // TARGET_OS_IPHONE

--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -45,7 +45,7 @@ API_AVAILABLE(macos(10.12), ios(10.0))
 
 - (NSData*) publicKeyHashFromCert: (SecCertificateRef)certRef {
     // Get public key from the certificate:
-    SecKeyRef publicKeyRef;
+    SecKeyRef publicKeyRef = NULL;
     if (@available(iOS 12, macOS 10.14, *)) {
         publicKeyRef = SecCertificateCopyKey(certRef);
     } else {

--- a/Objective-C/Tests/URLEndpointListenerTest.h
+++ b/Objective-C/Tests/URLEndpointListenerTest.h
@@ -68,8 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLURLEndpointListener (Test)
 
-- (NSURL*) localURL;
-- (CBLURLEndpoint*) localEndpoint;
+@property (nonatomic, readonly) NSURL* localURL;
+@property (nonatomic, readonly) CBLURLEndpoint* localEndpoint;
 
 @end
 

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -24,15 +24,6 @@
 #import "CollectionUtils.h"
 #import "URLEndpointListenerTest.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
-@interface CBLURLEndpointListener (Test)
-@property (nonatomic, readonly) NSURL* localURL;
-@property (nonatomic, readonly) CBLURLEndpoint* localEndpoint;
-@end
-
-NS_ASSUME_NONNULL_END
-
 @implementation CBLURLEndpointListener (Test)
 
 // TODO: Remove https://issues.couchbase.com/browse/CBL-3206

--- a/Objective-C/Tests/Util/CBLBlockConflictResolver.h
+++ b/Objective-C/Tests/Util/CBLBlockConflictResolver.h
@@ -1,0 +1,35 @@
+//
+//  CBLBlockConflictResolver.h
+//  CouchbaseLite
+//
+//  Copyright (c) 2023 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "CouchbaseLite.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CBLBlockConflictResolver : NSObject <CBLConflictResolver>
+
+@property(nonatomic, nullable) CBLDocument* winner;
+
+- (instancetype) init NS_UNAVAILABLE;
+
+// set this resolver, which will be used while resolving the conflict
+- (instancetype) initWithResolver: (CBLDocument* (^)(CBLConflict*))resolver;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/Tests/Util/CBLBlockConflictResolver.m
+++ b/Objective-C/Tests/Util/CBLBlockConflictResolver.m
@@ -1,0 +1,41 @@
+//
+//  CBLBlockConflictResolver.m
+//  CouchbaseLite
+//
+//  Copyright (c) 2023 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "CBLBlockConflictResolver.h"
+
+@implementation CBLBlockConflictResolver {
+    CBLDocument* (^_resolver)(CBLConflict*);
+}
+
+@synthesize winner=_winner;
+
+// set this resolver, which will be used while resolving the conflict
+- (instancetype) initWithResolver: (CBLDocument* (^)(CBLConflict*))resolver {
+    self = [super init];
+    if (self) {
+        _resolver = resolver;
+    }
+    return self;
+}
+
+- (CBLDocument *) resolve:(CBLConflict *)conflict {
+    _winner = _resolver(conflict);
+    return _winner;
+}
+
+@end

--- a/Swift/Tests/ReplicatorTest+Collection.swift
+++ b/Swift/Tests/ReplicatorTest+Collection.swift
@@ -640,21 +640,19 @@ class ReplicatorTest_Collection: ReplicatorTest {
         
         let r = Replicator(config: config)
         r.addDocumentReplicationListener { docReplication in
-            if docReplication.documents.count == 1 {
-                // change with single doc, will be update revisions from colA & colB collections.
+            if !docReplication.isPush {
+                // Pull will resolve the conflicts:
                 let doc = docReplication.documents[0]
                 XCTAssertEqual(doc.id, doc.collection == "colA" ? "doc1" : "doc2")
                 XCTAssertNil(doc.error)
                 
-            } else if docReplication.documents.count == 2 {
-                // change with 2 docs, will be the conflict change
+            } else {
+                // Pull will have conflict errors:
                 for doc in docReplication.documents {
                     XCTAssertEqual(doc.id, doc.collection == "colA" ? "doc1" : "doc2")
                     XCTAssertEqual((doc.error as? NSError)?.code, CBLError.httpConflict)
                 }
-            } else {
-                XCTFail("Unexpected document change listener")
-            }
+            } 
         }
         run(replicator: r, expectedError: nil)
         


### PR DESCRIPTION
* Cherry-Picked the fixes from lithium branch (9f194b81f70c626c774a817ac6d7dd2d942e1d02 and 0f33a19784041ca2feab8f17380efe46f7b91734) for CBSE-15077. There were conflicts during the cherry-pick but they are easy to resolve. Below are the commit messages copied from the original fixes.

* The extending background task shouldn’t be ended if there are still pending conflict resolutions.

* When the app was suspended by the background monitor, any current pending conflict resolutions should be canceled. All cancelled conflict resolutions will be notified and put into the queue again when the replicator is resumed or is restarted.

* Fixed bug that the backgrounding monitor may not be restarted after it was ended.

* Renamed some methods and add comments to code.

* Added test to test suspending conflict resolution.

* (Additional Commit) Fix EE Test build error when using XCode 15 and a flaky condition in testCollectionConflictResolver test.