### PR TITLE
Podspec and Swift Package updates 

### DIFF
--- a/CouchbaseLite-Swift.podspec
+++ b/CouchbaseLite-Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'CouchbaseLite-Swift'
-  s.version               = '3.1.0'
+  s.version               = '3.3.0'
   s.license               = 'Apache License, Version 2.0'
   s.homepage              = 'https://github.com/couchbase/couchbase-lite-ios'
   s.summary               = 'An embedded syncable NoSQL database for iOS and MacOS apps.'
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.osx.preserve_paths = 'frameworks/CBL_Swift/macOS/CouchbaseLiteSwift.framework'
   s.osx.vendored_frameworks = 'frameworks/CBL_Swift/macOS/CouchbaseLiteSwift.framework'
 
-  s.ios.deployment_target  = '9.0'
-  s.osx.deployment_target  = '10.11'
+  s.ios.deployment_target  = '12.0'
+  s.osx.deployment_target  = '12.0'
 end

--- a/CouchbaseLite.podspec
+++ b/CouchbaseLite.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'CouchbaseLite'
-  s.version               = '3.1.0'
+  s.version               = '3.3.0'
   s.license               = 'Apache License, Version 2.0'
   s.homepage              = 'https://github.com/couchbase/couchbase-lite-ios'
   s.summary               = 'An embedded syncable NoSQL database for iOS and MacOS apps.'
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.osx.preserve_paths = 'frameworks/CBL_ObjC/macOS/CouchbaseLite.framework'
   s.osx.vendored_frameworks = 'frameworks/CBL_ObjC/macOS/CouchbaseLite.framework'
 
-  s.ios.deployment_target  = '9.0'
-  s.osx.deployment_target  = '10.11'
+  s.ios.deployment_target  = '12.0'
+  s.osx.deployment_target  = '12.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "CouchbaseLiteSwift",
     platforms: [
-        .iOS(.v10), .macOS(.v10_12)
+        .iOS(.v12), .macOS(.v12)
     ],
     products: [
         .library(
@@ -14,8 +14,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "CouchbaseLiteSwift",
-            url: "https://packages.couchbase.com/releases/couchbase-lite-ios/3.1.0/couchbase-lite-swift_xc_community_3.1.0.zip",
-            checksum: "556d6ae41df3b5ebf91dbe45d38214dd7032f97ac1b132f925356d20e3b9ada5"
+            url: "https://packages.couchbase.com/releases/couchbase-lite-ios/3.2.0-beta.1/couchbase-lite-swift_xc_community_3.2.0-beta.1.zip",
+            checksum: "39dd4d80a8edb6eb87a2f5ae91753b16064c04c6c74f10f7ef2707902efe14c4"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Couchbase Lite implementation is on top of [Couchbase Lite Core](https://github.
 
 
 ## Requirements
-- iOS 11.0+ | macOS 10.14+
+- iOS 12.0+ | macOS 12.0+
 
 
 ## Installation
@@ -24,7 +24,7 @@ Couchbase Lite implementation is on top of [Couchbase Lite Core](https://github.
 dependencies: [
         .package(name: "CouchbaseLiteSwift",
                  url: "https://github.com/couchbase/couchbase-lite-ios.git", 
-                 from: "3.0.0"),
+                 from: "3.2.0-beta.1"),
     ],
 ```
 
@@ -34,7 +34,7 @@ dependencies: [
 dependencies: [
         .package(name: "CouchbaseLiteSwift",
                  url: "https://github.com/couchbase/couchbase-lite-swift-ee.git", 
-                 from: "3.0.0"),
+                 from: "3.2.0-beta.1"),
     ],
 ```
 


### PR DESCRIPTION
As we branched for a new release, have Podspecs updated to target 3.3.0 and Package.swift/README point to the latest public release available