### PR TITLE
CBL-5514: Swift MutableDocument's collection is not set when a new document is saved

### DIFF
--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -2237,6 +2237,16 @@
     AssertEqual(blob.length, 0);
 }
 
+- (void) testGetCollectionAfterDocIsSaved {
+    NSError* error;
+    CBLCollection* col1 = [self.db createCollectionWithName:@"collection1" scope: nil error: &error];
+    CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc setString: @"hello" forKey: @"greetings"];
+    [col1 saveDocument: doc error: &error];
+    CBLCollection* docColl = [doc collection];
+    AssertEqual(col1, docColl);
+}
+
 #pragma clang diagnostic pop
 
 @end

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -2247,6 +2247,22 @@
     AssertEqual(col1, docColl);
 }
 
+- (void) testDocumentResaveInAnotherCollection {
+    NSError* error;
+    CBLCollection* colA = [self.db createCollectionWithName:@"collA" scope: nil error: &error];
+    CBLCollection* colB = [self.db createCollectionWithName:@"collB" scope: nil error: &error];
+    
+    CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc setString: @"hello" forKey: @"greetings"];
+    
+    [colA saveDocument: doc error: &error];
+    doc = [[colA documentWithID: @"doc1" error: &error] toMutable];
+    
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in:^BOOL(NSError** e) {
+        return [colB saveDocument: doc error: e];
+    }];
+}
+
 #pragma clang diagnostic pop
 
 @end

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -2257,7 +2257,6 @@
     
     [colA saveDocument: doc error: &error];
     doc = [[colA documentWithID: @"doc1" error: &error] toMutable];
-    
     [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in:^BOOL(NSError** e) {
         return [colB saveDocument: doc error: e];
     }];

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -107,6 +107,7 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     /// Throws an NSError with the CBLError.notOpen code, if the collection is deleted or
     /// the database is closed.
     public func save(document: MutableDocument) throws {
+        document.collection = self
         try impl.save(document.impl as! CBLMutableDocument)
     }
     

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -107,10 +107,10 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     /// Throws an NSError with the CBLError.notOpen code, if the collection is deleted or
     /// the database is closed.
     public func save(document: MutableDocument) throws {
-        if (document.collection == nil){
+        try impl.save(document.impl as! CBLMutableDocument)
+        if (document.collection == nil) {
             document.collection = self
         }
-        try impl.save(document.impl as! CBLMutableDocument)
     }
     
     /// Save a document into the collection with a specified concurrency control. When specifying
@@ -133,6 +133,9 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
                 return false
             }
             throw err
+        }
+        if (document.collection == nil) {
+            document.collection = self
         }
         return result
     }
@@ -161,6 +164,9 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
                 return false
             }
             throw err
+        }
+        if (document.collection == nil) {
+            document.collection = self
         }
         return result
     }

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -107,7 +107,9 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     /// Throws an NSError with the CBLError.notOpen code, if the collection is deleted or
     /// the database is closed.
     public func save(document: MutableDocument) throws {
-        document.collection = self
+        if (document.collection == nil){
+            document.collection = self
+        }
         try impl.save(document.impl as! CBLMutableDocument)
     }
     

--- a/Swift/Document.swift
+++ b/Swift/Document.swift
@@ -43,7 +43,7 @@ public class Document : DictionaryProtocol, Equatable, Hashable, Sequence {
     }
     
     /// The collection that the document belongs to.
-    public let collection: Collection?
+    internal(set) public var collection: Collection?
     
     // MARK: Edit
     

--- a/Swift/MutableDocument.swift
+++ b/Swift/MutableDocument.swift
@@ -94,8 +94,7 @@ public final class MutableDocument : Document, MutableDictionaryProtocol {
     }
     
     // MARK: Edit
-    
-    // TODO: Implement copy
+
     /// Returns the same MutableDocument object.
     ///
     /// - Returns: The MutableDocument object.
@@ -307,5 +306,4 @@ public final class MutableDocument : Document, MutableDictionaryProtocol {
     private var docImpl: CBLMutableDocument {
         return impl as! CBLMutableDocument
     }
-    
 }

--- a/Swift/Tests/DocumentTest.swift
+++ b/Swift/Tests/DocumentTest.swift
@@ -1818,6 +1818,13 @@ class DocumentTest: CBLTestCase {
                                                             Blob.blobLengthProperty: blob.length])
         XCTAssertNil(retrivedBlob)
         XCTAssertEqual(retrivedBlob?.length ?? 0, 0)
-        
+    }
+    
+    func testGetCollectionAfterDocIsSaved() throws {
+        let col1 = try db.createCollection(name: "collection1")
+        var doc = MutableDocument(id: "doc1")
+        doc.setString("hello", forKey: "greeting")
+        try col1.save(document: doc)
+        XCTAssert(doc.collection == col1)
     }
 }

--- a/Swift/Tests/DocumentTest.swift
+++ b/Swift/Tests/DocumentTest.swift
@@ -1822,9 +1822,23 @@ class DocumentTest: CBLTestCase {
     
     func testGetCollectionAfterDocIsSaved() throws {
         let col1 = try db.createCollection(name: "collection1")
-        var doc = MutableDocument(id: "doc1")
+        let doc = MutableDocument(id: "doc1")
         doc.setString("hello", forKey: "greeting")
         try col1.save(document: doc)
         XCTAssert(doc.collection == col1)
+    }
+    
+    func testDocumentResaveInAnotherCollection() throws {
+        let colA = try db.createCollection(name: "collA")
+        let colB = try db.createCollection(name: "collB")
+        
+        var doc = MutableDocument(id: "doc1")
+        doc.setString("hello", forKey: "greeting")
+        
+        try colA.save(document: doc)
+        doc = try colA.document(id: "doc1")!.toMutable()
+        self.expectError(domain: CBLError.domain, code: CBLError.invalidParameter) {
+            try colB.save(document: doc)
+        }
     }
 }


### PR DESCRIPTION
- change Document.collection API to have a private setter
- set collection on save
- add 1 tests for each side (Obj-C and Swift)