### PR TITLE
Set API Doc Version in the generate release zip script

### DIFF
--- a/Scripts/generate_objc_release_zip.sh
+++ b/Scripts/generate_objc_release_zip.sh
@@ -160,9 +160,11 @@ then
 fi
 
 VERSION_SUFFIX=""
+API_DOC_VERSION=""
 if [ -n "$VERSION" ]
 then
   VERSION_SUFFIX="_$VERSION"
+  API_DOC_VERSION="$VERSION"
 fi
 
 # Build frameworks:
@@ -194,7 +196,7 @@ if [[ -z $NO_API_DOCS ]]; then
   # Generate API docs:
   echo "Generate API docs ..."
   OBJC_UMBRELLA_HEADER=`find $OUTPUT_OBJC_XC_DIR -name "CouchbaseLite.h"`
-  jazzy --clean --objc --umbrella-header ${OBJC_UMBRELLA_HEADER} --module CouchbaseLite --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLite
+  jazzy --clean --objc --umbrella-header ${OBJC_UMBRELLA_HEADER} --module CouchbaseLite --module-version "${API_DOC_VERSION}" --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLite
   
   # >> Objective-C API
   pushd "$OUTPUT_OBJC_DOCS_DIR" > /dev/null

--- a/Scripts/generate_swift_release_zip.sh
+++ b/Scripts/generate_swift_release_zip.sh
@@ -154,9 +154,11 @@ then
 fi
 
 VERSION_SUFFIX=""
+API_DOC_VERSION=""
 if [ -n "$VERSION" ]
 then
   VERSION_SUFFIX="_$VERSION"
+  API_DOC_VERSION="$VERSION"
 fi
 
 # Build frameworks:
@@ -191,7 +193,7 @@ sh Scripts/generate_package_manifest.sh -zip-path "$OUTPUT_DIR/couchbase-lite-sw
 if [[ -z $NO_API_DOCS ]]; then
   # Generate API docs:
   echo "Generate API docs ..."
-  jazzy --clean --xcodebuild-arguments "clean,build,-scheme,${SCHEME_PREFIX}_Swift,-sdk,iphonesimulator,-destination,generic/platform=iOS Simulator" --module CouchbaseLiteSwift --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLiteSwift
+  jazzy --clean --xcodebuild-arguments "clean,build,-scheme,${SCHEME_PREFIX}_Swift,-sdk,iphonesimulator,-destination,generic/platform=iOS Simulator" --module CouchbaseLiteSwift --module-version "${API_DOC_VERSION}" --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLiteSwift
   
   # >> Swift API docs
   pushd "$OUTPUT_SWIFT_DOCS_DIR" > /dev/null


### PR DESCRIPTION
* Without explicitly set the version, the tool intelligently but unexpectedly picks the version number from the podspec file in the repo. As we generate the API during the build time, this is causing a problem (as happened with 3.2.0-beta.1, the API doc shows version as 3.1.0) when we cannot update the version in the podspec until the release time.

* Explicitly set the version number when generating the doc. If the version is not specified when running the script, there will be no version shown in the doc.