### PR TITLE
CBL-4429 : Fix crash when creating multiple live queries concurrently

### DIFF
--- a/Objective-C/Internal/CBLQueryObserver.h
+++ b/Objective-C/Internal/CBLQueryObserver.h
@@ -20,8 +20,9 @@
 #import <Foundation/Foundation.h>
 
 @protocol CBLListenerToken;
-@class CBLQuery;
+@class CBLChangeListenerToken;
 @class CBLChangeNotifier;
+@class CBLQuery;
 @class CBLQueryChange;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,14 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Initialize with a Query. */
 - (instancetype) initWithQuery: (CBLQuery*)query
-                   columnNames: (NSDictionary *)columnNames
-                         token: (id<CBLListenerToken>)token;
+                   columnNames: (NSDictionary*)columnNames
+                         token: (CBLChangeListenerToken*)token;
 
 /** Starts the observer */
 - (void) start;
 
 /** Stops and frees the observer */
-- (void) stopAndFree;
+- (void) stop;
 
 @end
 

--- a/Objective-C/Internal/CBLQueryObserver.m
+++ b/Objective-C/Internal/CBLQueryObserver.m
@@ -25,7 +25,8 @@
 
 @interface CBLQueryObserver () <CBLStoppable>
 
-@property (nonatomic, readonly) CBLQuery* query;
+/** The query object will be set to nil when the replicator is stopped to break the circular retain references.  */
+@property (nonatomic, readonly, nullable) CBLQuery* query;
 
 @end
 
@@ -33,14 +34,14 @@
     CBLQuery* _query;
     NSDictionary* _columnNames;
     C4QueryObserver* _obs;
-    CBLChangeNotifier* _listenerToken;
+    CBLChangeListenerToken<CBLQueryChange*>* _token;
 }
 
 #pragma mark - Constructor
 
 - (instancetype) initWithQuery: (CBLQuery*)query
-                   columnNames: (NSDictionary *)columnNames
-                         token: (id<CBLListenerToken>)token {
+                   columnNames: (NSDictionary*)columnNames
+                         token: (CBLChangeListenerToken<CBLQueryChange*>*)token {
     NSParameterAssert(query);
     NSParameterAssert(columnNames);
     NSParameterAssert(token);
@@ -49,7 +50,10 @@
     if (self) {
         _query = query;
         _columnNames = columnNames;
-        _listenerToken = token;
+        _token = token;
+        
+        // https://github.com/couchbase/couchbase-lite-core/wiki/Thread-Safety
+        // c4queryobs_create is thread-safe.
         _obs = c4queryobs_create(query.c4query, liveQueryCallback, (__bridge void *)self);
         
         [query.database addActiveStoppable: self];
@@ -58,91 +62,80 @@
 }
 
 - (void) dealloc {
-    if (_obs) {
-        [self stopAndFree];
-    }
+    [self stop];
 }
 
 #pragma mark - Methods
 
 - (void) start {
-    [self observerEnable: YES];
-}
-
-- (void) stopAndFree {
     CBL_LOCK(self) {
-        if (_obs) {
-            [self observerEnable: NO];
-            c4queryobs_free(_obs);
-            _obs = nil;
-        }
+        Assert(_query, @"QueryObserver cannot be restarted.");
+        [_query.database safeBlock: ^{
+            c4queryobs_setEnabled(self->_obs, true);
+        }];
     }
-    
-    [_query.database removeActiveStoppable: self];
-    
-    _query = nil;
-    _columnNames = nil;
-    _listenerToken = nil;
 }
 
 #pragma mark - Internal
 
 - (CBLQuery*) query {
-    return _query;
-}
-
-- (NSString*) description {
-    return [NSString stringWithFormat:@"%@[%@:%@]%@", self.class, [_query description], _obs, [_listenerToken description]];
+    CBL_LOCK(self) {
+        return _query;
+    }
 }
 
 - (void) stop {
-    [self stopAndFree];
+    CBL_LOCK(self) {
+        if (!_query) {
+            return;
+        }
+        
+        [_query.database safeBlock: ^{
+            c4queryobs_setEnabled(self->_obs, false);
+            c4queryobs_free(self->_obs);
+            self->_obs = nil;
+            [self->_query.database removeActiveStoppable: self];
+        }];
+        
+        _query = nil; // Break circular reference cycle
+        _token = nil; // Break circular reference cycle
+    }
 }
 
 #pragma mark - Private
 
-static void liveQueryCallback(C4QueryObserver *obs, C4Query *query, void *context) {
-    CBLQueryObserver *queryObs = (__bridge CBLQueryObserver*)context;
-    dispatch_queue_t queue = [queryObs query].database.queryQueue;
-    if (!queue)
+static void liveQueryCallback(C4QueryObserver *obs, C4Query *c4query, void *context) {
+    CBLQueryObserver* queryObs = (__bridge CBLQueryObserver*)context;
+    CBLQuery* query = queryObs.query;
+    if (!query) {
         return;
+    }
     
-    dispatch_async(queue, ^{
+    dispatch_async(query.database.queryQueue, ^{
         [queryObs postQueryChange: obs];
     });
 };
 
 - (void) postQueryChange: (C4QueryObserver*)obs {
     CBL_LOCK(self) {
-        C4Error c4error = {};
-        
-        // Note: enumerator('e') will be released in ~QueryResultContext; no need to release it
-        C4QueryEnumerator* e = c4queryobs_getEnumerator(obs, true, &c4error);
-        if (!e) {
-            CBLLogInfo(Query, @"%@: C4QueryEnumerator returns empty (%d/%d)",
-                       self, c4error.domain, c4error.code);
+        if (!_query) {
             return;
         }
         
-        CBLQueryResultSet *rs = [[CBLQueryResultSet alloc] initWithQuery: self.query
-                                                              enumerator: e
-                                                             columnNames: _columnNames];
+        // Note: enumerator('result') will be released in ~QueryResultContext; no need to release it
+        __block C4Error c4error = {};
+        __block C4QueryEnumerator* result = NULL;
+        [_query.database safeBlock: ^{
+            result = c4queryobs_getEnumerator(obs, true, &c4error);
+        }];
         
-        if (!rs) {
-            CBLLogInfo(Query, @"%@: Result set returns empty", self);
+        if (!result) {
+            CBLLogVerbose(Query, @"%@: Ignore an empty result (%d/%d)", self, c4error.domain, c4error.code);
             return;
         }
         
-        NSError* error = nil;
-        [_listenerToken postChange: [[CBLQueryChange alloc] initWithQuery: self.query
-                                                                  results: rs
-                                                                    error: error]];
-    }
-}
-
-- (void) observerEnable: (BOOL)enable {
-    CBL_LOCK(self) {
-        c4queryobs_setEnabled(_obs, enable);
+        CBLQueryResultSet* rs = [[CBLQueryResultSet alloc] initWithQuery: _query enumerator: result columnNames: _columnNames];
+        [_token postChange: [[CBLQueryChange alloc] initWithQuery: _query results: rs error: nil]];
     }
 }
 

--- a/Swift/ListenerToken.swift
+++ b/Swift/ListenerToken.swift
@@ -26,14 +26,23 @@ public class ListenerToken {
     /// Remove the listener associated with the token.
     public func remove() {
         impl.remove()
+        
+        if let removedBlock = self.removedBlock {
+            removedBlock(self)
+        }
     }
     
     // MARK: Internal
     
-    init(_ impl: CBLListenerToken) {
+    typealias RemovedBlock = (_ token: ListenerToken) -> Void
+    
+    init(_ impl: CBLListenerToken, removeBlock: RemovedBlock? = nil) {
         self.impl = impl
+        self.removedBlock = removeBlock
     }
     
     let impl: CBLListenerToken
+    
+    let removedBlock: RemovedBlock?
     
 }


### PR DESCRIPTION
* Port the fix from dceea1af8f0f74b39bfaf5df5324f842e66b8285 in release/3.1 branch. The port was done by cherry-picking the commit with no conflicts.

* Background: Based on LiteCore’s thread safety doc, c4queryobs_* (except c4queryobs_create which is thread-safe) functions should be called under database-exclusive lock. Without doing that, when creating and starting multiple live queries concurrently, there could be a race condition as each live queries try to get the background database at the same time. The result of the race is that multiple background databases could be created but only the lastone stays and the rest will be freed. Therefore, some live queries will hold on to the bad background database which will cause the crash when the database is used.

* Fixed CBLQueryObserver to follow thread-safety instruction by calling c4queryobs_* functions under the database exclusive lock.

* Fixed Swift Query’s ListenerToken’s remove() function. After calling the objective-c CBLListenerToken’s remove() function, it will need to do some additional cleanup as well.

* Removed CBLQuery and CBLQueryObserver’s description function to use the default description. Currently they are used for some logging but those excessive information is redundant with what LiteCore is currently logging. More importantly, they could cause some crashes as they don’t handle null objects properly.