### PR TITLE
CBL-5524: Add all keys to the Privacy Manifest file

### DIFF
--- a/Resources/PrivacyInfo.xcprivacy
+++ b/Resources/PrivacyInfo.xcprivacy
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>C617.1</string>
-			</array>
-		</dict>
-	</array>
-</dict>
+    <dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array/>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array/>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+            <dict>
+                <key>NSPrivacyAccessedAPIType</key>
+                <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                <key>NSPrivacyAccessedAPITypeReasons</key>
+                <array>
+                    <string>C617.1</string>
+                </array>
+            </dict>
+        </array>
+    </dict>
 </plist>


### PR DESCRIPTION
Reported in #257 that NSPrivacyAccessedAPITypes and NSPrivacyCollectedDataTypes are required for generating the App’s privacy report even though in the Apple doc, the only required key for 3rd party SDK is NSPrivacyAccessedAPITypes. This commit adds all keys in case the other keys are required in the future by Apple.