### PR TITLE
CBL-5399 : Fix close database could hang waiting for active components to close

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1143,9 +1143,11 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
 - (void) removeActiveStoppable: (id<CBLStoppable>)stoppable {
     CBL_LOCK(_mutex) {
         [_activeStoppables removeObject: stoppable];
-        
-        if (_activeStoppables.count == 0)
+        if (_activeStoppables.count == 0) {
+            [_closeCondition lock];
             [_closeCondition broadcast];
+            [_closeCondition unlock];
+        }
     }
 }
 


### PR DESCRIPTION
* Cherry-Pick the fix (7daff8e9a5bff94fd6938149451d891e08b7fab1) from lithum branch.

* When signal the database thread to wake up and check for the close, the close condition needs to be locked first to avoid race condition.