### PR TITLE
CBL-5415 : Remove non-symbols from CouchbaseLite.exp

### DIFF
--- a/Objective-C/CouchbaseLite.exp
+++ b/Objective-C/CouchbaseLite.exp
@@ -27,7 +27,6 @@
 .objc_class_name_CBLConsoleLogger
 .objc_class_name_CBLDatabase
 .objc_class_name_CBLDatabaseChange
-.objc_class_name_CBLDatabaseChangeObservable
 .objc_class_name_CBLDatabaseConfiguration
 .objc_class_name_CBLDictionary
 .objc_class_name_CBLDocument
@@ -39,7 +38,6 @@
 .objc_class_name_CBLFullTextIndexItem
 .objc_class_name_CBLFragment
 .objc_class_name_CBLIndex
-.objc_class_name_CBLIndexable
 .objc_class_name_CBLIndexBuilder
 .objc_class_name_CBLLog
 .objc_class_name_CBLLogFileConfiguration


### PR DESCRIPTION
* Removed CBLDatabaseChangeObservable and CBLIndexable symbols from CouchbaseLite.exp as those are protocol.

* This issue was uncovered when building with XCode 15.2 on Jenkins with the error as `framework CoreAudioTypes not found`.