### PR TITLE
CBL-5434: Vector Index API Tests 21-26 [Obj-C]

### DIFF
--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -82,7 +82,7 @@
     Assert([names containsObject: @"words_index_1"]);
     
     CBLVectorIndexConfiguration* config2 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                        dimensions: 2048
+                                                                                        dimensions: 300
                                                                                          centroids: 20];
     AssertNotNil(config2);
     Assert([collection createIndexWithName: @"words_index_2" config: config2 error: &error]);
@@ -92,6 +92,12 @@
     [self expectException: NSInvalidArgumentException in:^{
         (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
                                                             dimensions: 0 
+                                                             centroids: 20];
+    }];
+    
+    [self expectException: NSInvalidArgumentException in:^{
+        (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
+                                                            dimensions: 301
                                                              centroids: 20];
     }];
     
@@ -112,6 +118,7 @@
                                                                                          centroids: 1];
     AssertNotNil(config1);
     Assert([collection createIndexWithName: @"words_index_1" config: config1 error: &error]);
+    
     
     CBLVectorIndexConfiguration* config2 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
                                                                                         dimensions: 300
@@ -326,7 +333,7 @@
 }
 
 // CBL-5444 + CBL-5453
-- (void) _testCreateVectorIndexUsingPredictionModelWithInvalidVectors {
+- (void) testCreateVectorIndexUsingPredictionModelWithInvalidVectors {
     NSError* error;
     CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
     

--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -360,7 +360,7 @@
     Assert([collection createIndexWithName: @"words_pred_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_pred_index"]);
+    Assert([names containsObject: @"words_pred_index"]);
 
     // Query:
     NSString* sql = @"select meta().id, word from _default.words where vector_match(words_pred_index, $vector, 350)";
@@ -400,7 +400,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Query:
     NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
@@ -675,7 +675,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Query:
     NSString* sql = @"select meta().id, word, vector_distance(words_index) from _default.words where vector_match(words_index, $vector, 20)";
@@ -726,7 +726,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Query:
     NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
@@ -769,7 +769,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Query:
     NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector)";
@@ -800,7 +800,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Check valid query with 1 and 10000 set limit
     int goodValues[2] = {1, 10000};
@@ -832,7 +832,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Query with a single AND:
     NSString* sql = @"select meta().id, word, catid from _default.words where vector_match(words_index, $vector, 300) AND catid = 'cat1'";
@@ -866,7 +866,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Query with mutiple ANDs:
     NSString* sql = @"select meta().id, word, catid from _default.words where (vector_match(words_index, $vector, 300) AND word is valued) AND catid = 'cat1'";
@@ -901,7 +901,7 @@
     Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
     
     NSArray* names = [collection indexes: &error];
-    Assert([names containsObject:@"words_index"]);
+    Assert([names containsObject: @"words_index"]);
     
     // Query with OR:
     NSString* sql = @"select meta().id, word, catid from _default.words where vector_match(words_index, $vector, 300) OR catid = 'cat1'";

--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -326,7 +326,7 @@
 }
 
 // CBL-5444 + CBL-5453
-- (void) testCreateVectorIndexUsingPredictionModelWithInvalidVectors {
+- (void) _testCreateVectorIndexUsingPredictionModelWithInvalidVectors {
     NSError* error;
     CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
     

--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -82,7 +82,7 @@
     Assert([names containsObject: @"words_index_1"]);
     
     CBLVectorIndexConfiguration* config2 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                        dimensions: 300
+                                                                                        dimensions: 2048
                                                                                          centroids: 20];
     AssertNotNil(config2);
     Assert([collection createIndexWithName: @"words_index_2" config: config2 error: &error]);
@@ -92,12 +92,6 @@
     [self expectException: NSInvalidArgumentException in:^{
         (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
                                                             dimensions: 0 
-                                                             centroids: 20];
-    }];
-    
-    [self expectException: NSInvalidArgumentException in:^{
-        (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                            dimensions: 301
                                                              centroids: 20];
     }];
     
@@ -118,7 +112,6 @@
                                                                                          centroids: 1];
     AssertNotNil(config1);
     Assert([collection createIndexWithName: @"words_index_1" config: config1 error: &error]);
-    
     
     CBLVectorIndexConfiguration* config2 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
                                                                                         dimensions: 300


### PR DESCRIPTION
- as per the last spec, the whole obj-c vector index api test suite is now complete
- 16/26 are currently running, the rest being disabled and have their respective ticket at the start of the test (in a comment)

- update TestVectorMatchOnNonExistingIndex off spec to check for consistency with fts
- added 2 more index related tests to confirm behaviour - I think we can leave them here as they don't require the creation of a query such that to be moved under the query tests... and also not so many that we need to have a separate file for now