### PR TITLE
CBL-5371 : Remove section header nav link from API doc template

### DIFF
--- a/Scripts/Support/Docs/Theme/templates/nav.mustache
+++ b/Scripts/Support/Docs/Theme/templates/nav.mustache
@@ -2,7 +2,7 @@
   <ul class="nav-groups">
     {{#structure}}
     <li class="nav-group-name">
-      <a href="{{path_to_root}}{{section}}.html">{{section}}</a>
+      {{section}}
       <ul class="nav-group-tasks">
         {{#children}}
         <li class="nav-group-task">


### PR DESCRIPTION
* The Jazzy (doc generation tool) doesn’t generate the HTML pages for all sections’ header in the navigation pane. Also the generated section header pages are not useful as they just list all the links shown in the section.

* Updated the template by removing the href link from the section headers on the nagivation pane.