### PR TITLE
CBL-5659 : Fix a released query context may be used in observer callback

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -351,6 +351,14 @@
 		27F9619A1ED8D9440060F804 /* CBLReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 27F961971ED8D9440060F804 /* CBLReachability.h */; };
 		27F9619B1ED8D9440060F804 /* CBLReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F961981ED8D9440060F804 /* CBLReachability.m */; };
 		27F9619C1ED8D9440060F804 /* CBLReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F961981ED8D9440060F804 /* CBLReachability.m */; };
+		4072227B2BD1F7D200A6B560 /* CBLContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4072227A2BD1F7D200A6B560 /* CBLContextManager.m */; };
+		4072227C2BD1F7D200A6B560 /* CBLContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 407222792BD1F7D200A6B560 /* CBLContextManager.h */; };
+		4072227D2BD1F7D200A6B560 /* CBLContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 407222792BD1F7D200A6B560 /* CBLContextManager.h */; };
+		4072227E2BD1F7D200A6B560 /* CBLContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4072227A2BD1F7D200A6B560 /* CBLContextManager.m */; };
+		4072227F2BD1F7D200A6B560 /* CBLContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 407222792BD1F7D200A6B560 /* CBLContextManager.h */; };
+		407222802BD1F7D200A6B560 /* CBLContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4072227A2BD1F7D200A6B560 /* CBLContextManager.m */; };
+		407222812BD1F7D200A6B560 /* CBLContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4072227A2BD1F7D200A6B560 /* CBLContextManager.m */; };
+		407222822BD1F7D200A6B560 /* CBLContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 407222792BD1F7D200A6B560 /* CBLContextManager.h */; };
 		40BC51EF2AFC39ED0090EDD5 /* CouchbaseLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9343F00F207D611600F19A89 /* CouchbaseLite.framework */; };
 		40BC51F02AFC39ED0090EDD5 /* CouchbaseLite.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9343F00F207D611600F19A89 /* CouchbaseLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		40BC51F82AFC40F10090EDD5 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */; };
@@ -2188,6 +2196,8 @@
 		40486D2E2BC8E37700BEA3EF /* CBL_EE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CBL_EE.txt; sourceTree = "<group>"; };
 		40486D2F2BC8E37700BEA3EF /* CBL.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CBL.txt; sourceTree = "<group>"; };
 		40486D302BC8E37700BEA3EF /* generate_exports.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate_exports.sh; sourceTree = "<group>"; };
+		407222792BD1F7D200A6B560 /* CBLContextManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLContextManager.h; sourceTree = "<group>"; };
+		4072227A2BD1F7D200A6B560 /* CBLContextManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLContextManager.m; sourceTree = "<group>"; };
 		40BC51F42AFC40930090EDD5 /* CBLBlockConflictResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLBlockConflictResolver.h; sourceTree = "<group>"; };
 		40BC51F52AFC40930090EDD5 /* CBLBlockConflictResolver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLBlockConflictResolver.m; sourceTree = "<group>"; };
 		40EF695F2B7C038000F0CB50 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -3373,6 +3383,8 @@
 		9378C5E81E26F0E1001BB196 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				407222792BD1F7D200A6B560 /* CBLContextManager.h */,
+				4072227A2BD1F7D200A6B560 /* CBLContextManager.m */,
 				69002EA9234E693F00776107 /* CBLErrorMessage.h */,
 				69002EB8234E693F00776107 /* CBLErrorMessage.m */,
 				72A87A031E2E0E70008466FF /* CBLBlobStream.h */,
@@ -4205,6 +4217,7 @@
 				932EA56D2061FF7E00EDB667 /* CBLVersion.h in Headers */,
 				9384D80A1FC3F75700FE89D8 /* CBLQueryArrayFunction.h in Headers */,
 				937F01DD1EFB1A2500060D64 /* CBLSessionAuthenticator.h in Headers */,
+				4072227D2BD1F7D200A6B560 /* CBLContextManager.h in Headers */,
 				27E35A9C1E8C522200E103F9 /* CBLReplicator.h in Headers */,
 				9388CBEE21BF727A005CA66D /* CBLLog.h in Headers */,
 				939B1B5B2009C04100FAA3CB /* CBLQueryVariableExpression.h in Headers */,
@@ -4445,6 +4458,7 @@
 				9343EFF1207D611600F19A89 /* MYLogging.h in Headers */,
 				9343EFF3207D611600F19A89 /* CBLValueIndex.h in Headers */,
 				1A3470E2266F415E0042C6BA /* CBLIndexSpec.h in Headers */,
+				4072227F2BD1F7D200A6B560 /* CBLContextManager.h in Headers */,
 				9343EFF4207D611600F19A89 /* ExceptionUtils.h in Headers */,
 				9343EFF5207D611600F19A89 /* CBLDocumentChangeNotifier.h in Headers */,
 				9392609520A0CB1300E5748C /* CBLMessageSocket.h in Headers */,
@@ -4597,6 +4611,7 @@
 				9343F0F2207D61AB00F19A89 /* CBLReplicator.h in Headers */,
 				9343F0F3207D61AB00F19A89 /* CBLQueryVariableExpression.h in Headers */,
 				69774C4D28361E5B00B1C793 /* CBLIndexable.h in Headers */,
+				407222822BD1F7D200A6B560 /* CBLContextManager.h in Headers */,
 				9343F0F4207D61AB00F19A89 /* CBLQueryLimit.h in Headers */,
 				9343F0F5207D61AB00F19A89 /* CBLDatabase.h in Headers */,
 				9343F0F6207D61AB00F19A89 /* CBLDocumentChange.h in Headers */,
@@ -4767,6 +4782,7 @@
 				934F4CA91E241FB500F90659 /* CBLCoreBridge.h in Headers */,
 				9384D8091FC3F75700FE89D8 /* CBLQueryArrayFunction.h in Headers */,
 				274B4F8121A4D51100B2B4E6 /* CBLQuery+JSON.h in Headers */,
+				4072227C2BD1F7D200A6B560 /* CBLContextManager.h in Headers */,
 				931C14661EAAD6610094F9B2 /* CBLMutableDictionaryFragment.h in Headers */,
 				934A27B71F30E810003946A7 /* CBLQuantifiedExpression.h in Headers */,
 				9383A58F1F1EE9550083053D /* CBLQueryResultSet+Internal.h in Headers */,
@@ -5234,7 +5250,7 @@
 					};
 					9343EF2A207D611600F19A89 = {
 						DevelopmentTeam = N2Q372V7W2;
-						LastSwiftMigration = 1340;
+						LastSwiftMigration = 1530;
 					};
 					9343F135207D61EC00F19A89 = {
 						DevelopmentTeam = N2Q372V7W2;
@@ -5265,7 +5281,7 @@
 					9398D9111E03434200464432 = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = N2Q372V7W2;
-						LastSwiftMigration = 1340;
+						LastSwiftMigration = 1530;
 						ProvisioningStyle = Automatic;
 					};
 					9398D91A1E03434200464432 = {
@@ -5672,6 +5688,7 @@
 				9388CC4A21C25135005CA66D /* Logger.swift in Sources */,
 				93B503621E64B073002C4680 /* CBLBlob.mm in Sources */,
 				93CED8D120488C9500E6F0A4 /* Authenticator.swift in Sources */,
+				4072227E2BD1F7D200A6B560 /* CBLContextManager.m in Sources */,
 				937F01E41EFB269300060D64 /* CBLAuthenticator.m in Sources */,
 				93B503761E64B0B7002C4680 /* CBLBlobStream.mm in Sources */,
 				932565C121ED51290092F4E0 /* LogFileConfiguration.swift in Sources */,
@@ -6066,6 +6083,7 @@
 				9343EF85207D611600F19A89 /* CBLQueryCollation.m in Sources */,
 				9392609620A0CB1300E5748C /* CBLMessageSocket.mm in Sources */,
 				9343EF86207D611600F19A89 /* CBLUnaryExpression.m in Sources */,
+				407222802BD1F7D200A6B560 /* CBLContextManager.m in Sources */,
 				9343EF87207D611600F19A89 /* CBLMutableDictionary.mm in Sources */,
 				9343EF88207D611600F19A89 /* CBLQueryResultArray.m in Sources */,
 				9343EF89207D611600F19A89 /* CBLDocumentFragment.m in Sources */,
@@ -6175,6 +6193,7 @@
 				9343F04E207D61AB00F19A89 /* HavingRouter.swift in Sources */,
 				9343F04F207D61AB00F19A89 /* CBLMutableFragment.m in Sources */,
 				9343F050207D61AB00F19A89 /* CBLArray.mm in Sources */,
+				407222812BD1F7D200A6B560 /* CBLContextManager.m in Sources */,
 				9343F051207D61AB00F19A89 /* WhereRouter.swift in Sources */,
 				932565AB21ED13290092F4E0 /* CBLLogFileConfiguration.m in Sources */,
 				9343F052207D61AB00F19A89 /* CBLValueExpression.m in Sources */,
@@ -6583,6 +6602,7 @@
 				93CD02671E9FFEC500AFB3FA /* CBLMutableArray.mm in Sources */,
 				937F02561EFC62B200060D64 /* CBLQueryChange.m in Sources */,
 				934A27941F30E5CA003946A7 /* CBLBinaryExpression.m in Sources */,
+				4072227B2BD1F7D200A6B560 /* CBLContextManager.m in Sources */,
 				275FF6B91E47B2FC005F90DD /* ExceptionUtils.m in Sources */,
 				1A1612B3283E29E600AA4987 /* CBLCollectionConfiguration.m in Sources */,
 				939B1B5C2009C04100FAA3CB /* CBLQueryVariableExpression.m in Sources */,

--- a/Objective-C/Internal/CBLContextManager.h
+++ b/Objective-C/Internal/CBLContextManager.h
@@ -1,0 +1,57 @@
+//
+//  CBLContextManager.h
+//  CouchbaseLite
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Thread-safe context manager for retaining and mapping the object with its pointer value which can be used as 
+ the context for LiteCore's callbacks (e.g. use when creating c4queryobserver objects). The implementation
+ simply stores the object in a map by using its memory address as the key and returns the memory address
+ as the pointer value.
+ 
+ @note
+ There is a chance that a new registered objects may have the same memory address as the ones previously
+ unregistered. This implementation can be improved to reduce a chance of reusing the same memory address
+ by generating integer keys with reuseable integer number + cycle count as inspired by the implementation of
+ C# GCHandle. For now, the context object MUST BE validated for its originality before use.
+ */
+@interface CBLContextManager : NSObject
+
++ (instancetype) shared;
+
+/** Register and retain the object. The context pointer of the registered object will be returned.  */
+- (void*) registerObject: (id)object;
+
+/** Unregister the object of the given context pointer. */
+- (void) unregisterObjectForPointer: (void*)ptr;
+
+/** Get the object of the given context pointer. */
+- (nullable id) objectForPointer: (void*)ptr;
+
+/** Count number of registered objects. */
+- (NSUInteger) count;
+
+/** Not available */
+- (instancetype) init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/Internal/CBLContextManager.m
+++ b/Objective-C/Internal/CBLContextManager.m
@@ -1,0 +1,69 @@
+//
+//  CBLContextManager.h
+//  CouchbaseLite
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "CBLContextManager.h"
+
+@implementation CBLContextManager {
+    NSMutableDictionary* _contextMap;
+}
+
++ (CBLContextManager*) shared {
+    static CBLContextManager* shared = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        shared = [[self alloc] init];
+    });
+    return shared;
+}
+
+- (instancetype) init {
+    self = [super init];
+    if (self) {
+        _contextMap = [NSMutableDictionary dictionaryWithCapacity: 20];
+    }
+    return self;
+}
+
+- (void*) registerObject: (id)object {
+    CBL_LOCK(self) {
+        void* ptr = (__bridge void *)(object);
+        [_contextMap setObject: object forKey: [NSValue valueWithPointer: ptr]];
+        return ptr;
+    }
+}
+
+- (void) unregisterObjectForPointer: (void*)ptr {
+    CBL_LOCK(self) {
+        [_contextMap removeObjectForKey: [NSValue valueWithPointer: ptr]];
+    }
+}
+
+- (id) objectForPointer: (void*)ptr {
+    CBL_LOCK(self) {
+        return [_contextMap objectForKey: [NSValue valueWithPointer: ptr]];
+    }
+}
+
+- (NSUInteger) count {
+    CBL_LOCK(self) {
+        return [_contextMap count];
+    }
+}
+
+@end

--- a/Objective-C/Internal/CBLQueryObserver.h
+++ b/Objective-C/Internal/CBLQueryObserver.h
@@ -29,8 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLQueryObserver : NSObject
 
-- (instancetype) init NS_UNAVAILABLE; 
-
 /** Initialize with a Query. */
 - (instancetype) initWithQuery: (CBLQuery*)query
                    columnNames: (NSDictionary*)columnNames
@@ -41,6 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Stops and frees the observer */
 - (void) stop;
+
+- (instancetype) init NS_UNAVAILABLE;
+
+#ifdef DEBUG
++ (void) setC4QueryObserverCallbackDelayInterval: (NSTimeInterval)delay;
+#endif
 
 @end
 

--- a/Objective-C/Internal/CBLQueryObserver.m
+++ b/Objective-C/Internal/CBLQueryObserver.m
@@ -16,9 +16,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
+
 #import "CBLQueryObserver.h"
 #import "c4.h"
 #import "CBLChangeNotifier.h"
+#import "CBLContextManager.h"
 #import "CBLQueryChange+Internal.h"
 #import "CBLQuery+Internal.h"
 #import "CBLQueryResultSet+Internal.h"
@@ -33,8 +35,9 @@
 @implementation CBLQueryObserver {
     CBLQuery* _query;
     NSDictionary* _columnNames;
-    C4QueryObserver* _obs;
+    C4QueryObserver* _c4obs;
     CBLChangeListenerToken<CBLQueryChange*>* _token;
+    void* _context;
 }
 
 #pragma mark - Constructor
@@ -52,9 +55,8 @@
         _columnNames = columnNames;
         _token = token;
         
-        // https://github.com/couchbase/couchbase-lite-core/wiki/Thread-Safety
-        // c4queryobs_create is thread-safe.
-        _obs = c4queryobs_create(query.c4query, liveQueryCallback, (__bridge void *)self);
+        _context = [[CBLContextManager shared] registerObject: self];
+        _c4obs = c4queryobs_create(query.c4query, liveQueryCallback, _context); // c4queryobs_create is thread-safe.
         
         [query.database addActiveStoppable: self];
     }
@@ -69,14 +71,12 @@
 
 - (void) start {
     CBL_LOCK(self) {
-        Assert(_query, @"QueryObserver cannot be restarted.");
+        Assert(_c4obs, @"QueryObserver cannot be restarted.");
         [_query.database safeBlock: ^{
-            c4queryobs_setEnabled(_obs, true);
+            c4queryobs_setEnabled(_c4obs, true);
         }];
     }
 }
-
-#pragma mark - Internal
 
 - (CBLQuery*) query {
     CBL_LOCK(self) {
@@ -86,57 +86,97 @@
 
 - (void) stop {
     CBL_LOCK(self) {
-        if (!_query) {
-            return;
-        }
+        if ([self isStopped]) { return; }
         
         [_query.database safeBlock: ^{
-            c4queryobs_setEnabled(_obs, false);
-            c4queryobs_free(_obs);
-            _obs = nil;
+            c4queryobs_setEnabled(_c4obs, false);
+            c4queryobs_free(_c4obs);
             [_query.database removeActiveStoppable: self];
         }];
         
+        [[CBLContextManager shared] unregisterObjectForPointer: _context];
+        _context = nil;
+        
+        _c4obs = nil;
         _query = nil; // Break circular reference cycle
         _token = nil; // Break circular reference cycle
     }
 }
 
+// Must call under self lock
+- (BOOL) isStopped {
+    return _c4obs == nil;
+}
+
+#ifdef DEBUG
+
+static NSTimeInterval sC4QueryObserverCallbackDelayInterval = 0;
+
++ (void) setC4QueryObserverCallbackDelayInterval: (NSTimeInterval)delay {
+    sC4QueryObserverCallbackDelayInterval = delay;
+}
+
+#endif
+
 #pragma mark - Private
 
-static void liveQueryCallback(C4QueryObserver *obs, C4Query *c4query, void *context) {
-    CBLQueryObserver* queryObs = (__bridge CBLQueryObserver*)context;
-    CBLQuery* query = queryObs.query;
+static void liveQueryCallback(C4QueryObserver *c4obs, C4Query *c4query, void *context) {
+#ifdef DEBUG
+    if (sC4QueryObserverCallbackDelayInterval > 0) {
+        [NSThread sleepForTimeInterval: sC4QueryObserverCallbackDelayInterval];
+    }
+#endif
+    
+    // Get and retain object:
+    id obj = [[CBLContextManager shared] objectForPointer: context];
+    CBLQueryObserver* obs = $castIf(CBLQueryObserver, obj);
+    
+    // Validate:
+    if (!obs || obs->_c4obs != c4obs) {
+        CBLLogVerbose(Query, @"Query observer context was already released, ignore observer callback");
+        return;
+    }
+    
+    // Check stopped:
+    CBLQuery* query = obs.query;
     if (!query) {
+        CBLLogVerbose(Query, @"%@: Query observer was already stopped, ignore observer callback", obs);
+        return;
+    }
+    
+    // MUST get the enumerator inside the callback as the c4obs could be deleted after the callback if called.
+    __block C4QueryEnumerator* enumerator = NULL;
+    __block C4Error c4error = {};
+    
+    [query.database safeBlock: ^{
+        enumerator = c4queryobs_getEnumerator(c4obs, true, &c4error);
+    }];
+    
+    if (!enumerator) {
+        CBLLogVerbose(Query, @"%@: Ignore an empty result (%d/%d)", obs, c4error.domain, c4error.code);
         return;
     }
     
     dispatch_async(query.database.queryQueue, ^{
-        [queryObs postQueryChange: obs];
+        [obs postQueryChange: enumerator];
     });
 };
 
-- (void) postQueryChange: (C4QueryObserver*)obs {
+- (void) postQueryChange: (C4QueryEnumerator*)enumerator {
+    CBLChangeListenerToken<CBLQueryChange*>* token;
     CBL_LOCK(self) {
-        if (!_query) {
+        if ([self isStopped]) {
+            c4queryenum_release( enumerator);
+            CBLLogVerbose(Query, @"%@: Query observer was already stopped, skip notification", self);
             return;
         }
-        
-        // Note: enumerator('result') will be released in ~QueryResultContext; no need to release it
-        __block C4Error c4error = {};
-        __block C4QueryEnumerator* result = NULL;
-        [_query.database safeBlock: ^{
-            result = c4queryobs_getEnumerator(obs, true, &c4error);
-        }];
-        
-        if (!result) {
-            CBLLogVerbose(Query, @"%@: Ignore an empty result (%d/%d)", self, c4error.domain, c4error.code);
-            return;
-        }
-        
-        CBLQueryResultSet* rs = [[CBLQueryResultSet alloc] initWithQuery: _query enumerator: result columnNames: _columnNames];
-        [_token postChange: [[CBLQueryChange alloc] initWithQuery: _query results: rs error: nil]];
+        token = _token;
     }
+    
+    CBLQueryResultSet* rs = [[CBLQueryResultSet alloc] initWithQuery: _query 
+                                                          enumerator: enumerator
+                                                         columnNames: _columnNames];
+    [token postChange: [[CBLQueryChange alloc] initWithQuery: _query results: rs error: nil]];
 }
 
 @end


### PR DESCRIPTION
Implemented CBLContextManager class for retaining and mapping the object with its pointer value which can be used as the context for LiteCore's callbacks (e.g. use when creating c4queryobserver objects). The implementation simply stores the object in a map by using its memory address as the key and returns the memory address as the pointer value.

Updated CBLQueryObserver to use CBLContextManager to register its query context and unregister the context when the C4QueryObserver is disabled. The C4QueryObserver's callback now can verified that the query context is still valid before using it. Also when using the query context, the query context is retained in the callback itself.

Updated CBLQueryObserver to get the C4QueryEnumerator object inside the callback as the enumerator object to prevent using the already freed C4QueryObserver in the notification queue.

Added a test for [CBSE-16662](https://issues.couchbase.com/browse/CBSE-16662) which is related to this issue and two tests to check that there are no notification received without crash ([CBL-5659](https://issues.couchbase.com/browse/CBL-5659)) after removing the token.

Added an internal debug build only C4QueryObserverCallbackDelayInterval config for testing the fix.

Found that the retain cyble between CBLQueryObserver and CBLQuery and CBLListenerToken can be improved.

Updated LiteCore to 3.1.7-1 to get the fix for [CBSE-16662](https://issues.couchbase.com/browse/CBSE-16662).