### PR TITLE
CBL-5485 : Update build script per changes in Jenkins's scripts

### DIFF
--- a/Scripts/generate_objc_release_zip.sh
+++ b/Scripts/generate_objc_release_zip.sh
@@ -4,7 +4,7 @@ set -e
 
 function usage
 {
-  echo "Usage: ${0} -o <Output Directory> [-v <Version (<Version Number>[-<Build Number>])>]"
+  echo "Usage: ${0} -o <Output Directory> -e <Edition; ce, community, ee, enterprise> [-v <Version (<Version Number>[-<Build Number>])>]"
   echo "\nOptions:"
   echo "  --notest\t create a release package but no tests needs to be run"
   echo "  --nocov\t create a release package, run tests but no code coverage zip"
@@ -30,8 +30,9 @@ do
       OUTPUT_DIR=${2}
       shift
       ;;
-      --EE)
-      EE=YES
+      -e)
+      EDITION=${2}
+      shift
       ;;
       --notest)
       NO_TEST=YES
@@ -59,14 +60,14 @@ then
   exit 4
 fi
 
-if [ -z "$EE" ]
+if [ "$EDITION" == "ce" ] || [ "$EDITION" == "community" ]
 then
   SCHEME_PREFIX="CBL"
   CONFIGURATION="Release"
   CONFIGURATION_TEST="Debug"
   COVERAGE_NAME="objc_coverage"
   EDITION="community"
-else
+elif [ "$EDITION" == "ee" ] || [ "$EDITION" == "enterprise" ]
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
   CONFIGURATION_TEST="Debug_EE"
@@ -74,7 +75,12 @@ else
   EDITION="enterprise"
   EXTRA_CMD_OPTIONS="--EE"
   OPTS="--EE"
+else
+  echo "Invalid Edition"
+  exit 4
 fi
+
+echo "Build Edition : ${EDITION}"
 
 if [ -z "$PRETTY" ]
 then

--- a/Scripts/generate_swift_release_zip.sh
+++ b/Scripts/generate_swift_release_zip.sh
@@ -30,8 +30,9 @@ do
       OUTPUT_DIR=${2}
       shift
       ;;
-      --EE)
-      EE=YES
+      -e)
+      EDITION=${2}
+      shift
       ;;
       --notest)
       NO_TEST=YES
@@ -59,21 +60,26 @@ then
   exit 4
 fi
 
-if [ -z "$EE" ]
+if [ "$EDITION" == "ce" ] || [ "$EDITION" == "community" ]
 then
   SCHEME_PREFIX="CBL"
   CONFIGURATION="Release"
   CONFIGURATION_TEST="Debug"
   COVERAGE_NAME="swift_coverage"
   EDITION="community"
-else
+elif [ "$EDITION" == "ee" ] || [ "$EDITION" == "enterprise" ]
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
   CONFIGURATION_TEST="Debug_EE"
   COVERAGE_NAME="swift_coverage-ee"
   EDITION="enterprise"
   OPTS="--EE"
+else
+  echo "Invalid Edition"
+  exit 4
 fi
+
+echo "Build Edition : ${EDITION}"
 
 if [ -z "$PRETTY" ]
 then


### PR DESCRIPTION
* There is a change in the scripts of the Jenkin’s build configuration for building objective-c and swift binary to use the same script to build CE and EE.

* Update the scripts to accomidate the changes. Also this changes have been made in the master branch.

* Note : This shouldn't be merged until 3.1.6 is released or there is a new RC required for 3.1.6.