### PR TITLE
Fix error and set API doc version in generate release scripts

### DIFF
--- a/Scripts/generate_objc_release_zip.sh
+++ b/Scripts/generate_objc_release_zip.sh
@@ -68,6 +68,7 @@ then
   COVERAGE_NAME="objc_coverage"
   EDITION="community"
 elif [ "$EDITION" == "ee" ] || [ "$EDITION" == "enterprise" ]
+then
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
   CONFIGURATION_TEST="Debug_EE"
@@ -153,9 +154,11 @@ then
 fi
 
 VERSION_SUFFIX=""
+API_DOC_VERSION=""
 if [ -n "$VERSION" ]
 then
   VERSION_SUFFIX="_$VERSION"
+  API_DOC_VERSION="$VERSION"
 fi
 
 # Build frameworks:
@@ -187,7 +190,7 @@ if [[ -z $NO_API_DOCS ]]; then
   # Generate API docs:
   echo "Generate API docs ..."
   OBJC_UMBRELLA_HEADER=`find $OUTPUT_OBJC_XC_DIR -name "CouchbaseLite.h"`
-  jazzy --clean --objc --umbrella-header ${OBJC_UMBRELLA_HEADER} --module CouchbaseLite --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLite
+  jazzy --clean --objc --umbrella-header ${OBJC_UMBRELLA_HEADER} --module CouchbaseLite --module-version "${API_DOC_VERSION}" --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLite
   
   # >> Objective-C API
   pushd "$OUTPUT_OBJC_DOCS_DIR" > /dev/null

--- a/Scripts/generate_swift_release_zip.sh
+++ b/Scripts/generate_swift_release_zip.sh
@@ -68,6 +68,7 @@ then
   COVERAGE_NAME="swift_coverage"
   EDITION="community"
 elif [ "$EDITION" == "ee" ] || [ "$EDITION" == "enterprise" ]
+then
   SCHEME_PREFIX="CBL_EE"
   CONFIGURATION="Release_EE"
   CONFIGURATION_TEST="Debug_EE"
@@ -147,9 +148,11 @@ then
 fi
 
 VERSION_SUFFIX=""
+API_DOC_VERSION=""
 if [ -n "$VERSION" ]
 then
   VERSION_SUFFIX="_$VERSION"
+  API_DOC_VERSION="$VERSION"
 fi
 
 # Build frameworks:
@@ -184,7 +187,7 @@ sh Scripts/generate_package_manifest.sh -zip-path "$OUTPUT_DIR/couchbase-lite-sw
 if [[ -z $NO_API_DOCS ]]; then
   # Generate API docs:
   echo "Generate API docs ..."
-  jazzy --clean --xcodebuild-arguments "clean,build,-scheme,${SCHEME_PREFIX}_Swift,-sdk,iphonesimulator,-destination,generic/platform=iOS Simulator" --module CouchbaseLiteSwift --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLiteSwift
+  jazzy --clean --xcodebuild-arguments "clean,build,-scheme,${SCHEME_PREFIX}_Swift,-sdk,iphonesimulator,-destination,generic/platform=iOS Simulator" --module CouchbaseLiteSwift --module-version "${API_DOC_VERSION}" --theme Scripts/Support/Docs/Theme --readme README.md --output ${OUTPUT_DOCS_DIR}/CouchbaseLiteSwift
   
   # >> Swift API docs
   pushd "$OUTPUT_SWIFT_DOCS_DIR" > /dev/null


### PR DESCRIPTION
CBL-5674 : Fixed missing “then” in elif in generate release zip scripts.
CBL-5675 : Set —module-version when generating API doc.