### PR TITLE
CBL-5075 : Fix backgrounding logic to cover conflict resolution

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -364,6 +364,10 @@
 		40086B1A2B7EDDD500DA6770 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 40086B172B7EDDD400DA6770 /* README.md */; };
 		40086B1B2B7EDDE100DA6770 /* CouchbaseLiteVectorSearch.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40086B152B7EDDD400DA6770 /* CouchbaseLiteVectorSearch.xcframework */; settings = {ATTRIBUTES = (Required, ); }; };
 		40086B3A2B800CC600DA6770 /* CouchbaseLiteVectorSearch.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40086B152B7EDDD400DA6770 /* CouchbaseLiteVectorSearch.xcframework */; };
+		40086B532B803B2B00DA6770 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */; };
+		40086B552B803B2B00DA6770 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */; };
+		40086B572B803B4300DA6770 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */; };
+		40086B582B803B4E00DA6770 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */; };
 		40EF690C2B7757CF00F0CB50 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 40EF690A2B77564000F0CB50 /* PrivacyInfo.xcprivacy */; };
 		40EF690E2B77582E00F0CB50 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 40EF690A2B77564000F0CB50 /* PrivacyInfo.xcprivacy */; };
 		40EF69102B77584600F0CB50 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 40EF690A2B77564000F0CB50 /* PrivacyInfo.xcprivacy */; };
@@ -2233,6 +2237,8 @@
 		40086B152B7EDDD400DA6770 /* CouchbaseLiteVectorSearch.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = CouchbaseLiteVectorSearch.xcframework; sourceTree = "<group>"; };
 		40086B162B7EDDD400DA6770 /* version.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = version.txt; sourceTree = "<group>"; };
 		40086B172B7EDDD400DA6770 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		40086B452B803B2A00DA6770 /* CBLBlockConflictResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLBlockConflictResolver.h; sourceTree = "<group>"; };
+		40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLBlockConflictResolver.m; sourceTree = "<group>"; };
 		40E905462B5B6D9D00EDF483 /* CouchbaseLiteSwift.private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = CouchbaseLiteSwift.private.modulemap; sourceTree = "<group>"; };
 		40E905782B5B9A6700EDF483 /* CouchbaseLiteSwift.private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = CouchbaseLiteSwift.private.modulemap; sourceTree = "<group>"; };
 		40EF68102B71891A00F0CB50 /* remove_private_module.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = remove_private_module.sh; sourceTree = "<group>"; };
@@ -3076,6 +3082,8 @@
 				930C7F8020FE4F7400C74A12 /* CBLMockConnectionLifecycleLocation.h */,
 				AE006DD22B7B9FEF00884E2B /* CBLWordEmbeddingModel.h */,
 				AE006DD32B7B9FEF00884E2B /* CBLWordEmbeddingModel.m */,
+				40086B452B803B2A00DA6770 /* CBLBlockConflictResolver.h */,
+				40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -6526,6 +6534,7 @@
 				9343F13E207D61EC00F19A89 /* DocumentTest.m in Sources */,
 				9343F140207D61EC00F19A89 /* DictionaryTest.m in Sources */,
 				1A6F0945246C78FC0097D8B5 /* URLEndpointListenerTest.m in Sources */,
+				40086B552B803B2B00DA6770 /* CBLBlockConflictResolver.m in Sources */,
 				9343F141207D61EC00F19A89 /* ConcurrentTest.m in Sources */,
 				1A961800289BF7F80037E78E /* URLEndpointListenerTest+Collection.m in Sources */,
 				9388CBAD21BD9185005CA66D /* DocumentExpirationTest.m in Sources */,
@@ -6600,6 +6609,7 @@
 				930C7F9320FE4F7500C74A12 /* CBLMockConnectionErrorLogic.m in Sources */,
 				9343F17F207D633300F19A89 /* CBLTestCase.m in Sources */,
 				1A4160E02283759A0061A567 /* ReplicatorTest+CustomConflict.m in Sources */,
+				40086B582B803B4E00DA6770 /* CBLBlockConflictResolver.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6677,6 +6687,7 @@
 				1A4160DD228375950061A567 /* ReplicatorTest+Main.m in Sources */,
 				1A93FB0824F735260015D54D /* ReplicatorTest+PendingDocIds.m in Sources */,
 				938CFA2D1E442B4200291631 /* DocumentTest.m in Sources */,
+				40086B572B803B4300DA6770 /* CBLBlockConflictResolver.m in Sources */,
 				1A0BFA4727B5274300BA84E5 /* ReplicatorTest+SG.m in Sources */,
 				1A4160DF228375990061A567 /* ReplicatorTest+CustomConflict.m in Sources */,
 				93CD01901E95546200AFB3FA /* DictionaryTest.m in Sources */,
@@ -6838,6 +6849,7 @@
 				1A0BFA4527B5273B00BA84E5 /* ReplicatorTest+SG.m in Sources */,
 				93DD9BA81EB419BB00E502A2 /* ArrayTest.m in Sources */,
 				931C146A1EAAF08C0094F9B2 /* FragmentTest.m in Sources */,
+				40086B532B803B2B00DA6770 /* CBLBlockConflictResolver.m in Sources */,
 				9332082C1E774419000D9993 /* QueryTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -89,8 +89,9 @@ typedef enum {
     CBLChangeNotifier<CBLReplicatorChange*>* _changeNotifier;
     CBLChangeNotifier<CBLDocumentReplication*>* _docReplicationNotifier;
     BOOL _resetCheckpoint;          // Reset the replicator checkpoint
-    unsigned _conflictCount;        // Current number of conflict resolving tasks
-    BOOL _deferReplicatorNotification; // Defer replicator notification until finishing all conflict resolving tasks
+    BOOL _conflictResolutionSuspended;
+    NSMutableArray<dispatch_block_t>* _pendingConflicts;
+    BOOL _deferChangeNotification;  // Defer change notification until finishing all conflict resolving tasks
     SecCertificateRef _serverCertificate;
     NSDictionary* _collectionMap;   // [scopeName.collectionName : CBLCollection]
 }
@@ -120,6 +121,7 @@ typedef enum {
         _progressLevel = kCBLProgressLevelOverall;
         _changeNotifier = [CBLChangeNotifier new];
         _docReplicationNotifier = [CBLChangeNotifier new];
+        _pendingConflicts = [NSMutableArray array];
         _status = [[CBLReplicatorStatus alloc] initWithStatus: {kC4Stopped, {}, {}}];
         
         NSString* qName = self.description;
@@ -171,13 +173,14 @@ typedef enum {
             // Start the C4Replicator:
             self.serverCertificate = NULL;
             _state = kCBLStateStarting;
+            [self setConflictResolutionSuspended: NO];
             c4repl_start(_repl, reset);
             status = c4repl_getStatus(_repl);
             [_config.database addActiveStoppable: self];
             
 #if TARGET_OS_IPHONE
             if (!_config.allowReplicatingInBackground)
-                [self setupBackgrounding];
+                [self startBackgroundingMonitor];
 #endif
         } else {
             // Failed to create C4Replicator:
@@ -370,6 +373,10 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
     CBLReplicator* repl = self;
     [_config.database removeActiveStoppable: repl];
     
+#if TARGET_OS_IPHONE
+    [self endBackgroundingMonitor];
+#endif
+
     CBLLogInfo(Sync, @"%@: Replicator is now stopped.", self);
 }
 
@@ -377,6 +384,15 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
     CBL_LOCK(self) {
         block();
     }
+}
+
+// Always being called inside the lock
+- (void) idled {
+    Assert(_rawStatus.level == kC4Idle);
+#if TARGET_OS_IPHONE
+    [self endCurrentBackgroundTask];
+#endif
+    CBLLogInfo(Sync, @"%@: Replicator is now idled.", self);
 }
 
 #pragma mark - Server Certificate
@@ -605,59 +621,63 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
         // Record raw status:
         _rawStatus = c4Status;
         
-        // Running; idle or busy:
-        if (c4Status.level > kC4Connecting) {
-            if (_state == kCBLStateStarting) {
-                _state = kCBLStateRunning;
-            }
-            [self stopReachability];
-        }
+        // Reset to notify for now:
+        _deferChangeNotification = NO;
         
-        // Offline / suspending:
         if (c4Status.level == kC4Offline) {
+            // When the replicator is offline, it could be either that :
+            // 1. The replicator is offline as the remote server is not reachable.
+            // 2. (iOS Only) The replicator is suspended as the app was backgrounding
+            //    or lost the access to the database file due to the file protection
+            //    level set when the screen was lock.
+            // When the app went offline, start the reachability monitor to observe the
+            // network changes and retry when the remote server is reachable again.
+            // No reachability is started when the replicator is suspended.
             if (_state == kCBLStateSuspending) {
                 _state = kCBLStateSuspended;
             } else if (_state > kCBLStateStopping) {
                 _state = kCBLStateOffline;
                 [self startReachability];
             }
-        }
-        
-        // Stopped:
-        if (c4Status.level == kC4Stopped) {
+        } else {
+            // Stop the reachability monitor as the replicator is not offline anymore.
             [self stopReachability];
-        #if TARGET_OS_IPHONE
-            [self endBackgrounding];
-        #endif
             
-            if (_conflictCount == 0)
-                [self stopped];
+            if (c4Status.level == kC4Stopped) {
+                // When the replicator is stopped, check if there are any pending conflicts
+                // to be resolved. If none, the replicator will go into the stopped state,
+                // and the change listeners will be notified about the stopped status.
+                // Otherwise, the stopped status will be defered to notify until all pending
+                // conflicts are resolved.
+                if ([self hasPendingConflicts]) {
+                    _state = kCBLStateStopping;
+                    _deferChangeNotification = YES;
+                } else {
+                    [self stopped];
+                }
+            } else if (c4Status.level == kC4Idle) {
+                // When the replicator is idle, check if there are any pending conflicts
+                // to be resolved. If none, the change listeners will be notified about
+                // the idle status. Otherwise, the idle status will be defered to notify
+                // until all pending conflicts are resolved.
+                _state = kCBLStateRunning;
+                if ([self hasPendingConflicts]) {
+                    _deferChangeNotification = YES;
+                } else {
+                    [self idled];
+                }
+            } else if (c4Status.level == kC4Busy) {
+                _state = kCBLStateRunning;
+            }
         }
-
-        // replicator status callback
-        /// stopped and idle state, we will defer status callback till conflicts finish resolving
-        if (_conflictCount > 0 && (c4Status.level == kC4Stopped || c4Status.level == kC4Idle)) {
-            CBLLogInfo(Sync, @"%@: Status = %d, but waiting for conflict resolution (pending = %d) "
-            "to finish before notifying.", self, c4Status.level, _conflictCount);
-            
-            _deferReplicatorNotification = YES;
-            if (c4Status.level == kC4Stopped)
-                _state = kCBLStateStopping;
-        } else
-            _deferReplicatorNotification = NO;
         
-        if (!_deferReplicatorNotification)
-            [self updateAndPostStatus];
-
-    #if TARGET_OS_IPHONE
-        //  End the current background task when the replicator is idle:
-        if (c4Status.level == kC4Idle)
-            [self endCurrentBackgroundTask];
-    #endif
+        if (!_deferChangeNotification) {
+            [self postChangeNotification];
+        }
     }
 }
 
-- (void) updateAndPostStatus {
+- (void) postChangeNotification {
     NSError* error = nil;
     if (_rawStatus.error.code)
         convertError(_rawStatus.error, &error);
@@ -674,7 +694,7 @@ static void statusChanged(C4Replicator *repl, C4ReplicatorStatus status, void *c
                                                                           status: self.status]];
 }
 
-#pragma mark - DOCUMENT-LEVEL 0:
+#pragma mark - DOCUMENT REPLICATION EVENT HANDLER:
 
 static void onDocsEnded(C4Replicator* repl,
                         bool pushing,
@@ -698,12 +718,13 @@ static void onDocsEnded(C4Replicator* repl,
     });
 }
 
+// Called inside the lock
 - (void) onDocsEnded: (NSArray<CBLReplicatedDocument*>*)docs pushing: (BOOL)pushing {
     NSMutableArray* posts = [NSMutableArray array];
     for (CBLReplicatedDocument *doc in docs) {
         C4Error c4err = doc.c4Error;
         if (!pushing && c4err.domain == LiteCoreDomain && c4err.code == kC4ErrorConflict) {
-            [self resolveConflict: doc];
+            [self scheduleConflictResolutionForDocument: doc];
         } else {
             [posts addObject: doc];
             [self logErrorOnDocument: doc pushing: pushing];
@@ -713,25 +734,50 @@ static void onDocsEnded(C4Replicator* repl,
         [self postDocumentReplications: posts pushing: pushing];
 }
 
-- (void) resolveConflict: (CBLReplicatedDocument*)doc {
-    _conflictCount++;
-    dispatch_async(_conflictQueue, ^{
-        [self _resolveConflict: doc];
-        CBL_LOCK(self) {
-            if (--self->_conflictCount == 0 && self->_deferReplicatorNotification) {
-                if (self->_rawStatus.level == kC4Stopped) {
-                    Assert(self->_state == kCBLStateStopping);
-                    [self stopped];
-                }
-                
-                self->_deferReplicatorNotification = NO;
-                [self updateAndPostStatus];
-            }
-        }
-    });
+- (void) postDocumentReplications: (NSArray<CBLReplicatedDocument*>*)docs pushing: (BOOL)pushing {
+    id replication = [[CBLDocumentReplication alloc] initWithReplicator: self
+                                                                 isPush: pushing
+                                                              documents: docs];
+    [_docReplicationNotifier postChange: replication];
 }
 
+- (void) logErrorOnDocument: (CBLReplicatedDocument*)doc pushing: (BOOL)pushing {
+    C4Error c4err = doc.c4Error;
+    if (doc.c4Error.code)
+        CBLLogInfo(Sync, @"%@: %serror %s '%@': %d/%d", self, (doc.isTransientError ? "transient " : ""),
+                   (pushing ? "pushing" : "pulling"), doc.id, c4err.domain, c4err.code);
+}
+
+#pragma mark - CONFLICT RESOLUTION:
+
+// Called inside the lock
+- (void) scheduleConflictResolutionForDocument: (CBLReplicatedDocument*)doc {
+    if (_conflictResolutionSuspended || _state == kCBLStateStopped) {
+        return;
+    }
+    
+    dispatch_block_t resolution = dispatch_block_create(DISPATCH_BLOCK_ASSIGN_CURRENT, ^{
+        [self _resolveConflict: doc];
+    });
+    
+    dispatch_block_notify(resolution, _dispatchQueue, ^{
+        // Called when the resolution was either successful or cancelled:
+        [self didFinishConflictResolution: resolution];
+    });
+    
+    [_pendingConflicts addObject: resolution];
+    
+    dispatch_async(_conflictQueue, resolution);
+}
+
+// Called inside conflict resolution queue:
 - (void) _resolveConflict: (CBLReplicatedDocument*)doc {
+    CBL_LOCK(self) {
+        if (_conflictResolutionSuspended) {
+            return;
+        }
+    }
+    
     CBLLogInfo(Sync, @"%@: Resolve conflicting version of '%@'", self, doc.id);
     
     CBLCollection* c = [_collectionMap objectForKey: $sprintf(@"%@.%@", doc.scope, doc.collection)];
@@ -752,18 +798,53 @@ static void onDocsEnded(C4Replicator* repl,
     [self postDocumentReplications: @[doc] pushing: NO];
 }
 
-- (void) postDocumentReplications: (NSArray<CBLReplicatedDocument*>*)docs pushing: (BOOL)pushing {
-    id replication = [[CBLDocumentReplication alloc] initWithReplicator: self
-                                                                 isPush: pushing
-                                                              documents: docs];
-    [_docReplicationNotifier postChange: replication];
+- (void) didFinishConflictResolution: (dispatch_block_t)resolution {
+    CBL_LOCK(self) {
+        [_pendingConflicts removeObject: resolution];
+        
+        if (_pendingConflicts.count == 0) {
+            if (_rawStatus.level == kC4Stopped && _state == kCBLStateStopping) {
+                [self stopped];
+            } else if (_rawStatus.level == kC4Idle) {
+                [self idled];
+            }
+            if (_deferChangeNotification) {
+                _deferChangeNotification = NO;
+                [self postChangeNotification];
+            }
+        }
+    }
 }
 
-- (void) logErrorOnDocument: (CBLReplicatedDocument*)doc pushing: (BOOL)pushing {
-    C4Error c4err = doc.c4Error;
-    if (doc.c4Error.code)
-        CBLLogInfo(Sync, @"%@: %serror %s '%@': %d/%d", self, (doc.isTransientError ? "transient " : ""),
-                   (pushing ? "pushing" : "pulling"), doc.id, c4err.domain, c4err.code);
+// Called inside the lock
+- (BOOL) hasPendingConflicts {
+    return _pendingConflicts.count > 0;
+}
+
+// For test to get number of pending conflicts
+- (NSUInteger) pendingConflictCount {
+    CBL_LOCK(self) {
+        return _pendingConflicts.count > 0;
+    }
+}
+
+// Called inside the lock
+- (void) setConflictResolutionSuspended: (BOOL)suspended {
+    _conflictResolutionSuspended = suspended;
+    if (suspended) {
+        // Note: All cancelled resolutions will be notified and queued again when
+        // the replicator is resumed or restarted.
+        for (dispatch_block_t resolution in _pendingConflicts) {
+            dispatch_block_cancel(resolution);
+        }
+    }
+}
+
+// For test to check the suspended status
+- (BOOL) conflictResolutionSuspended {
+    CBL_LOCK(self) {
+        return _conflictResolutionSuspended;
+    }
 }
 
 #pragma mark - PUSH/PULL FILTER:
@@ -817,13 +898,34 @@ static bool pullFilter(C4CollectionSpec collectionSpec,
 
 - (BOOL) active {
     CBL_LOCK(self) {
-        return (_rawStatus.level == kC4Connecting || _rawStatus.level == kC4Busy);
+        return (_rawStatus.level == kC4Connecting || _rawStatus.level == kC4Busy || [self hasPendingConflicts]);
     }
 }
 
 - (void) setSuspended: (BOOL)suspended {
+    // (iOS Only) The replicator could be suspended by the backgrounding
+    // monitor either when :
+    // 1. The app was in the background && the replicator was caught up
+    //    (IDLE) or the background task for the replicator was expired.
+    // 2. The app lost access to the database files under the lock screen
+    //    as the file protection level as set to "Complete" or
+    //    "Complete Unless Open".
+    //
+    // When the replicator is suspended, the internal replicator at
+    // the LiteCore level will be stopped and the replicator status
+    // will be OFFLINE (instead of stopped). Any pending conflict
+    // resolution will be cancelled as best effort as any being-excuted
+    // conflict resolution cannot be cancelled.
+    //
+    // All cancelled conflict resolutions will be notified, and put into the queue 
+    // again when the replicator is resumed or is restarted.
     CBL_LOCK(self) {
+        if (suspended && _state > kCBLStateSuspending) {
+            // Currently not in any suspend* or stop* state:
+            _state = kCBLStateSuspending;
+        }
         c4repl_setSuspended(_repl, suspended);
+        [self setConflictResolutionSuspended: suspended];
     }
 }
 

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -60,7 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @property (readonly, atomic) BOOL active;
-@property (nonatomic) MYBackgroundMonitor* bgMonitor;
+@property (readonly, atomic) BOOL conflictResolutionSuspended;
+@property (readonly, atomic) NSUInteger pendingConflictCount;
+@property (nonatomic, nullable) MYBackgroundMonitor* bgMonitor;
 @property (readonly, atomic) dispatch_queue_t dispatchQueue;
 
 // For CBLWebSocket to set the current server certificate

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.h
@@ -23,9 +23,9 @@
 
 @interface CBLReplicator (Backgrounding)
 
-- (void) setupBackgrounding;
+- (void) startBackgroundingMonitor;
 
-- (void) endBackgrounding;
+- (void) endBackgroundingMonitor;
 
 - (void) endCurrentBackgroundTask;
 

--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
@@ -27,7 +27,12 @@
 
 @implementation CBLReplicator (Backgrounding)
 
-- (void) setupBackgrounding {
+- (void) startBackgroundingMonitor {
+    if (self.bgMonitor) {
+        CBLLogInfo(Sync, @"%@: Ignored starting backgrounding monitor as already started", self);
+        return;
+    }
+    
     CBLLogInfo(Sync, @"%@: Starting backgrounding monitor...", self);
     NSFileProtectionType prot = self.fileProtection;
     if ([prot isEqual: NSFileProtectionComplete] ||
@@ -59,7 +64,12 @@
 #pragma clang diagnostic pop
 }
 
-- (void) endBackgrounding {
+- (void) endBackgroundingMonitor {
+    if (!self.bgMonitor) {
+        CBLLogInfo(Sync, @"%@: Ignored ending backgrounding monitor as not started", self);
+        return;
+    }
+    
     CBLLogInfo(Sync, @"%@: Ending backgrounding monitor...", self);
     [NSNotificationCenter.defaultCenter removeObserver: self
                                                   name: UIApplicationProtectedDataWillBecomeUnavailable
@@ -68,6 +78,7 @@
                                                   name: UIApplicationProtectedDataDidBecomeAvailable
                                                 object: nil];
     [self.bgMonitor stop];
+    self.bgMonitor = nil;
 }
 
 // Called when the replicator goes idle
@@ -96,8 +107,9 @@
 
 - (void) appForegrounding {
     BOOL ended = [self.bgMonitor endBackgroundTask];
-    if (ended)
+    if (ended) {
         CBLLogInfo(Sync, @"%@: App foregrounding, ending background task.", self);
+    }
     if (_deepBackground) {
         _deepBackground = NO;
         [self updateSuspended];
@@ -112,13 +124,14 @@
 
 // Called when the app is about to lose access to files:
 - (void) fileAccessChanged: (NSNotification*)n {
-    CBLLogInfo(Sync, @"%@: Device locked, database unavailable.", self);
+    CBLLogInfo(Sync, @"%@: Device lock status and file access changed to %@", self, n.name);
     _filesystemUnavailable = [n.name isEqual: UIApplicationProtectedDataWillBecomeUnavailable];
     [self updateSuspended];
 }
 
 - (void) updateSuspended {
     BOOL suspended = (_filesystemUnavailable || _deepBackground);
+    CBLLogInfo(Sync, @"%@: Update suspended status to '%@'", self, suspended ? @"suspended" : @"resumed");
     self.suspended = suspended;
 }
 

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -18,6 +18,7 @@
 //
 
 #import "ReplicatorTest.h"
+#import "CBLBlockConflictResolver.h"
 #import "CBLDatabase+Internal.h"
 #import "CBLDocumentReplication+Internal.h"
 #import "CBLReplicator+Backgrounding.h"
@@ -375,9 +376,11 @@
     for (int i = 0; i < numRounds; i++) {
         [r appBackgrounding];
         [self waitForExpectations: @[backgroundExps[i]] timeout: 5.0];
+        Assert(r.conflictResolutionSuspended);
         
         [r appForegrounding];
         [self waitForExpectations: @[foregroundExps[i+1]] timeout: 5.0];
+        AssertFalse(r.conflictResolutionSuspended);
     }
     
     [r stop];
@@ -534,6 +537,83 @@
     CBLDocument* doc = [self.otherDB documentWithID: @"doc1"];
     CBLBlob* blob2 = [doc blobForKey: @"blob"];
     AssertEqualObjects(blob2.digest, blob.digest);
+}
+    
+- (void) testSuspendConflictResolution {
+    // Prepare conflicts:
+    NSUInteger numDocs = 1000;
+    for (NSUInteger i = 0; i < numDocs; i++) {
+        NSError* error;
+        NSString* docID = [NSString stringWithFormat: @"doc-%lu", (unsigned long)i];
+        CBLMutableDocument *doc1a = [[CBLMutableDocument alloc] initWithID: docID];
+        [doc1a setString: self.db.name forKey: @"name"];
+        Assert([self.db saveDocument: doc1a error: &error]);
+        
+        CBLMutableDocument *doc1b = [[CBLMutableDocument alloc] initWithID: docID];
+        [doc1b setString: self.otherDB.name forKey: @"name"];
+        Assert([self.otherDB saveDocument: doc1b error: &error]);
+    }
+    
+    NSLock* lock = [[NSLock alloc] init];
+    
+    __block NSUInteger resolvingCount = 0;
+    XCTestExpectation* resolving = [self allowOverfillExpectationWithDescription: @"Resolver was called"];
+    CBLBlockConflictResolver* resolver = [[CBLBlockConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* conflict) {
+        [lock lock];
+        resolvingCount++;
+        [lock unlock];
+        
+        [resolving fulfill];
+        return conflict.remoteDocument;
+    }];
+    
+    id target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
+    CBLReplicatorConfiguration* config = [self configWithTarget: target type: kCBLReplicatorTypePull continuous: YES];
+    config.conflictResolver = resolver;
+    CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
+    
+    XCTestExpectation* offline = [self expectationWithDescription: @"Offline"];
+    XCTestExpectation* stopped = [self expectationWithDescription: @"Stopped"];
+    
+    id token = [r addChangeListener: ^(CBLReplicatorChange* change) {
+        NSLog(@">>> %d (%llu/%llu) %@", change.status.activity, change.status.progress.completed, change.status.progress.total, change.status.error);
+        if (change.status.activity == kCBLReplicatorOffline) {
+            [offline fulfill];
+        } else if (change.status.activity == kCBLReplicatorStopped) {
+            [stopped fulfill];
+        }
+    }];
+    
+    [r start];
+    
+    // Wait until there is at least one conflict resolver is called.
+    [self waitForExpectations: @[resolving] timeout: 10.0];
+    
+    // Now suspend.
+    [r setSuspended: YES];
+    
+    // Wait until no pending conflcit resolver:
+    NSDate* checkTimeout = [NSDate dateWithTimeIntervalSinceNow: 10.0];
+    while (r.pendingConflictCount != 0 && checkTimeout.timeIntervalSinceNow > 0.0) {
+        if (![[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.5]]) {
+            break;
+        }
+    }
+    
+    AssertEqual(r.pendingConflictCount, 0);
+    Assert(resolvingCount > 0);
+    Assert(resolvingCount < numDocs);
+    
+    // Wait until suspended:
+    [self waitForExpectations: @[offline] timeout: 10.0];
+    
+    // Stop the replicator:
+    [r stop];
+    
+    // Wait until the replicator is stopped:
+    [self waitForExpectations: @[stopped] timeout: 5.0];
+    
+    [r removeChangeListenerWithToken: token];
 }
 
 #endif // TARGET_OS_IPHONE

--- a/Objective-C/Tests/URLEndpointListenerTest.h
+++ b/Objective-C/Tests/URLEndpointListenerTest.h
@@ -66,8 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLURLEndpointListener (Test)
 
-- (NSURL*) localURL;
-- (CBLURLEndpoint*) localEndpoint;
+@property (nonatomic, readonly) NSURL* localURL;
+@property (nonatomic, readonly) CBLURLEndpoint* localEndpoint;
 
 @end
 

--- a/Objective-C/Tests/URLEndpointListenerTest.m
+++ b/Objective-C/Tests/URLEndpointListenerTest.m
@@ -24,15 +24,6 @@
 #import "CollectionUtils.h"
 #import "URLEndpointListenerTest.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
-@interface CBLURLEndpointListener (Test)
-@property (nonatomic, readonly) NSURL* localURL;
-@property (nonatomic, readonly) CBLURLEndpoint* localEndpoint;
-@end
-
-NS_ASSUME_NONNULL_END
-
 @implementation CBLURLEndpointListener (Test)
 
 // TODO: Remove https://issues.couchbase.com/browse/CBL-3206

--- a/Objective-C/Tests/Util/CBLBlockConflictResolver.h
+++ b/Objective-C/Tests/Util/CBLBlockConflictResolver.h
@@ -1,0 +1,35 @@
+//
+//  CBLBlockConflictResolver.h
+//  CouchbaseLite
+//
+//  Copyright (c) 2023 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "CouchbaseLite.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CBLBlockConflictResolver : NSObject <CBLConflictResolver>
+
+@property(nonatomic, nullable) CBLDocument* winner;
+
+- (instancetype) init NS_UNAVAILABLE;
+
+// set this resolver, which will be used while resolving the conflict
+- (instancetype) initWithResolver: (CBLDocument* (^)(CBLConflict*))resolver;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/Tests/Util/CBLBlockConflictResolver.m
+++ b/Objective-C/Tests/Util/CBLBlockConflictResolver.m
@@ -1,0 +1,41 @@
+//
+//  CBLBlockConflictResolver.m
+//  CouchbaseLite
+//
+//  Copyright (c) 2023 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "CBLBlockConflictResolver.h"
+
+@implementation CBLBlockConflictResolver {
+    CBLDocument* (^_resolver)(CBLConflict*);
+}
+
+@synthesize winner=_winner;
+
+// set this resolver, which will be used while resolving the conflict
+- (instancetype) initWithResolver: (CBLDocument* (^)(CBLConflict*))resolver {
+    self = [super init];
+    if (self) {
+        _resolver = resolver;
+    }
+    return self;
+}
+
+- (CBLDocument *) resolve:(CBLConflict *)conflict {
+    _winner = _resolver(conflict);
+    return _winner;
+}
+
+@end


### PR DESCRIPTION
* Cherry-Picked the fixes from lithium branch (9f194b81f70c626c774a817ac6d7dd2d942e1d02 and 0f33a19784041ca2feab8f17380efe46f7b91734) for CBSE-15077. There were conflicts during the cherry-pick but they are easy to resolve. Below are the commit messages copied from the original fixes.

* The extending background task shouldn’t be ended if there are still pending conflict resolutions.

* When the app was suspended by the background monitor, any current pending conflict resolutions should be canceled. All cancelled conflict resolutions will be notified and put into the queue again when the replicator is resumed or is restarted.

* Fixed bug that the backgrounding monitor may not be restarted after it was ended.

* Renamed some methods and add comments to code.

* Added test to test suspending conflict resolution.

* Fix XCode 15 test build error.