### PR TITLE
Change PR Validation

### DIFF
--- a/.github/workflows/xcodebuild-ios.yml
+++ b/.github/workflows/xcodebuild-ios.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: build-and-test
+    name: build
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -33,9 +33,3 @@ jobs:
         run: |
           DEVICE=$(cat device)
           xcodebuild build-for-testing -scheme "${SCHEME}" -project CouchbaseLite.xcodeproj  -destination "platform=iOS Simulator,name=${DEVICE}"
-      - name: "Test"
-        env:
-          SCHEME: ${{ matrix.scheme }}
-        run: |
-          DEVICE=$(cat device)
-          xcodebuild test-without-building -scheme "${SCHEME}" -project CouchbaseLite.xcodeproj  -destination "platform=iOS Simulator,name=${DEVICE}"

--- a/.github/workflows/xcodebuild-mac.yml
+++ b/.github/workflows/xcodebuild-mac.yml
@@ -12,7 +12,7 @@ on:
 
 jobs: 
   build:
-    name: build-and-test
+    name: build
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -31,10 +31,3 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           xcodebuild build-for-testing -scheme "${SCHEME}" -project CouchbaseLite.xcodeproj  -destination "${PLATFORM},arch=${ARCH}"
-      - name: "Test"
-        env:
-          SCHEME: ${{ matrix.scheme }}
-          PLATFORM: ${{ matrix.platform }}
-          ARCH: ${{ matrix.arch }}
-        run: |
-          xcodebuild test-without-building -scheme "${SCHEME}" -project CouchbaseLite.xcodeproj  -destination "${PLATFORM},arch=${ARCH}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         stage('Build'){
             steps {
                 sh """ 
-		            ./couchbase-lite-ios/Scripts/pull_request_build.sh
+		            ./couchbase-lite-ios/Scripts/pull_request_build_test.sh
                 """
             }
         }

--- a/Scripts/pull_request_build_test.sh
+++ b/Scripts/pull_request_build_test.sh
@@ -6,11 +6,11 @@ if [ "$1" = "-enterprise" ]
     cd couchbase-lite-ios
 fi
 
-SCHEMES_MACOS=("CBL_EE_ObjC" "CBL_EE_Swift")
+SCHEMES_MACOS=("CBL_EE_ObjC_Tests" "CBL_EE_Swift_Tests")
 
 for SCHEMES_MACOS in "${SCHEMES_MACOS[@]}"
 do
-  xcodebuild build -project CouchbaseLite.xcodeproj -scheme "$SCHEMES_MACOS" -destination "platform=macOS"
+  xcodebuild test -project CouchbaseLite.xcodeproj -scheme "$SCHEMES_MACOS" -destination "platform=macOS"
 done
 
 TEST_SIMULATOR=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | sed 's/Simulator//g' | awk '{$1=$1;print}')


### PR DESCRIPTION
Due to having a couple of test constantly being flaky in Actions, mostly iOS, but we've seen some in macOS as well, due to the machine being very slow: 
- we will only build via Actions from now on
- we will build and test in Jenkins for both macOS and iOS as EE scheme includes all CE tests alongside EE specific ones

Unfortunately, we cannot run iOS and macOS on parallel as we only have 1 machine for Jenkins. After Beryllium, we will try and get another one so it speeds up the process and run these in parallel.

Caveat: I am not sure if all macOS tests are part of the iOS scheme and until I can confirm this, I prefer to have the test run on both in Jenkins - it will be slower ~30min (and I hope it wont hang as much as LiteCore did in the past from unknown reasons)