### PR TITLE
CBL-5803 : Implement Lazy Vector Index and Test for Swift

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -374,6 +374,15 @@
 		4017E46A2BED6E5400A438EE /* CBLContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4017E4642BED6E5400A438EE /* CBLContextManager.m */; };
 		4017E46B2BED6E5400A438EE /* CBLContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4017E4642BED6E5400A438EE /* CBLContextManager.m */; };
 		4017E46C2BED6E5400A438EE /* CBLContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4017E4642BED6E5400A438EE /* CBLContextManager.m */; };
+		406F8DEB2C26901A000223FC /* QueryIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406F8DEA2C26901A000223FC /* QueryIndex.swift */; };
+		406F8DEC2C26901A000223FC /* QueryIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406F8DEA2C26901A000223FC /* QueryIndex.swift */; };
+		406F8DFB2C27C303000223FC /* IndexUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406F8DF92C27C302000223FC /* IndexUpdater.swift */; };
+		406F8DFF2C27F0A9000223FC /* LazyVectorIndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406F8DFC2C27F097000223FC /* LazyVectorIndexTest.swift */; };
+		406F8E002C27F0AB000223FC /* LazyVectorIndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406F8DFC2C27F097000223FC /* LazyVectorIndexTest.swift */; };
+		40AA72952C28938D007FB1E0 /* VectorSearchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AE006DE62B7BB98B00884E2B /* VectorSearchTest.m */; };
+		40AA72962C28938E007FB1E0 /* VectorSearchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AE006DE62B7BB98B00884E2B /* VectorSearchTest.m */; };
+		40AA729D2C28B1A3007FB1E0 /* LazyVectorIndexTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 40AA72972C28B1A3007FB1E0 /* LazyVectorIndexTest.m */; };
+		40AA729E2C28B1A3007FB1E0 /* LazyVectorIndexTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 40AA72972C28B1A3007FB1E0 /* LazyVectorIndexTest.m */; };
 		40C5FD5B2B9947B3004BFD3B /* CBLVectorIndexTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 40C5FD5A2B9946E6004BFD3B /* CBLVectorIndexTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40C5FD5C2B9947B9004BFD3B /* CBLVectorIndexTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 40C5FD5A2B9946E6004BFD3B /* CBLVectorIndexTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		40EF690C2B7757CF00F0CB50 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 40EF690A2B77564000F0CB50 /* PrivacyInfo.xcprivacy */; };
@@ -1735,8 +1744,6 @@
 		93FD618E2020757500E7F6A1 /* CBLIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FD618A2020757500E7F6A1 /* CBLIndex.m */; };
 		AE006DE42B7BB22000884E2B /* CBLWordEmbeddingModel.m in Sources */ = {isa = PBXBuildFile; fileRef = AE006DD32B7B9FEF00884E2B /* CBLWordEmbeddingModel.m */; };
 		AE006DE52B7BB22000884E2B /* CBLWordEmbeddingModel.m in Sources */ = {isa = PBXBuildFile; fileRef = AE006DD32B7B9FEF00884E2B /* CBLWordEmbeddingModel.m */; };
-		AE006DE92B7BB98B00884E2B /* VectorSearchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AE006DE62B7BB98B00884E2B /* VectorSearchTest.m */; };
-		AE006DEA2B7BB98B00884E2B /* VectorSearchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AE006DE62B7BB98B00884E2B /* VectorSearchTest.m */; };
 		AE5803A42B99C67D001A1BE3 /* VectorSearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5803A32B99C67D001A1BE3 /* VectorSearchTest.swift */; };
 		AE5803A52B99C67D001A1BE3 /* VectorSearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5803A32B99C67D001A1BE3 /* VectorSearchTest.swift */; };
 		AE5803D82B9B5B2A001A1BE3 /* WordEmbeddingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5803D72B9B5B2A001A1BE3 /* WordEmbeddingModel.swift */; };
@@ -2270,11 +2277,16 @@
 		40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLBlockConflictResolver.m; sourceTree = "<group>"; };
 		4017E4572BED6E5400A438EE /* CBLContextManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLContextManager.h; sourceTree = "<group>"; };
 		4017E4642BED6E5400A438EE /* CBLContextManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLContextManager.m; sourceTree = "<group>"; };
+		406F8DEA2C26901A000223FC /* QueryIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryIndex.swift; sourceTree = "<group>"; };
+		406F8DF92C27C302000223FC /* IndexUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexUpdater.swift; sourceTree = "<group>"; };
+		406F8DFC2C27F097000223FC /* LazyVectorIndexTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyVectorIndexTest.swift; sourceTree = "<group>"; };
 		40A789282BE2C7D100CA43A1 /* CBL_EE.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = CBL_EE.exp; sourceTree = "<group>"; };
 		40A789292BE2C7D100CA43A1 /* CBL.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = CBL.exp; sourceTree = "<group>"; };
 		40A7892B2BE2C7D100CA43A1 /* CBL_EE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CBL_EE.txt; sourceTree = "<group>"; };
 		40A7892C2BE2C7D100CA43A1 /* CBL.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CBL.txt; sourceTree = "<group>"; };
 		40A7892D2BE2C7D100CA43A1 /* generate_exports.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate_exports.sh; sourceTree = "<group>"; };
+		40AA72972C28B1A3007FB1E0 /* LazyVectorIndexTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LazyVectorIndexTest.m; sourceTree = "<group>"; };
+		40AA72A12C28B1F2007FB1E0 /* VectorSearchTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VectorSearchTest.h; sourceTree = "<group>"; };
 		40C5FD5A2B9946E6004BFD3B /* CBLVectorIndexTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLVectorIndexTypes.h; sourceTree = "<group>"; };
 		40E905462B5B6D9D00EDF483 /* CouchbaseLiteSwift.private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = CouchbaseLiteSwift.private.modulemap; sourceTree = "<group>"; };
 		40EF68102B71891A00F0CB50 /* remove_private_module.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = remove_private_module.sh; sourceTree = "<group>"; };
@@ -3059,6 +3071,7 @@
 				934608EE247F35CC00CF2F27 /* URLEndpointListenerTest.swift */,
 				1A13DD3328B8809300BC1084 /* URLEndpointListenerTest+Collection.swift */,
 				AE5803A32B99C67D001A1BE3 /* VectorSearchTest.swift */,
+				406F8DFC2C27F097000223FC /* LazyVectorIndexTest.swift */,
 				1AA91DC522B0356000BF0BDE /* CustomLogger.swift */,
 				93249D81246B99FD000A8A6E /* iOS */,
 				939B79241E679017009A70EF /* Info.plist */,
@@ -3424,6 +3437,7 @@
 			children = (
 				40FC1C4F2B928C1600394276 /* VectorEncoding.swift */,
 				40FC1C4E2B928C1600394276 /* VectorIndexConfiguration.swift */,
+				406F8DF92C27C302000223FC /* IndexUpdater.swift */,
 			);
 			name = Vector;
 			sourceTree = "<group>";
@@ -4120,7 +4134,9 @@
 				1A9617F2289BF3C10037E78E /* URLEndpointListenerTest+Collection.m */,
 				1AA3D77122AB06E10098E16B /* CustomLogger.h */,
 				1AA3D77222AB06E10098E16B /* CustomLogger.m */,
+				40AA72A12C28B1F2007FB1E0 /* VectorSearchTest.h */,
 				AE006DE62B7BB98B00884E2B /* VectorSearchTest.m */,
+				40AA72972C28B1A3007FB1E0 /* LazyVectorIndexTest.m */,
 				93DECF3E200DBE5800F44953 /* Support */,
 				936483AA1E4431C6008D08B3 /* iOS */,
 				275FF5FA1E3FBD3B005F90DD /* Performance */,
@@ -4284,6 +4300,7 @@
 				1A84E8F4268560E600C43AF9 /* IndexConfiguration.swift */,
 				931DE0661F4E3EC2003EF76F /* Index.swift */,
 				93EB261A21DDC34C0006FB88 /* IndexBuilder.swift */,
+				406F8DEA2C26901A000223FC /* QueryIndex.swift */,
 			);
 			name = Index;
 			sourceTree = "<group>";
@@ -6096,6 +6113,7 @@
 				931DE0671F4E3EC2003EF76F /* Index.swift in Sources */,
 				93CED8CD20488C1300E6F0A4 /* Blob.swift in Sources */,
 				938B36A7200745FF004485D8 /* CBLQueryResultArray.m in Sources */,
+				406F8DEB2C26901A000223FC /* QueryIndex.swift in Sources */,
 				9384D8631FC4163D00FE89D8 /* FullTextFunction.swift in Sources */,
 				1A8E2FB328FF756600E141A8 /* Defaults.swift in Sources */,
 				9322DCF71F14671F00C4ACF7 /* LimitRouter.swift in Sources */,
@@ -6236,6 +6254,7 @@
 				93BB1C9E246BB2BF004FFA00 /* DatabaseTest.swift in Sources */,
 				93BB1C9C246BB2BB004FFA00 /* CBLTestCase.swift in Sources */,
 				93BB1CB8246BB2F4004FFA00 /* ReplicatorTest+CustomConflict.swift in Sources */,
+				406F8E002C27F0AB000223FC /* LazyVectorIndexTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6555,6 +6574,7 @@
 				9343F07C207D61AB00F19A89 /* ReplicatorConfiguration.swift in Sources */,
 				40FC1C012B928AB200394276 /* CBLCert.mm in Sources */,
 				9343F07E207D61AB00F19A89 /* CBLCollationExpression.m in Sources */,
+				406F8DFB2C27C303000223FC /* IndexUpdater.swift in Sources */,
 				9343F07F207D61AB00F19A89 /* Index.swift in Sources */,
 				9343F080207D61AB00F19A89 /* Blob.swift in Sources */,
 				1A84E901268560E600C43AF9 /* IndexConfiguration.swift in Sources */,
@@ -6609,6 +6629,7 @@
 				9388CC5121C2514C005CA66D /* FileLogger.swift in Sources */,
 				40FC1C662B928C1600394276 /* VectorIndexConfiguration.swift in Sources */,
 				9343F0A3207D61AB00F19A89 /* CBLReplicator.mm in Sources */,
+				406F8DEC2C26901A000223FC /* QueryIndex.swift in Sources */,
 				40FC1C632B928C1600394276 /* DatabaseEndpoint.swift in Sources */,
 				9343F0A4207D61AB00F19A89 /* CBLMutableDictionary.mm in Sources */,
 				9343F0A5207D61AB00F19A89 /* MutableArrayObject.swift in Sources */,
@@ -6645,18 +6666,19 @@
 				933F841D220BA4100093EC88 /* PredictiveQueryTest+CoreML.m in Sources */,
 				1AA3D78722AB07D70098E16B /* CustomLogger.m in Sources */,
 				9343F13B207D61EC00F19A89 /* CBLTestCase.m in Sources */,
-				AE006DE92B7BB98B00884E2B /* VectorSearchTest.m in Sources */,
 				1A4160DB22836E8C0061A567 /* ReplicatorTest+Main.m in Sources */,
 				930C7F9220FE4F7500C74A12 /* CBLMockConnectionErrorLogic.m in Sources */,
 				1AA6744B227924120018CC6D /* QueryTest+Join.m in Sources */,
 				934EF8312460D0770053A47C /* TLSIdentityTest.m in Sources */,
 				9343F13C207D61EC00F19A89 /* DatabaseTest.m in Sources */,
 				1ABA63B028813A8C005835E7 /* ReplicatorTest+Collection.m in Sources */,
+				40AA72962C28938E007FB1E0 /* VectorSearchTest.m in Sources */,
 				1AA6744A227924120018CC6D /* QueryTest+Meta.m in Sources */,
 				AE006DE42B7BB22000884E2B /* CBLWordEmbeddingModel.m in Sources */,
 				1A621D7A2887DCFD0017F905 /* QueryTest+Collection.m in Sources */,
 				93EB25CC21CDD12A0006FB88 /* PredictiveQueryTest.m in Sources */,
 				1AF555D422948BD90077DF6D /* QueryTest+Main.m in Sources */,
+				40AA729D2C28B1A3007FB1E0 /* LazyVectorIndexTest.m in Sources */,
 				9343F13D207D61EC00F19A89 /* MigrationTest.m in Sources */,
 				9343F13E207D61EC00F19A89 /* DocumentTest.m in Sources */,
 				9343F140207D61EC00F19A89 /* DictionaryTest.m in Sources */,
@@ -6699,6 +6721,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				40AA72952C28938D007FB1E0 /* VectorSearchTest.m in Sources */,
 				9343F173207D633300F19A89 /* ReplicatorTest.m in Sources */,
 				1AF555D622948BE00077DF6D /* QueryTest+Main.m in Sources */,
 				1ABA63B128813A8D005835E7 /* ReplicatorTest+Collection.m in Sources */,
@@ -6708,8 +6731,8 @@
 				9343F175207D633300F19A89 /* DatabaseTest.m in Sources */,
 				1AA6744C227924130018CC6D /* QueryTest+Meta.m in Sources */,
 				934EF8322460D07B0053A47C /* TLSIdentityTest.m in Sources */,
-				AE006DEA2B7BB98B00884E2B /* VectorSearchTest.m in Sources */,
 				9369A6AF207DD105009B5B83 /* DatabaseEncryptionTest.m in Sources */,
+				40AA729E2C28B1A3007FB1E0 /* LazyVectorIndexTest.m in Sources */,
 				9343F176207D633300F19A89 /* DocumentTest.m in Sources */,
 				1A13DD4228B882A800BC1084 /* URLEndpointListenerTest+Main.m in Sources */,
 				9388CBAE21BD9187005CA66D /* DocumentExpirationTest.m in Sources */,
@@ -6771,6 +6794,7 @@
 				9343F198207D636300F19A89 /* CBLTestCase.swift in Sources */,
 				93C50EB021BDFC7B00C7E980 /* DocumentExpirationTest.swift in Sources */,
 				9369A6B7207DEB60009B5B83 /* DatabaseEncryptionTest.swift in Sources */,
+				406F8DFF2C27F0A9000223FC /* LazyVectorIndexTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Objective-C/CBLArray.h
+++ b/Objective-C/CBLArray.h
@@ -35,11 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*
  Gets value at the given index. The object types are CBLBlob,
- CBLArray, CBLDictionary, NSNumber, or NSString based on the underlying
- data type; or nil if the value is nil.
+ CBLArray, CBLDictionary, NSNumber, NSString, or NSNull based on
+ the underlying data type.
  
  @param index The index.
- @return The object or nil.
+ @return The value or nil.
  */
 - (nullable id) valueAtIndex: (NSUInteger)index;
 

--- a/Objective-C/CBLCollection.h
+++ b/Objective-C/CBLCollection.h
@@ -269,17 +269,6 @@ extern NSString* const kCBLDefaultCollectionName;
                                                    queue: (nullable dispatch_queue_t)queue
                                                 listener: (void (^)(CBLDocumentChange*))listener;
 
-
-/**
- Get a query index object by name.
-
- @param name The index name.
- @param error On return, the error if any.
- @return CBLQueryIndex object if index exists. If not, it will return nil.
- */
-- (nullable CBLQueryIndex*) indexWithName: (NSString*)name
-                                    error: (NSError**)error;
-
 #pragma mark -
 
 /** Not available */

--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -966,7 +966,9 @@ static void colObserverCallback(C4CollectionObserver* obs, void* context) {
         C4Index* c4index = c4coll_getIndex(_c4col, iName, &c4err);
         if (!c4index) {
             if (c4err.code != 0){
-                convertError(c4err, error);
+                if (c4err.domain != LiteCoreDomain || c4err.code != kC4ErrorMissingIndex) {
+                    convertError(c4err, error);
+                }
             }
             return nil;
         }

--- a/Objective-C/CBLDictionary.h
+++ b/Objective-C/CBLDictionary.h
@@ -43,12 +43,12 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Type Setters
 
 /**
- Gets a property's value. The object types are CBLBlob, CBLArray,
- CBLDictionary, NSNumber, or NSString based on the underlying data type; or nil if the
- property value is NSNull or the property doesn't exist.
+ Gets a property's value. The object types are CBLBlob, CBLArray, CBLDictionary,
+ NSNumber, NSString, or NSNull based on the underlying data type; or nil if the
+ the property doesn't exist.
  
  @param key The key.
- @return The object value or nil.
+ @return The value or nil.
  */
 - (nullable id) valueForKey: (NSString*)key;
 

--- a/Objective-C/CBLIndexable.h
+++ b/Objective-C/CBLIndexable.h
@@ -19,6 +19,7 @@
 
 #import <CouchbaseLite/CBLIndexConfiguration.h>
 #import <CouchbaseLite/CBLIndex.h>
+#import <CouchbaseLite/CBLQueryIndex.h>
 
 NS_ASSUME_NONNULL_BEGIN
 /** The Indexable interface defines a set of functions for managing the query indexes. */
@@ -37,6 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Delete an index by name. */
 - (BOOL) deleteIndexWithName: (NSString*)name error: (NSError**)error;
+
+/** Get an index object by name. */
+- (nullable CBLQueryIndex*) indexWithName: (NSString*)name
+                                    error: (NSError**)error NS_SWIFT_NOTHROW;
 
 @end
 

--- a/Objective-C/CBLQueryIndex.h
+++ b/Objective-C/CBLQueryIndex.h
@@ -25,20 +25,16 @@
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
-/**
- QueryIndex object representing an existing index in the collection.
- */
 
+/**
+ CBLQueryIndex object representing an existing index in the collection.
+ */
 @interface CBLQueryIndex : NSObject
 
-/**
- The collection object.
- */
+/** The collection. */
 @property (readonly, nonatomic) CBLCollection* collection;
 
-/**
- The index name.
- */
+/** The index name. */
 @property (readonly, nonatomic) NSString* name;
 
 #ifdef COUCHBASE_ENTERPRISE
@@ -47,18 +43,18 @@ NS_ASSUME_NONNULL_BEGIN
 
  For updating lazy vector indexes only.
  Finds new or updated documents for which vectors need to be (re)computed and
- return an IndexUpdater object used for setting the computed vectors for updating the index.
+ return a CBLIndexUpdater object used for setting the computed vectors for updating the index.
  The limit parameter is for setting the max number of vectors to be computed.
  
  If index is up-to-date, nil will be returned.
  If the index is not lazy, an error will be returned.
  
- @param limit The limit per update..
+ @param limit The limit per update.
  @param error On return, the error if any.
  @return CBLIndexUpdater object if there are updates to be done, or nil if the index is up-to-date or if an error occurred.
  */
 - (nullable CBLIndexUpdater*) beginUpdateWithLimit: (uint64_t)limit
-                                             error: (NSError**)error;
+                                             error: (NSError**)error NS_SWIFT_NOTHROW;
 #endif
 
 /** Not available */

--- a/Objective-C/CBLQueryIndex.mm
+++ b/Objective-C/CBLQueryIndex.mm
@@ -55,6 +55,10 @@
 
 - (nullable CBLIndexUpdater*) beginUpdateWithLimit: (uint64_t)limit
                                              error: (NSError**)error {
+    if (limit == 0) {
+        [NSException raise: NSInvalidArgumentException format: @"limit must be > 0"];
+    }
+    
     CBL_LOCK(_mutex){
         C4Error c4err = {};
         C4IndexUpdater* _c4updater = c4index_beginUpdate(_c4index, (size_t)limit, &c4err);

--- a/Objective-C/Exports/CBL.txt
+++ b/Objective-C/Exports/CBL.txt
@@ -62,6 +62,7 @@
 .objc_class_name_CBLQueryFullTextExpression
 .objc_class_name_CBLQueryFullTextFunction
 .objc_class_name_CBLQueryFunction
+.objc_class_name_CBLQueryIndex
 .objc_class_name_CBLQueryJoin
 .objc_class_name_CBLQueryLimit
 .objc_class_name_CBLQueryMeta

--- a/Objective-C/Exports/CBL_EE.txt
+++ b/Objective-C/Exports/CBL_EE.txt
@@ -23,6 +23,7 @@
 .objc_class_name_CBLClientCertificateAuthenticator
 .objc_class_name_CBLDatabaseEndpoint
 .objc_class_name_CBLEncryptionKey
+.objc_class_name_CBLIndexUpdater
 .objc_class_name_CBLListenerCertificateAuthenticator
 .objc_class_name_CBLListenerPasswordAuthenticator
 .objc_class_name_CBLMessage

--- a/Objective-C/Exports/Generated/CBL.exp
+++ b/Objective-C/Exports/Generated/CBL.exp
@@ -43,6 +43,7 @@
 .objc_class_name_CBLQueryFullTextExpression
 .objc_class_name_CBLQueryFullTextFunction
 .objc_class_name_CBLQueryFunction
+.objc_class_name_CBLQueryIndex
 .objc_class_name_CBLQueryJoin
 .objc_class_name_CBLQueryLimit
 .objc_class_name_CBLQueryMeta

--- a/Objective-C/Exports/Generated/CBL_EE.exp
+++ b/Objective-C/Exports/Generated/CBL_EE.exp
@@ -30,6 +30,7 @@
 .objc_class_name_CBLIndex
 .objc_class_name_CBLIndexBuilder
 .objc_class_name_CBLIndexConfiguration
+.objc_class_name_CBLIndexUpdater
 .objc_class_name_CBLListenerCertificateAuthenticator
 .objc_class_name_CBLListenerPasswordAuthenticator
 .objc_class_name_CBLLog
@@ -57,6 +58,7 @@
 .objc_class_name_CBLQueryFullTextExpression
 .objc_class_name_CBLQueryFullTextFunction
 .objc_class_name_CBLQueryFunction
+.objc_class_name_CBLQueryIndex
 .objc_class_name_CBLQueryJoin
 .objc_class_name_CBLQueryLimit
 .objc_class_name_CBLQueryMeta

--- a/Objective-C/Tests/CollectionTest.m
+++ b/Objective-C/Tests/CollectionTest.m
@@ -950,7 +950,10 @@
         return [col createIndexWithName: @"index2" config: config2 error: err];
     }];
     
-    // get indexes, delete index
+    // get index, get indexes, delete index
+    [self expectError: CBLErrorDomain code: CBLErrorNotOpen in: ^BOOL(NSError** err) {
+        return [col indexWithName: @"index1" error: err];
+    }];
     [self expectError: CBLErrorDomain code: CBLErrorNotOpen in: ^BOOL(NSError** err) {
         return [col indexes: err] != nil;
     }];

--- a/Objective-C/Tests/LazyVectorIndexTest.m
+++ b/Objective-C/Tests/LazyVectorIndexTest.m
@@ -1,0 +1,1272 @@
+//
+//  LazyVectorIndexTest.m
+//  CouchbaseLite
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+#import "VectorSearchTest.h"
+#import "CBLJSON.h"
+
+/**
+ * Test Spec: https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0002-Lazy-Vector-Index.md
+ *
+ *  Test 6. TestGetIndexOnClosedDatabase is tested in CollectionTest
+ *  Test 7. TestGetIndexOnDeletedCollection is tested in CollectionTest
+ */
+
+#define LAZY_VECTOR_INDEX_CONFIG(E, D, C) [self lazyVectorIndexConfigWithExpression: (E) dimensions: (D) centroids: (C)]
+
+@interface LazyVectorIndexTest : VectorSearchTest
+
+@end
+
+@implementation LazyVectorIndexTest
+
+- (CBLQueryIndex*) wordsIndex {
+    CBLQueryIndex* index = [self.wordsCollection indexWithName: kWordsIndexName error: nil];
+    AssertNotNil(index);
+    return index;
+}
+
+- (CBLVectorIndexConfiguration*) lazyVectorIndexConfigWithExpression: (NSString*)expression 
+                                                          dimensions: (unsigned int)dimensions
+                                                           centroids: (unsigned int)centroids {
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(expression, dimensions, centroids);
+    config.isLazy = true;
+    return config;
+}
+
+- (nullable NSArray<NSNumber*>*) vectorForWord: (NSString*)word collection: (CBLCollection*)collection {
+    NSError* error;
+    NSString* sql = [NSString stringWithFormat:@"SELECT vector FROM %@ WHERE word = '%@'", collection.name, word];
+    
+    CBLQuery* query = [self.wordDB createQuery: sql error: &error];
+    AssertNotNil(query);
+
+    CBLQueryResultSet* rs = [query execute: &error];
+    AssertNotNil(rs);
+
+    NSArray<NSNumber*>* vector;
+    CBLQueryResult *result = [rs nextObject];
+    if (result) {
+        id value = [result arrayAtIndex: 0];
+        if (value) {
+            vector = (NSArray<NSNumber*>*)value;
+        }
+    }
+    return vector;
+}
+
+- (nullable NSArray<NSNumber*>*) vectorForWord: (NSString*)word {
+    NSArray<NSNumber*>* results = [self vectorForWord: word collection: self.wordsCollection];
+    if (!results) {
+        results = [self vectorForWord: word collection: self.extWordsCollection];
+    }
+    AssertNotNil(results);
+    return results;
+}
+
+/**
+ * 1. TestIsLazyDefaultValue
+ * Description
+ *     Test that isLazy property is false by default.
+ * Steps
+ *     1. Create a VectorIndexConfiguration object.
+ *         - expression: "vector"
+ *         - dimensions: 300
+ *         - centroids: 20
+ *     2.  Check that isLazy returns false.
+ */
+- (void) testIsLazyDefaultValue {
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    AssertEqual(config.isLazy, false);
+}
+
+/**
+ * 2. TestIsLazyAccessor
+ *
+ * Description
+ * Test that isLazy getter/setter of the VectorIndexConfiguration work as expected.
+ *
+ * Steps
+ * 1. Create a VectorIndexConfiguration object.
+ *    - expression: word
+ *    - dimensions: 300
+ *    - centroids : 20
+ * 2. Set isLazy to true
+ * 3. Check that isLazy returns true.
+ */
+- (void) testIsLazyAccessor {
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    config.isLazy = true;
+    AssertEqual(config.isLazy, true);
+}
+
+/**
+ * 3. TestGetNonExistingIndex
+ *
+ * Description
+ * Test that getting non-existing index object by name returning null.
+ *
+ * Steps
+ * 1. Get the default collection from a test database.
+ * 2. Get a QueryIndex object from the default collection with the name as
+ *   "nonexistingindex".
+ * 3. Check that the result is null.
+ */
+- (void) testGetNonExistingIndex {
+    NSError* error;
+    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
+    AssertNil([defaultCollection indexWithName: @"nonexistingindex" error: &error]);
+    AssertEqual(error.code, 0);
+}
+
+/**
+ * 4. TestGetExistingNonVectorIndex
+ *
+ * Description
+ * Test that getting non-existing index object by name returning an index object correctly.
+ *
+ * Steps
+ * 1. Get the default collection from a test database.
+ * 2. Create a value index named "value_index" in the default collection
+ *   with the expression as "value".
+ * 3. Get a QueryIndex object from the default collection with the name as
+ *   "value_index".
+ * 4. Check that the result is not null.
+ * 5. Check that the QueryIndex's name is "value_index".
+ * 6. Check that the QueryIndex's collection is the same instance that
+ *   is used for getting the QueryIndex object.
+ */
+- (void) testGetExistingNonVectorIndex {
+    NSError* error;
+    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
+    
+    CBLValueIndexItem* item = [CBLValueIndexItem expression:
+                               [CBLQueryExpression property: @"value"]];
+    CBLValueIndex* vIndex = [CBLIndexBuilder valueIndexWithItems: @[item]];
+    [defaultCollection createIndex: vIndex name: @"value_index" error: &error];
+    AssertNil(error);
+    
+    CBLQueryIndex* qIndex = [defaultCollection indexWithName: @"value_index" error: &error];
+    AssertEqual(qIndex.name, @"value_index");
+    AssertEqual(qIndex.collection, defaultCollection);
+}
+
+/**
+ * 5. TestGetExistingVectorIndex
+ *
+ * Description
+ * Test that getting an existing index object by name returning an index object correctly.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "vector"
+ *     - dimensions: 300
+ *     - centroids : 8
+ * 3. Get a QueryIndex object from the words collection with the name as "words_index".
+ * 4. Check that the result is not null.
+ * 5. Check that the QueryIndex's name is "words_index".
+ * 6. Check that the QueryIndex's collection is the same instance that is used for
+ *   getting the index.
+ */
+- (void) testGetExistingVectorIndex {
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(@"vector", 300, 8)];
+    
+    CBLQueryIndex* index = [self wordsIndex];
+    AssertEqual(index.name, @"words_index");
+    AssertEqual(index.collection, self.wordsCollection);
+}
+
+/**
+ * 8. TestLazyVectorIndexNotAutoUpdatedChangedDocs
+ *
+ * Description
+ * Test that the lazy index is lazy. The index will not be automatically
+ * updated when the documents are created or updated.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Create an SQL++ query:
+ *     - SELECT word
+ *       FROM _default.words
+ *       WHERE vector_match(words_index, < dinner vector >)
+ * 4. Execute the query and check that 0 results are returned.
+ * 5. Update the documents:
+ *     - Create _default.words.word301 with the content from _default.extwords.word1
+ *     - Update _default.words.word1 with the content from _default.extwords.word3
+ * 6. Execute the same query and check that 0 results are returned.
+ */
+- (void) testLazyVectorIndexNotAutoUpdatedChangedDocs {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    CBLQueryResultSet* rs = [self executeWordsQueryNoTrainingCheckWithLimit: nil];
+    AssertEqual(rs.allObjects.count, 0);
+    
+    // Update docs:
+    NSError* error;
+    CBLDocument* extWord1 = [self.extWordsCollection documentWithID: @"word1" error : &error];
+    CBLMutableDocument* word301 = [self createDocument: @"word301" data: [extWord1 toDictionary]];
+    Assert([self.wordsCollection saveDocument: word301 error: &error]);
+    
+    CBLDocument* extWord3 = [self.extWordsCollection documentWithID: @"word3" error : &error];
+    CBLMutableDocument* word1 = [[self.wordsCollection documentWithID: @"word1" error: &error] toMutable];
+    [word1 setData: [extWord3 toDictionary]];
+    Assert([self.wordsCollection saveDocument: word1 error: &error]);
+    
+    rs = [self executeWordsQueryNoTrainingCheckWithLimit: nil];
+    AssertEqual(rs.allObjects.count, 0);
+}
+
+/**
+ * 9. TestLazyVectorIndexAutoUpdateDeletedDocs
+ *
+ * Description
+ * Test that when the lazy vector index automatically update when documents are
+ * deleted.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Call beginUpdate() with limit 1 to get an IndexUpdater object.
+ * 4. Check that the IndexUpdater is not null and IndexUpdater.count = 1.
+ * 5. With the IndexUpdater object:
+ *    - Get the word string from the IndexUpdater.
+ *    - Query the vector by word from the _default.words collection.
+ *    - Convert the vector result which is an array object to a platform's float array.
+ *    - Call setVector() with the platform's float array at the index.
+ *    - Call finish()
+ * 6. Create an SQL++ query:
+ *    - SELECT word
+ *      FROM _default.words
+ *      WHERE vector_match(words_index, < dinner vector >, 300)
+ * 7. Execute the query and check that 1 results are returned.
+ * 8. Check that the word gotten from the query result is the same as the word in Step 5.
+ * 9. Delete _default.words.word1 doc.
+ * 10. Execute the same query as Step again and check that 0 results are returned.
+ */
+- (void) testLazyVectorIndexAutoUpdateDeletedDocs {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 1 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 1);
+    
+    // Update Index:
+    NSString* word = [updater stringAtIndex: 0];
+    NSArray<NSNumber*>* vector = [self vectorForWord: word];
+    [updater setVector: vector atIndex: 0 error: &error];
+    [updater finishWithError: &error];
+    AssertNil(error);
+    
+    // Query:
+    CBLQueryResultSet* rs = [self executeWordsQueryNoTrainingCheckWithLimit: @300];
+    AssertEqual(rs.allObjects.count, 1);
+    
+    // Delete doc and requery:
+    [self.wordsCollection deleteDocument: [self.wordsCollection documentWithID: @"word1" error: &error] error: &error];
+    rs = [self executeWordsQueryNoTrainingCheckWithLimit: @300];
+    AssertEqual(rs.allObjects.count, 0);
+}
+
+/**
+ * 10. TestLazyVectorIndexAutoUpdatePurgedDocs
+ *
+ * Description
+ * Test that when the lazy vector index automatically update when documents are
+ * purged.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Call beginUpdate() with limit 1 to get an IndexUpdater object.
+ * 4. Check that the IndexUpdater is not null and IndexUpdater.count = 1.
+ * 5. With the IndexUpdater object:
+ *    - Get the word string from the IndexUpdater.
+ *    - Query the vector by word from the _default.words collection.
+ *    - Convert the vector result which is an array object to a platform's float array.
+ *    - Call setVector() with the platform's float array at the index.
+ * 6. With the IndexUpdater object, call finish()
+ * 7. Create an SQL++ query:
+ *    - SELECT word
+ *      FROM _default.words
+ *      WHERE vector_match(words_index, < dinner vector >, 300)
+ * 8. Execute the query and check that 1 results are returned.
+ * 9. Check that the word gotten from the query result is the same as the word in Step 5.
+ * 10. Purge _default.words.word1 doc.
+ * 11. Execute the same query as Step again and check that 0 results are returned.
+ */
+- (void) testLazyVectorIndexAutoUpdatePurgedDocs {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 1 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 1);
+    
+    // Update Index:
+    NSString* word = [updater stringAtIndex: 0];
+    NSArray<NSNumber*>* vector = [self vectorForWord: word];
+    [updater setVector: vector atIndex: 0 error: &error];
+    [updater finishWithError: &error];
+    AssertNil(error);
+    
+    // Query:
+    CBLQueryResultSet* rs = [self executeWordsQueryNoTrainingCheckWithLimit: @300];
+    AssertEqual(rs.allObjects.count, 1);
+    
+    // Delete doc and requery:
+    [self.wordsCollection purgeDocumentWithID: @"word1" error: &error];
+    rs = [self executeWordsQueryNoTrainingCheckWithLimit: @300];
+    AssertEqual(rs.allObjects.count, 0);
+}
+
+/**
+ * 11. TestIndexUpdaterBeginUpdateOnNonVectorIndex
+ *
+ * Description
+ * Test that a CouchbaseLiteException is thrown when calling beginUpdate on
+ * a non vector index.
+ *
+ * Steps
+ * 1. Get the default collection from a test database.
+ * 2. Create a value index named "value_index" in the default collection with the
+ *   expression as "value".
+ * 3. Get a QueryIndex object from the default collection with the name as
+ *   "value_index".
+ * 4. Call beginUpdate() with limit 10 on the QueryIndex object.
+ * 5. Check that a CouchbaseLiteException with the code Unsupported is thrown.
+ */
+- (void) testIndexUpdaterBeginUpdateOnNonVectorIndex {
+    NSError* error;
+    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
+    AssertNil(error);
+    
+    CBLValueIndexItem* item = [CBLValueIndexItem expression:
+                               [CBLQueryExpression property: @"value"]];
+    CBLValueIndex* vIndex = [CBLIndexBuilder valueIndexWithItems: @[item]];
+    [defaultCollection createIndex: vIndex name: @"value_index" error: &error];
+    
+    AssertNil(error);
+    
+    CBLQueryIndex* qIndex = [defaultCollection indexWithName: @"value_index" error: &error];
+    
+    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
+        return [qIndex beginUpdateWithLimit: 10 error: err] != nil;
+    }];
+}
+
+/**
+ * 12. TestIndexUpdaterBeginUpdateOnNonLazyVectorIndex
+ *
+ * Description
+ * Test that a CouchbaseLiteException is thrown when calling beginUpdate
+ * on a non lazy vector index.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ * 3. Get a QueryIndex object from the words collection with the name as
+ *   "words_index".
+ * 4. Call beginUpdate() with limit 10 on the QueryIndex object.
+ * 5. Check that a CouchbaseLiteException with the code Unsupported is thrown.
+ */
+- (void) testIndexUpdaterBeginUpdateOnNonLazyVectorIndex {
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(@"vector", 300, 8)];
+    
+    CBLQueryIndex* index = [self wordsIndex];
+    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
+        return [index beginUpdateWithLimit: 10 error: err] != nil;
+    }];
+}
+
+/**
+ * 13. TestIndexUpdaterBeginUpdateWithZeroLimit
+ *
+ * Description
+ * Test that an InvalidArgument exception is returned when calling beginUpdate
+ * with zero limit.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Get a QueryIndex object from the words collec
+ *    "words_index".
+ * 4. Call beginUpdate() with limit 0 on the QueryIndex object.
+ * 5. Check that an InvalidArgumentException is thrown.
+ */
+- (void) testIndexUpdaterBeginUpdateWithZeroLimit {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    CBLQueryIndex* index = [self wordsIndex];
+    
+    [self expectException: @"NSInvalidArgumentException" in: ^{
+        [index beginUpdateWithLimit: 0 error: nil];
+    }];
+}
+
+/**
+ * 14. TestIndexUpdaterBeginUpdateOnLazyVectorIndex
+ *
+ * Description
+ * Test that calling beginUpdate on a lazy vector index returns an IndexUpdater.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Get a QueryIndex object from the words with the name as "words_index".
+ * 4. Call beginUpdate() with limit 10 on the QueryIndex object.
+ * 5. Check that the returned IndexUpdater is not null.
+ * 6. Check that the IndexUpdater.count is 10.
+ */
+- (void) testIndexUpdaterBeginUpdateOnLazyVectorIndex {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 10 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 10);
+}
+
+/**
+ * 15. TestIndexUpdaterGettingValues
+ *
+ * Description
+ * Test all type getters and toArary() from the Array interface. The test
+ * may be divided this test into multiple tests per type getter as appropriate.
+ *
+ * Steps
+ * 1. Get the default collection from a test database.
+ * 2. Create the followings documents:
+ *     - doc-0 : { "value": "a string" }
+ *     - doc-1 : { "value": 100 }
+ *     - doc-2 : { "value": 20.8 }
+ *     - doc-3 : { "value": true }
+ *     - doc-4 : { "value": false }
+ *     - doc-5 : { "value": Date("2024-05-10T00:00:00.000Z") }
+ *     - doc-6 : { "value": Blob(Data("I'm Bob")) }
+ *     - doc-7 : { "value": {"name": "Bob"} }
+ *     - doc-8 : { "value": ["one", "two", "three"] }
+ *     - doc-9 : { "value": null }
+ * 3. Create a vector index named "vector_index" in the default collection.
+ *     - expression: "value"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 4. Get a QueryIndex object from the default collection with the name as
+ *    "vector_index".
+ * 5. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+ * 6. Check that the IndexUpdater.count is 10.
+ * 7. Get string value from each index and check the followings:
+ *     - getString(0) : value == "a string"
+ *     - getString(1) : value == null
+ *     - getString(2) : value == null
+ *     - getString(3) : value == null
+ *     - getString(4) : value == null
+ *     - getString(5) : value == "2024-05-10T00:00:00.000Z"
+ *     - getString(6) : value == null
+ *     - getString(7) : value == null
+ *     - getString(8) : value == null
+ *     - getString(9) : value == null
+ * 8. Get integer value from each index and check the followings:
+ *     - getInt(0) : value == 0
+ *     - getInt(1) : value == 100
+ *     - getInt(2) : value == 20
+ *     - getInt(3) : value == 1
+ *     - getInt(4) : value == 0
+ *     - getInt(5) : value == 0
+ *     - getInt(6) : value == 0
+ *     - getInt(7) : value == 0
+ *     - getInt(8) : value == 0
+ *     - getInt(9) : value == 0
+ * 9. Get float value from each index and check the followings:
+ *     - getFloat(0) : value == 0.0
+ *     - getFloat(1) : value == 100.0
+ *     - getFloat(2) : value == 20.8
+ *     - getFloat(3) : value == 1.0
+ *     - getFloat(4) : value == 0.0
+ *     - getFloat(5) : value == 0.0
+ *     - getFloat(6) : value == 0.0
+ *     - getFloat(7) : value == 0.0
+ *     - getFloat(8) : value == 0.0
+ *     - getFloat(9) : value == 0.0
+ * 10. Get double value from each index and check the followings:
+ *     - getDouble(0) : value == 0.0
+ *     - getDouble(1) : value == 100.0
+ *     - getDouble(2) : value == 20.8
+ *     - getDouble(3) : value == 1.0
+ *     - getDouble(4) : value == 0.0
+ *     - getDouble(5) : value == 0.0
+ *     - getDouble(6) : value == 0.0
+ *     - getDouble(7) : value == 0.0
+ *     - getDouble(8) : value == 0.0
+ *     - getDouble(9) : value == 0.0
+ * 11. Get boolean value from each index and check the followings:
+ *     - getBoolean(0) : value == true
+ *     - getBoolean(1) : value == true
+ *     - getBoolean(2) : value == true
+ *     - getBoolean(3) : value == true
+ *     - getBoolean(4) : value == false
+ *     - getBoolean(5) : value == true
+ *     - getBoolean(6) : value == true
+ *     - getBoolean(7) : value == true
+ *     - getBoolean(8) : value == true
+ *     - getBoolean(9) : value == false
+ * 12. Get date value from each index and check the followings:
+ *     - getDate(0) : value == "2024-05-10T00:00:00.000Z"
+ *     - getDate(1) : value == null
+ *     - getDate(2) : value == null
+ *     - getDate(3) : value == null
+ *     - getDate(4) : value == null
+ *     - getDate(5) : value == Date("2024-05-10T00:00:00.000Z")
+ *     - getDate(6) : value == null
+ *     - getDate(7) : value == null
+ *     - getDate(8) : value == null
+ *     - getDate(9) : value == null
+ * 13. Get blob value from each index and check the followings:
+ *     - getBlob(0) : value == null
+ *     - getBlob(1) : value == null
+ *     - getBlob(2) : value == null
+ *     - getBlob(3) : value == null
+ *     - getBlob(4) : value == null
+ *     - getBlob(5) : value == null
+ *     - getBlob(6) : value == Blob(Data("I'm Bob"))
+ *     - getBlob(7) : value == null
+ *     - getBlob(8) : value == null
+ *     - getBlob(9) : value == null
+ * 14. Get dictionary object from each index and check the followings:
+ *     - getDictionary(0) : value == null
+ *     - getDictionary(1) : value == null
+ *     - getDictionary(2) : value == null
+ *     - getDictionary(3) : value == null
+ *     - getDictionary(4) : value == null
+ *     - getDictionary(5) : value == null
+ *     - getDictionary(6) : value == null
+ *     - getDictionary(7) : value == Dictionary({"name": "Bob"})
+ *     - getDictionary(8) : value == null
+ *     - getDictionary(9) : value == null
+ * 15. Get array object from each index and check the followings:
+ *     - getArray(0) : value == null
+ *     - getArray(1) : value == null
+ *     - getArray(2) : value == null
+ *     - getArray(3) : value == null
+ *     - getArray(4) : value == null
+ *     - getArray(5) : value == null
+ *     - getArray(6) : value == null
+ *     - getArray(7) : value == null
+ *     - getArray(8) : value == Array(["one", "two", "three"])
+ *     - getArray(9) : value == null
+ * 16. Get value from each index and check the followings:
+ *     - getValue(0) : value == "a string"
+ *     - getValue(1) : value == PlatformNumber(100)
+ *     - getValue(2) : value == PlatformNumber(20.8)
+ *     - getValue(3) : value == PlatformBoolean(true)
+ *     - getValue(4) : value == PlatformBoolean(false)
+ *     - getValue(5) : value == Date("2024-05-10T00:00:00.000Z")
+ *     - getValue(6) : value == Blob(Data("I'm Bob"))
+ *     - getValue(7) : value == Dictionary({"name": "Bob"})
+ *     - getValue(8) : value == Array(["one", "two", "three"])
+ *     - getValue(9) : value == null
+ * 17. Get IndexUodater values as a platform array by calling toArray() and check
+ *     that the array contains all values as expected.
+ */
+- (void) testIndexUpdaterGettingValues {
+    NSError* error;
+    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
+    
+    CBLMutableDocument* mdoc = [self createDocument: @"doc-0"];
+    [mdoc setValue: @"a string" forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-1"];
+    [mdoc setValue: @(100) forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-2"];
+    [mdoc setValue: @(20.8) forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-3"];
+    [mdoc setValue: @(true) forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-4"];
+    [mdoc setValue: @(false) forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-5"];
+    [mdoc setValue: [CBLJSON dateWithJSONObject: @"2024-05-10T00:00:00.000Z"] forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-6"];
+    NSData* content = [@"I'm Blob" dataUsingEncoding: NSUTF8StringEncoding];
+    CBLBlob* blob = [[CBLBlob alloc] initWithContentType:@"text/plain" data: content];
+    [mdoc setValue: blob forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-7"];
+    CBLMutableDictionary* dict = [[CBLMutableDictionary alloc] init];
+    [dict setValue: @"Bob" forKey: @"name"];
+    [mdoc setValue: dict forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-8"];
+    CBLMutableArray* array = [[CBLMutableArray alloc] init];
+    [array addValue: @"one"];
+    [array addValue: @"two"];
+    [array addValue: @"three"];
+    [mdoc setValue: array forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    mdoc = [self createDocument: @"doc-9"];
+    [mdoc setValue: [NSNull null] forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    // Create index
+    [self createVectorIndexInCollection: defaultCollection
+                                   name: @"vector_index"
+                                 config: LAZY_VECTOR_INDEX_CONFIG(@"value", 300, 8)];
+    
+    CBLQueryIndex* index = [defaultCollection indexWithName: @"vector_index" error: &error];
+    AssertNotNil(index);
+    
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 10 error: &error];
+    AssertEqual(updater.count, 10);
+    
+    // String getter
+    Assert([[updater stringAtIndex: 0] isEqual: @"a string"]);
+    AssertEqual([updater stringAtIndex: 1], nil);
+    AssertEqual([updater stringAtIndex: 2], nil);
+    AssertEqual([updater stringAtIndex: 3], nil);
+    AssertEqual([updater stringAtIndex: 4], nil);
+    Assert([[updater stringAtIndex: 5] isEqual: @"2024-05-10T00:00:00.000Z"]);
+    AssertEqual([updater stringAtIndex: 6], nil);
+    AssertEqual([updater stringAtIndex: 7], nil);
+    AssertEqual([updater stringAtIndex: 8], nil);
+    AssertEqual([updater stringAtIndex: 9], nil);
+    
+    // Int getter
+    AssertEqual([updater integerAtIndex: 0], 0);
+    AssertEqual([updater integerAtIndex: 1], 100);
+    AssertEqual([updater integerAtIndex: 2], 20);
+    AssertEqual([updater integerAtIndex: 3], 1);
+    AssertEqual([updater integerAtIndex: 4], 0);
+    AssertEqual([updater integerAtIndex: 5], 0);
+    AssertEqual([updater integerAtIndex: 6], 0);
+    AssertEqual([updater integerAtIndex: 7], 0);
+    AssertEqual([updater integerAtIndex: 8], 0);
+    AssertEqual([updater integerAtIndex: 9], 0);
+    
+    // Float getter
+    AssertEqual([updater floatAtIndex: 0], 0.0);
+    AssertEqual([updater floatAtIndex: 1], 100.0);
+    AssertEqual([updater floatAtIndex: 2], (float)20.8);
+    AssertEqual([updater floatAtIndex: 3], 1.0);
+    AssertEqual([updater floatAtIndex: 4], 0.0);
+    AssertEqual([updater floatAtIndex: 5], 0.0);
+    AssertEqual([updater floatAtIndex: 6], 0.0);
+    AssertEqual([updater floatAtIndex: 7], 0.0);
+    AssertEqual([updater floatAtIndex: 8], 0.0);
+    AssertEqual([updater floatAtIndex: 9], 0.0);
+    
+    // Double getter
+    AssertEqual([updater doubleAtIndex: 0], 0.0);
+    AssertEqual([updater doubleAtIndex: 1], 100.0);
+    AssertEqual([updater doubleAtIndex: 2], 20.8);
+    AssertEqual([updater doubleAtIndex: 3], 1.0);
+    AssertEqual([updater doubleAtIndex: 4], 0.0);
+    AssertEqual([updater doubleAtIndex: 5], 0.0);
+    AssertEqual([updater doubleAtIndex: 6], 0.0);
+    AssertEqual([updater doubleAtIndex: 7], 0.0);
+    AssertEqual([updater doubleAtIndex: 8], 0.0);
+    AssertEqual([updater doubleAtIndex: 9], 0.0);
+    
+    // Boolean getter
+    AssertEqual([updater booleanAtIndex: 0], true);
+    AssertEqual([updater booleanAtIndex: 1], true);
+    AssertEqual([updater booleanAtIndex: 2], true);
+    AssertEqual([updater booleanAtIndex: 3], true);
+    AssertEqual([updater booleanAtIndex: 4], false);
+    AssertEqual([updater booleanAtIndex: 5], true);
+    AssertEqual([updater booleanAtIndex: 6], true);
+    AssertEqual([updater booleanAtIndex: 7], true);
+    AssertEqual([updater booleanAtIndex: 8], true);
+    AssertEqual([updater booleanAtIndex: 9], false);
+    
+    // Date getter
+    AssertEqual([updater dateAtIndex: 0], nil);
+    AssertEqual([updater dateAtIndex: 1], nil);
+    AssertEqual([updater dateAtIndex: 2], nil);
+    AssertEqual([updater dateAtIndex: 3], nil);
+    AssertEqual([updater dateAtIndex: 4], nil);
+    Assert([[updater dateAtIndex: 5] isEqual: [CBLJSON dateWithJSONObject: @"2024-05-10T00:00:00.000Z"]]);
+    AssertEqual([updater dateAtIndex: 6], nil);
+    AssertEqual([updater dateAtIndex: 7], nil);
+    AssertEqual([updater dateAtIndex: 8], nil);
+    AssertEqual([updater dateAtIndex: 9], nil);
+    
+    // Blob getter
+    AssertEqual([updater blobAtIndex: 0], nil);
+    AssertEqual([updater blobAtIndex: 1], nil);
+    AssertEqual([updater blobAtIndex: 2], nil);
+    AssertEqual([updater blobAtIndex: 3], nil);
+    AssertEqual([updater blobAtIndex: 4], nil);
+    AssertEqual([updater blobAtIndex: 5], nil);
+    Assert([[updater blobAtIndex: 6] isEqual: blob]);
+    AssertEqual([updater blobAtIndex: 7], nil);
+    AssertEqual([updater blobAtIndex: 8], nil);
+    AssertEqual([updater blobAtIndex: 9], nil);
+    
+    // Dict getter
+    AssertEqual([updater dictionaryAtIndex: 0], nil);
+    AssertEqual([updater dictionaryAtIndex: 1], nil);
+    AssertEqual([updater dictionaryAtIndex: 2], nil);
+    AssertEqual([updater dictionaryAtIndex: 3], nil);
+    AssertEqual([updater dictionaryAtIndex: 4], nil);
+    AssertEqual([updater dictionaryAtIndex: 5], nil);
+    AssertEqual([updater dictionaryAtIndex: 6], nil);
+    Assert([[updater dictionaryAtIndex: 7] isEqual: dict]);
+    AssertEqual([updater dictionaryAtIndex: 8], nil);
+    AssertEqual([updater dictionaryAtIndex: 9], nil);
+    
+    // Array getter
+    AssertEqual([updater arrayAtIndex: 0], nil);
+    AssertEqual([updater arrayAtIndex: 1], nil);
+    AssertEqual([updater arrayAtIndex: 2], nil);
+    AssertEqual([updater arrayAtIndex: 3], nil);
+    AssertEqual([updater arrayAtIndex: 4], nil);
+    AssertEqual([updater arrayAtIndex: 5], nil);
+    AssertEqual([updater arrayAtIndex: 6], nil);
+    AssertEqual([updater arrayAtIndex: 7], nil);
+    Assert([[updater arrayAtIndex: 8] isEqual: array]);
+    AssertEqual([updater arrayAtIndex: 9], nil);
+    
+    // Value getter
+    Assert([[updater valueAtIndex: 0] isEqual: @"a string"]);
+    Assert([[updater valueAtIndex: 1] isEqual: @(100)]);
+    Assert([[updater valueAtIndex: 2] isEqual: @(20.8)]);
+    Assert([[updater valueAtIndex: 3] isEqual: @(true)]);
+    Assert([[updater valueAtIndex: 4] isEqual: @(false)]);
+    Assert([[updater valueAtIndex: 5] isEqual: @"2024-05-10T00:00:00.000Z"]);
+    Assert([[updater valueAtIndex: 6] isEqual: blob]);
+    Assert([[updater valueAtIndex: 7] isEqual: dict]);
+    Assert([[updater valueAtIndex: 8] isEqual: array]);
+    Assert([[updater valueAtIndex: 9] isEqual: [NSNull null]]);
+    
+    NSArray* expected = @[@"a string", @(100), @(20.8), @(true), @(false), @"2024-05-10T00:00:00.000Z", blob,
+                           [dict toDictionary], [array toArray], [NSNull null]];
+    NSArray* updaterArray = [updater toArray];
+    for (NSUInteger i = 0; i < expected.count; i++) {
+        AssertEqualObjects(updaterArray[i], expected[i]);
+    }
+}
+
+/**
+ * 17. TestIndexUpdaterSetFloatArrayVectors
+ *
+ * Description
+ * Test that setting float array vectors works as expected.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Get a QueryIndex object from the words with the name as "words_index".
+ * 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+ * 5. With the IndexUpdater object, for each index from 0 to 9.
+ *     - Get the word string from the IndexUpdater and store the word string in a set for verifying
+ *        the vector search result.
+ *     - Query the vector by word from the _default.words collection.
+ *     - Convert the vector result which is an array object to a platform's float array.
+ *     - Call setVector() with the platform's float array at the index.
+ * 6. With the IndexUpdater object, call finish()
+ * 7. Execute a vector search query.
+ *     - SELECT word
+ *       FROM _default.words
+ *       WHERE vector_match(words_index, < dinner vector >, 300)
+ * 8. Check that there are 10 words returned.
+ * 9. Check that the word is in the word set from the step 5.
+ */
+
+- (void) testIndexUpdaterSetFloatArrayVectors {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 10 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 10);
+    
+    // Update Index:
+    NSMutableArray<NSString*>* indexedWords = [NSMutableArray array];
+    for(NSUInteger i = 0; i < updater.count; i++) {
+        NSString* word = [updater stringAtIndex: i];
+        NSArray<NSNumber*>* vector = [self vectorForWord: word];
+        Assert([updater setVector: vector atIndex: i error: &error]);
+        [indexedWords addObject: word];
+    }
+    
+    Assert([updater finishWithError: &error]);
+    
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @300
+                                               queryDistance: false
+                                                   andClause: nil
+                                               checkTraining: false];
+    NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
+    AssertEqual(wordMap.count, 10);
+    
+    NSArray<NSString*>* words = [wordMap allValues];
+    for(NSString* word in words) {
+        Assert([indexedWords containsObject: word]);
+    }
+}
+
+/**
+ * 20. TestIndexUpdaterSetInvalidVectorDimensions
+ *
+ * Description
+ * Test thta the vector with the invalid dimenions different from the dimensions
+ * set to the configuration will not be included in the index.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Get a QueryIndex object from the words with the name as "words_index".
+ * 4. Call beginUpdate() with limit 1 to get an IndexUpdater object.
+ * 5. With the IndexUpdater object, call setVector() with a float array as [1.0]
+ * 6. Check that the setVector throws CouchbaseLiteException with the InvalidParameter error.
+ */
+// CBL-5814
+- (void) _testIndexUpdaterSetInvalidVectorDimensions {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 1 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 1);
+    
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** err) {
+        return [updater setVector: @[@1.0] atIndex: 0 error: err];
+    }];
+}
+
+/**
+ * 21. TestIndexUpdaterSkipVectors
+ *
+ * Description
+ * Test that skipping vectors works as expected.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Get a QueryIndex object from the words with the name as "words_index".
+ * 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+ * 5. With the IndexUpdater object, for each index from 0 - 9.
+ *     - Get the word string from the IndexUpdater.
+ *     - If index % 2 == 0,
+ *         - Store the word string in a skipped word set for verifying the skipped words later.
+ *         - Call skipVector at the index.
+ *     - If index % 2 != 0,
+ *         - Query the vector by word from the _default.words collection.
+ *         - Convert the vector result which is an array object to a platform's float array.
+ *         - Call setVector() with the platform's float array at the index.
+ * 6. With the IndexUpdater object, call finish()
+ * 7. Call beginUpdate with limit 10 to get an IndexUpdater object.
+ * 8. With the IndexUpdater object, for each index
+ *     - Get the word string from the dictionary for the key named "word".
+ *     - Check if the word is in the skipped word set from the Step 5. If the word
+ *        is in the skipped word set, remove the word from the skipped word set.
+ *     - Query the vector by word from the _default.words collection.
+ *         - Convert the vector result which is an array object to a platform's float array.
+ *         - Call setVector() with the platform's float array at the index
+ * 9. With the IndexUpdater object, call finish()
+ * 10. Repeat Step 7, until the returned IndexUpdater is null or the skipped word set
+ *      has zero words in it.
+ * 11. Verify that the skipped word set has zero words in it.
+ */
+- (void) _testIndexUpdaterSkipVectors {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 10 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 10);
+    
+    // Update Index:
+    NSMutableArray<NSString*>* skippedWords = [NSMutableArray array];
+    NSMutableArray<NSString*>* indexedWords = [NSMutableArray array];
+    for(NSUInteger i = 0; i < updater.count; i++) {
+        NSString* word = [updater stringAtIndex: i];
+        if (i % 2 == 0) {
+            [skippedWords addObject: word];
+            [updater skipVectorAtIndex: i];
+        } else {
+            [indexedWords addObject: word];
+            NSArray<NSNumber*>* vector = [self vectorForWord: word];
+            [updater setVector: vector atIndex: i error: &error];
+        }
+    }
+    [updater finishWithError: &error];
+    AssertNil(error);
+    AssertEqual(skippedWords.count, 5);
+    AssertEqual(indexedWords.count, 5);
+   
+    // Update index for the skipped words:
+    updater = [index beginUpdateWithLimit: 10 error: &error];
+    for (NSUInteger i = 0; i < updater.count; i++) {
+        NSString* word = [updater stringAtIndex: i];
+        [skippedWords removeObject: word];
+    }
+    AssertEqual(skippedWords.count, 0);
+}
+
+/**
+ * 22. TestIndexUpdaterFinishWithIncompletedUpdate
+ *
+ * Description
+ * Test that a CouchbaseLiteException is thrown when calling finish() on
+ * an IndexUpdater that has incomplete updated.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Get a QueryIndex object from the words with the name as "words_index".
+ * 4. Call beginUpdate() with limit 2 to get an IndexUpdater object.
+ * 5. With the IndexUpdater object, call finish().
+ * 6. Check that a CouchbaseLiteException with code UnsupportedOperation is thrown.
+ * 7. For the index 0,
+ *     - Get the word string from the IndexUpdater.
+ *     - Query the vector by word from the _default.words collection.
+ *     - Convert the vector result which is an array object to a platform's float array.
+ *     - Call setVector() with the platform's float array at the index.
+ * 8. With the IndexUpdater object, call finish().
+ * 9. Check that a CouchbaseLiteException with code UnsupportedOperation is thrown.
+ */
+- (void) testIndexUpdaterFinishWithIncompletedUpdate {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 10)];
+
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 2 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 2);
+    
+    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
+        return [updater finishWithError: err];
+    }];
+    
+    NSString* word = [updater stringAtIndex: 0];
+    NSArray<NSNumber*>* vector = [self vectorForWord: word];
+    [updater setVector: vector atIndex: 0 error: &error];
+    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
+        return [updater finishWithError: err];
+    }];
+}
+
+/**
+ * 23. TestIndexUpdaterCaughtUp
+ *
+ * Description
+ * Test that when the lazy vector index is caught up, calling beginUpdate() to
+ * get an IndexUpdater will return null.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Call beginUpdate() with limit 100 to get an IndexUpdater object.
+ *     - Get the word string from the IndexUpdater.
+ *     - Query the vector by word from the _default.words collection.
+ *     - Convert the vector result which is an array object to a platform's float array.
+ *     - Call setVector() with the platform's float array at the index.
+ * 4. Repeat Step 3 two more times.
+ * 5. Call beginUpdate() with limit 100 to get an IndexUpdater object.
+ * 6. Check that the returned IndexUpdater is null.
+ */
+- (void) testIndexUpdaterCaughtUp {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 10)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    
+    for (NSUInteger i = 0; i < 3; i++) {
+        CBLIndexUpdater* updater = [index beginUpdateWithLimit: 100 error: &error];
+        AssertNotNil(updater);
+        
+        for(NSUInteger j = 0; j < updater.count; j++) {
+            NSString* word = [updater stringAtIndex: j];
+            NSArray<NSNumber*>* vector = [self vectorForWord: word];
+            Assert([updater setVector: vector atIndex: j error: &error]);
+        }
+        Assert([updater finishWithError: &error]);
+    }
+    
+    AssertNil([index beginUpdateWithLimit: 100 error: &error]);
+    AssertEqual(error.code, 0);
+}
+
+/**
+ * 24. TestNonFinishedIndexUpdaterNotUpdateIndex
+ *
+ * Description
+ * Test that the index updater can be released without calling finish(),
+ * and the released non-finished index updater doesn't update the index.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Get a QueryIndex object from the words with the name as "words_index".
+ * 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+ * 5. With the IndexUpdater object, for each index from 0 - 9.
+ *     - Get the word string from the IndexUpdater.
+ *     - Query the vector by word from the _default.words collection.
+ *     - Convert the vector result which is an array object to a platform's float array.
+ *     - Call setVector() with the platform's float array at the index.
+ * 6. Release or close the index updater object.
+ * 7. Execute a vector search query.
+ *     - SELECT word
+ *       FROM _default.words
+ *       WHERE vector_match(words_index, < dinner vector >, 300)
+ * 8. Check that there are 0 words returned.
+ */
+
+- (void) testNonFinishedIndexUpdaterNotUpdateIndex {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 10 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 10);
+    
+    // Update index:
+    for(NSUInteger i = 0; i < updater.count; i++) {
+        NSString* word = [updater stringAtIndex: i];
+        NSArray<NSNumber*>* vector = [self vectorForWord: word];
+        Assert([updater setVector: vector atIndex: i error: &error]);
+    }
+    
+    // "Release" CBLIndexUpdater
+    updater = nil;
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @300
+                                               queryDistance: false
+                                                   andClause: nil
+                                               checkTraining: false];
+    
+    AssertEqual(rs.allObjects.count, 0);
+}
+
+/**
+ * 25. TestIndexUpdaterIndexOutOfBounds
+ *
+ * Description
+ * Test that when using getter, setter, and skip function with the index that
+ * is out of bounds, an IndexOutOfBounds or InvalidArgument exception
+ * is throws.
+ *
+ * Steps
+ * 1. Get the default collection from a test database.
+ * 2. Create the followings documents:
+ *     - doc-0 : { "value": "a string" }
+ * 3. Create a vector index named "vector_index" in the default collection.
+ *     - expression: "value"
+ *     - dimensions: 3
+ *     - centroids : 8
+ *     - isLazy : true
+ * 4. Get a QueryIndex object from the default collection with the name as
+ *    "vector_index".
+ * 5. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+ * 6. Check that the IndexUpdater.count is 1.
+ * 7. Call each getter function with index = -1 and check that
+ *    an IndexOutOfBounds or InvalidArgument exception is thrown.
+ * 8. Call each getter function with index = 1 and check that
+ *    an IndexOutOfBounds or InvalidArgument exception is thrown.
+ * 9. Call setVector() function with a vector = [1.0, 2.0, 3.0] and index = -1 and check that
+ *    an IndexOutOfBounds or InvalidArgument exception is thrown.
+ * 10. Call setVector() function with a vector = [1.0, 2.0, 3.0] and index = 1 and check that
+ *    an IndexOutOfBounds or InvalidArgument exception is thrown.
+ * 9. Call skipVector() function with index = -1 and check that
+ *    an IndexOutOfBounds or InvalidArgument exception is thrown.
+ * 10. Call skipVector() function with index = 1 and check that
+ *    an IndexOutOfBounds or InvalidArgument exception is thrown.
+ */
+- (void) testIndexUpdaterIndexOutOfBounds {
+    NSError* error;
+    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
+    
+    CBLMutableDocument* mdoc = [self createDocument: @"doc-0"];
+    [mdoc setValue: @"a string" forKey: @"value"];
+    [defaultCollection saveDocument: mdoc error: &error];
+    
+    [self createVectorIndexInCollection: defaultCollection
+                                   name: @"vector_index"
+                                 config: LAZY_VECTOR_INDEX_CONFIG(@"value", 300, 8)];
+    
+    CBLQueryIndex* index = [defaultCollection indexWithName: @"vector_index" error: &error];
+    AssertNotNil(index);
+    
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 10 error: &error];
+    AssertEqual(updater.count, 1);
+    
+    // This is in line with ArrayProtocol, throws RangeException
+    [self expectException: @"NSRangeException" in:^{
+        [updater valueAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater stringAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater numberAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater integerAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater doubleAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater floatAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater longLongAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater dateAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater arrayAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater dictionaryAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater booleanAtIndex: 1];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater setVector: @[@1.0, @2.0, @3.0] atIndex: 1 error: nil];
+    }];
+    
+    [self expectException: @"NSRangeException" in:^{
+        [updater skipVectorAtIndex: 1];
+    }];
+}
+
+/**
+ * 26. TestIndexUpdaterCallFinishTwice
+ *
+ * Description
+ * Test that when calling IndexUpdater's finish() after it was finished,
+ * a CuchbaseLiteException is thrown.
+ *
+ * Steps
+ * 1. Copy database words_db.
+ * 2. Create a vector index named "words_index" in the _default.words collection.
+ *     - expression: "word"
+ *     - dimensions: 300
+ *     - centroids : 8
+ *     - isLazy : true
+ * 3. Call beginUpdate() with limit 1 to get an IndexUpdater object.
+ *     - Get the word string from the IndexUpdater.
+ *     - Query the vector by word from the _default.words collection.
+ *     - Convert the vector result which is an array object to a platform's float array.
+ *     - Call setVector() with the platform's float array at the index..
+ * 8. Call finish() and check that the finish() is successfully called.
+ * 9. Call finish() again and check that a CouchbaseLiteException with the code Unsupported is thrown.
+ */
+// CBL-5843
+- (void) _testIndexUpdaterCallFinishTwice {
+    [self createWordsIndexWithConfig: LAZY_VECTOR_INDEX_CONFIG(@"word", 300, 8)];
+    
+    NSError* error;
+    CBLQueryIndex* index = [self wordsIndex];
+    CBLIndexUpdater* updater = [index beginUpdateWithLimit: 1 error: &error];
+    AssertNotNil(updater);
+    AssertEqual(updater.count, 1);
+    
+    NSString* word = [updater stringAtIndex: 0];
+    NSArray<NSNumber*>* vector = [self vectorForWord: word];
+    Assert([updater setVector: vector atIndex: 0 error: &error]);
+    Assert([updater finishWithError: &error]);
+    
+    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
+        return [updater finishWithError: err];
+    }];
+}
+
+@end

--- a/Objective-C/Tests/VectorSearchTest.h
+++ b/Objective-C/Tests/VectorSearchTest.h
@@ -1,0 +1,74 @@
+//
+//  VectorIndexTest.h
+//  CouchbaseLite
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "CBLTestCase.h"
+
+#ifdef COUCHBASE_ENTERPRISE
+
+NS_ASSUME_NONNULL_BEGIN
+
+#define kWordsDatabaseName @"words_db"
+
+#define kWordsCollectionName @"words"
+
+#define kExtWordsCollectionName @"extwords"
+
+#define kWordsIndexName @"words_index"
+
+#define kWordPredictiveModelName @"WordEmbedding"
+
+#define VECTOR_INDEX_CONFIG(E, D, C) [[CBLVectorIndexConfiguration alloc] initWithExpression: (E) dimensions: (D) centroids: (C)]
+
+
+@interface VectorSearchTest : CBLTestCase
+
+@property (nonatomic, readonly) CBLDatabase* wordDB;
+
+@property (nonatomic, readonly) CBLCollection* wordsCollection;
+
+@property (nonatomic, readonly) CBLCollection* extWordsCollection;
+
+- (void) createVectorIndexInCollection: (CBLCollection*)collection
+                                  name: (NSString*)name
+                                config: (CBLVectorIndexConfiguration*)config;
+
+- (void) createWordsIndexWithConfig: (CBLVectorIndexConfiguration*)config;
+
+- (void) deleteWordsIndex;
+
+- (NSString*) wordsQueryStringWithLimit: (nullable NSNumber*)limit
+                          queryDistance: (BOOL) queryDistance
+                              andClause: (nullable NSString*)andClause;
+
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (nullable NSNumber*)limit
+                                    queryDistance: (BOOL) queryDistance
+                                        andClause: (nullable NSString*)andClause
+                                    checkTraining: (BOOL) checkTraining;
+
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (nullable NSNumber*)limit;
+
+- (CBLQueryResultSet*) executeWordsQueryNoTrainingCheckWithLimit: (nullable NSNumber*)limit;
+
+- (NSDictionary<NSString*, NSString*>*) toDocIDWordMap: (CBLQueryResultSet*)resultSet;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -17,19 +17,13 @@
 //  limitations under the License.
 //
 
-#import "CBLTestCase.h"
+#import "VectorSearchTest.h"
 #import "CBLWordEmbeddingModel.h"
 #import "CustomLogger.h"
-#import "CBLQueryIndex.h"
-#import "CBLJSON.h"
 
 #define kDinnerVector @[@0.03193166106939316, @0.032055653631687164, @0.07188114523887634, @(-0.09893740713596344), @(-0.07693558186292648), @0.07570040225982666, @0.42786234617233276, @(-0.11442682892084122), @(-0.7863243818283081), @(-0.47983086109161377), @(-0.10168658196926117), @0.10985997319221497, @(-0.15261511504650116), @(-0.08458329737186432), @(-0.16363860666751862), @(-0.20225222408771515), @(-0.2593214809894562), @(-0.032738097012043), @(-0.16649988293647766), @(-0.059701453894376755), @0.17472036182880402, @(-0.007310086861252785), @(-0.13918264210224152), @(-0.07260780036449432), @(-0.02461239881813526), @(-0.04195880889892578), @(-0.15714778006076813), @0.48038315773010254, @0.7536261677742004, @0.41809454560279846, @(-0.17144775390625), @0.18296195566654205, @(-0.10611499845981598), @0.11669538915157318, @0.07423929125070572, @(-0.3105475902557373), @(-0.045081984251737595), @(-0.18190748989582062), @0.22430984675884247, @0.05735112354159355, @(-0.017394868656992912), @(-0.148889422416687), @(-0.20618586242198944), @(-0.1446581482887268), @0.061972495168447495, @0.07787969708442688, @0.14225411415100098, @0.20560632646083832, @0.1786964386701584, @(-0.380594402551651), @(-0.18301603198051453), @(-0.19542981684207916), @0.3879885971546173, @(-0.2219538390636444), @0.11549852043390274, @(-0.0021717497147619724), @(-0.10556972026824951), @0.030264658853411674, @0.16252967715263367, @0.06010117009282112, @(-0.045007310807704926), @0.02435707487165928, @0.12623260915279388, @(-0.12688252329826355), @(-0.3306281864643097), @0.06452160328626633,@0.0707000121474266, @(-0.04959108680486679), @(-0.2567063570022583), @(-0.01878536120057106), @(-0.10857286304235458), @(-0.01754194125533104), @(-0.0713721290230751), @0.05946013703942299, @(-0.1821729987859726), @(-0.07293688505887985), @(-0.2778160572052002), @0.17880073189735413, @(-0.04669278487563133), @0.05351974070072174, @(-0.23292849957942963), @0.05746332183480263, @0.15462779998779297, @(-0.04772235080599785), @(-0.003306782804429531), @0.058290787041187286, @0.05908169597387314, @0.00504430802538991, @(-0.1262340396642685), @0.11612161248922348, @0.25303348898887634, @0.18580256402492523, @0.09704313427209854, @(-0.06087183952331543), @0.19697663187980652, @(-0.27528849244117737), @(-0.0837797075510025), @(-0.09988483041524887), @(-0.20565757155418396), @0.020984146744012833, @0.031014855951070786, @0.03521743416786194, @(-0.05171370506286621), @0.009112107567489147, @(-0.19296088814735413), @(-0.19363830983638763), @0.1591167151927948, @(-0.02629968523979187), @(-0.1695055067539215), @(-0.35807400941848755), @(-0.1935291737318039), @(-0.17090126872062683), @(-0.35123637318611145), @(-0.20035606622695923), @(-0.03487539291381836), @0.2650701701641083, @(-0.1588021069765091), @0.32268261909484863, @(-0.024521857500076294), @(-0.11985184997320175), @0.14826008677482605, @0.194917231798172, @0.07971998304128647, @0.07594677060842514, @0.007186363451182842, @(-0.14641280472278595), @0.053229596465826035, @0.0619836151599884, @0.003207010915502906, @(-0.12729716300964355), @0.13496214151382446, @0.107656329870224, @(-0.16516226530075073), @(-0.033881571143865585), @(-0.11175122112035751), @(-0.005806141998618841), @(-0.4765360355377197), @0.11495379358530045, @0.1472187340259552, @0.3781401813030243, @0.10045770555734634, @(-0.1352398842573166), @(-0.17544329166412354), @(-0.13191302120685577), @(-0.10440415143966675), @0.34598618745803833, @0.09728766977787018, @(-0.25583627820014954), @0.035236816853284836, @0.16205145418643951, @(-0.06128586828708649), @0.13735555112361908, @0.11582338809967041, @(-0.10182418674230576), @0.1370954066514969, @0.15048766136169434, @0.06671152263879776, @(-0.1884871870279312), @(-0.11004580557346344), @0.24694739282131195, @(-0.008159132674336433), @(-0.11668405681848526), @(-0.01214478351175785), @0.10379738360643387, @(-0.1626262664794922), @0.09377897530794144, @0.11594484746456146, @(-0.19621512293815613), @0.26271334290504456, @0.04888357222080231, @(-0.10103251039981842), @0.33250945806503296, @0.13565145432949066, @(-0.23888370394706726), @(-0.13335271179676056), @(-0.0076894499361515045), @0.18256276845932007, @0.3276212215423584, @(-0.06567271053791046), @(-0.1853761374950409), @0.08945729583501816, @0.13876311480998993, @0.09976287186145782, @0.07869105041027069, @(-0.1346970647573471), @0.29857659339904785, @0.1329529583454132, @0.11350086331367493, @0.09112624824047089, @(-0.12515446543693542), @(-0.07917925715446472), @0.2881546914577484, @(-1.4532661225530319e-05), @(-0.07712751626968384), @0.21063975989818573, @0.10858846455812454, @(-0.009552721865475178), @0.1629313975572586, @(-0.39703384041786194), @0.1904662847518921, @0.18924959003925323, @(-0.09611514210700989), @0.001136621693149209, @(-0.1293390840291977), @(-0.019481558352708817), @0.09661063551902771, @(-0.17659670114517212), @0.11671938002109528, @0.15038564801216125, @(-0.020016824826598167), @(-0.20642194151878357), @0.09050136059522629, @(-0.1768183410167694), @(-0.2891409397125244), @0.04596589505672455, @(-0.004407480824738741), @0.15323616564273834, @0.16503025591373444, @0.17370983958244324, @0.02883041836321354, @0.1463884711265564, @0.14786243438720703, @(-0.026439940556883812), @(-0.03113352134823799), @0.10978181660175323, @0.008928884752094746, @0.24813824892044067, @(-0.06918247044086456), @0.06958142668008804, @0.17475970089435577, @0.04911438003182411, @0.17614248394966125, @0.19236832857131958, @(-0.1425514668226242), @(-0.056531358510255814), @(-0.03680772706866264), @(-0.028677923604846), @(-0.11353116482496262), @0.012293893843889236, @(-0.05192646384239197), @0.20331953465938568, @0.09290937334299088, @0.15373043715953827, @0.21684466302394867, @0.40546831488609314, @(-0.23753701150417328), @0.27929359674453735, @(-0.07277711480855942), @0.046813879162073135, @0.06883064657449722, @(-0.1033223420381546), @0.15769273042678833, @0.21685580909252167, @(-0.00971329677850008), @0.17375953495502472, @0.027193285524845123, @(-0.09943609684705734), @0.05770351365208626, @0.0868956446647644, @(-0.02671697922050953), @(-0.02979189157485962), @0.024517420679330826, @(-0.03931192681193352), @(-0.35641804337501526), @(-0.10590721666812897), @(-0.2118944674730301), @(-0.22070199251174927), @0.0941486731171608, @0.19881175458431244, @0.1815279871225357, @(-0.1256905049085617), @(-0.0683583989739418), @0.19080783426761627, @(-0.009482398629188538), @(-0.04374842345714569), @0.08184348791837692, @0.20070189237594604, @0.039221834391355515, @(-0.12251003831624985), @(-0.04325549304485321), @0.03840530663728714, @(-0.19840988516807556), @(-0.13591833412647247), @0.03073180839419365, @0.1059495136141777, @(-0.10656466335058212), @0.048937033861875534, @(-0.1362423598766327), @(-0.04138947278261185), @0.10234509408473969, @0.09793911874294281, @0.1391254961490631, @(-0.0906999260187149), @0.146945983171463, @0.14941848814487457, @0.23930180072784424, @0.36049938201904297, @0.0239607822149992, @0.08884347230195999, @0.061145078390836716]
 
 #define kLunchVectorBase64 @"4OYevd8eyDxJGj69HCKOvoCJYTzQCJs9xhDbPp1Y6r2OTEm/ZKz1vtRbwL1Ik8I9+RQFPpyGBD69OEI9ul+evZD71L2nI4y8uTINPnVN+702+c4+8zToPEoGKj6xEqi93vPFvQDdK71Z6yC+yPT1PqXtQD99ENY+xnh+PpBEOD6aIUi+eVezvg24fj0YAJ++46c4vfVFOr57sWU+A+lqPdFq3T1ZJg6+Ok6yvs1/Cr5blju+ITa9vAFxlj1+8h4+c7UePe6fUL6OaDu+wR5IvnGmxj7eR2O+fYrsPf8kw73IOfq8YOJtvAxBMj0g99O8+toTPr0v8r2I4mK+Yxd1PTGxhbzu3aS9zeJEPqKy0Ty2cOy9YqgQPL7af703wFK9965hvOM0pz2VuAc+RIyTu4nxi73pigA9RCjpvVTOFj6zPIC+HTsrvrcpTz4vXzS6ArPxvM+VNL3hJgk+9pM7vtP1jL51sao8q4oJPonfBDxkAiC9XvJUPWiWTD1Kwbe+4KHOvUQmjjypsrS6i4MJPjRnWz0g8E4+Ad3IvVsKMT5O7Qw9X4tFPbpriT1TYme8uw5uvqBar72DLEa+vgAvvkHVs74kKk2+gNkOvZkV57zBfcC+/WM7PrKQQb4+adC9ftEXPmKYRz47RKM9+4mbPZZ76zs4LZq+0gIXPgNoxL26tT09rGFdvPdQqDwi/Y8939OLvYVTQr7J8hK+ljyeveMZsL5xeGi8sppcPfezjT11QuU9cvRpPSoby7yIZ3U9FUPXPd/y1z2xBhu9CfRyvbjXR72xLjk+9rkLvrdWJD2u+Iy9TtM/vlc0Ez4E1ju9XtcrPP+4Cr5ymDu+DfEAPswpP770tKm+3u07vsXxXb19zcC8MQ/APX507T2e7Ei+XYKGPiQ6SD0MORK+Lk4NP1zuHTzrAKW+Eu2WvSGPRj6fL7g9IdSgPkNyojxUSPi95uGqvJugrj0Bqbc9x1eVPk8qh74NlYk+07gZPVqt271XR2E+bMxmOyw0JD1Lg2Y+h+GDvRpuj70YCss890HtPdFwMz7oo7I+RpgXv4/lkz54b+Y8l6yOPdbWYj3H+4G+Q4wXvsXhyD0ayts9XIXBPndXLj34Q1I+0zfQu5pblj66UKa9dSWqvRl1xb04RQK9HsA6PrH2rD2r8wC+XQQPPlSirDwC3zU+K7Z4vUfVML4xHyY92TguPigvMj2emD8+q3AXPsSHWz4Cq5+9P/o7PveDcD095w++4fc9vvE81j17lt09AY7CvHD/Nz7FdCe+t7z4PDJPZD4Qsce9mdwZPtvzDj60sz6+ETvUPTLZ970Gauu83dW7PZZPCj51tCc+yMYtPYrmSjyUcpE+GCDgPf1tGr7aODg+ESYGPmu52T070vi9kW0vvaiwWj6JgQ6+hoehPVygk77JeOg8yCI+PtSnpD2I6w0+z3IFPRUoLD7boxM+XJYbviPzNrxBSBs+XO+WPpkuH74N9+m9tds9PiCinT6BaZ2+tGIfvhZSTj2ZP2k+cld+PHx1Kj4uOfK9bsXHPRx8Bz5OlMg96nYOPuLAub0CeRY+KQEZPogLdT5gk7g+Z0nEPJHztT1Dc3o9"
-
-@interface VectorSearchTest : CBLTestCase
-
-@end
 
 #pragma mark - Vector Search test
 /**
@@ -37,10 +31,47 @@
 */
 @implementation VectorSearchTest {
     CustomLogger* _logger;
+    
+    CBLDatabase* _wordDB;
+    CBLDatabase* _modelDB;
+    
+    // For some reason the autorelease poll could run after the teardown is called.
+    // To avoid leaking check issue, lazy creating these from the tests.
+    CBLCollection* _wordsCollection;
+    CBLCollection* _extWordsCollection;
+}
+
+@synthesize wordDB=_wordDB;
+
+- (CBLCollection*) wordsCollection {
+    if (!_wordsCollection) {
+        _wordsCollection = [_wordDB collectionWithName: kWordsCollectionName scope: nil error: nil];
+    }
+    return _wordsCollection;
+}
+
+- (CBLCollection*) extWordsCollection {
+    if (!_extWordsCollection) {
+        _extWordsCollection = [_wordDB collectionWithName: kExtWordsCollectionName scope: nil error: nil];
+    }
+    return _extWordsCollection;
 }
 
 - (void) setUp {
+    [self deleteDBNamed: kWordsDatabaseName error: nil];
+    
     [super setUp];
+
+    NSError* error;
+    
+    CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
+    config.directory = self.directory;
+    
+    NSString* path = [self databasePath: @"words_db.cblite2" inDirectory: @"vectorsearch"];
+    Assert([CBLDatabase copyFromPath:path toDatabase: kWordsDatabaseName withConfig: config error: &error]);
+    
+    _wordDB = [self openDBNamed: kWordsDatabaseName error: &error];
+    AssertNotNil(_wordDB);
     
     _logger = [[CustomLogger alloc] init];
     _logger.level = kCBLLogLevelInfo;
@@ -50,18 +81,117 @@
 - (void) tearDown {
     CBLDatabase.log.custom = nil;
     
+    _wordsCollection = nil;
+    _extWordsCollection = nil;
+    
+    NSError* error;
+    if (_wordDB) {
+        Assert([_wordDB close: &error], @"Failed to close db: %@", error);
+        _wordDB = nil;
+    }
+    
+    if (_modelDB) {
+        Assert([_modelDB close: &error], @"Failed to close db: %@", error);
+        _modelDB = nil;
+    }
+    
+    [self unregisterPredictiveModel];
+    
     [super tearDown];
 }
 
-- (void) initDB {
+- (void) registerPredictiveModel {
+    if (!_modelDB) {
+        _modelDB = [self openDBNamed: kWordsDatabaseName error: nil];
+        AssertNotNil(_modelDB);
+    }
+    
+    CBLWordEmbeddingModel* model = [[CBLWordEmbeddingModel alloc] initWithDatabase: _modelDB];
+    [CBLDatabase.prediction registerModel: model withName: kWordPredictiveModelName];
+}
+
+- (void) unregisterPredictiveModel {
+    [CBLDatabase.prediction unregisterModelWithName: kWordPredictiveModelName];
+}
+
+- (void) resetIndexWasTrainedLog {
+    [_logger reset];
+}
+
+- (BOOL) checkIndexWasTrained {
+    return ![_logger containsString: @"Untrained index; queries may be slow"];
+}
+
+- (void) createVectorIndexInCollection: (CBLCollection*)collection 
+                                  name: (NSString*)name
+                                config: (CBLVectorIndexConfiguration*)config {
+    Assert([collection createIndexWithName: name config: config error: nil]);
+    Assert([[collection indexes: nil] containsObject: name]);
+}
+
+- (void) createWordsIndexWithConfig: (CBLVectorIndexConfiguration*)config {
+    [self createVectorIndexInCollection: self.wordsCollection name: kWordsIndexName config: config];
+}
+
+- (void) deleteWordsIndex {
+    Assert([_wordsCollection deleteIndexWithName: kWordsIndexName error: nil]);
+    AssertFalse([[self.wordsCollection indexes: nil] containsObject: @"words_index"]);
+}
+
+- (NSString*) wordsQueryStringWithLimit: (NSNumber*)limit
+                          queryDistance: (BOOL) queryDistance
+                              andClause: (NSString*)andClause {
+    NSString* sql = @"SELECT meta().id, word, catid";
+    if (queryDistance) {
+        sql = [sql stringByAppendingFormat: @", VECTOR_DISTANCE(%@)", kWordsIndexName];
+    }
+    
+    sql = [sql stringByAppendingFormat: @" FROM %@ WHERE VECTOR_MATCH(%@, $vector)",
+           kWordsCollectionName, kWordsIndexName];
+    
+    if (andClause) {
+        sql = [sql stringByAppendingFormat: @" %@", andClause];
+    }
+    
+    if (limit) {
+        sql = [sql stringByAppendingFormat: @" LIMIT %d", [limit intValue]];
+    }
+    
+    return sql;
+}
+
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSNumber*)limit
+                                    queryDistance: (BOOL) queryDistance
+                                        andClause: (NSString*)andClause
+                                    checkTraining: (BOOL) checkTraining {
     NSError* error;
-    CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
-    config.directory = self.directory;
+    NSString* sql = [self wordsQueryStringWithLimit: limit queryDistance: queryDistance andClause: andClause];
+    CBLQuery* query = [_wordDB createQuery: sql error: &error];
+    AssertNotNil(query);
     
-    NSString* path = [self databasePath: @"words_db.cblite2" inDirectory: @"vectorsearch"];
-    [CBLDatabase copyFromPath:path toDatabase: kDatabaseName withConfig: config error: &error];
+    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
+    [parameters setValue: kDinnerVector forName: @"vector"];
+    [query setParameters: parameters];
     
-    [self openDB];
+    NSString* explain = [query explain: &error];
+    Assert([explain rangeOfString: @"kv_.words:vector:words_index"].location != NSNotFound);
+    
+    CBLQueryResultSet* rs = [query execute: &error];
+    AssertNotNil(rs);
+    
+    if (checkTraining) {
+        XCTAssert([self checkIndexWasTrained]);
+    }
+    
+    return rs;
+}
+
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSNumber*)limit {
+    return [self executeWordsQueryWithLimit: limit queryDistance: false andClause: nil checkTraining: true];
+}
+
+- (CBLQueryResultSet*) executeWordsQueryNoTrainingCheckWithLimit: (NSNumber*)limit {
+    return [self executeWordsQueryWithLimit: limit queryDistance: false andClause: nil checkTraining: false];
 }
 
 - (NSDictionary<NSString*, NSString*>*) toDocIDWordMap: (CBLQueryResultSet*)resultSet {
@@ -74,55 +204,6 @@
     return wordMap;
 }
 
-- (void) resetIndexWasTrainedLog {
-    [_logger reset];
-}
-
-- (BOOL) checkIndexWasTrained {
-    return ![_logger containsString: @"Untrained index; queries may be slow"];
-}
-
-- (nullable NSArray<NSNumber*>*) vectorArrayForWord: (NSString*) word
-                                         collection: (CBLCollection*) collection {
-    AssertNotNil(collection);
-    NSError* error;
-    NSString* queryString = [NSString stringWithFormat:@"SELECT vector FROM %@ WHERE word = '%@'",
-                             collection.name, word];
-    
-    CBLQuery* q = [_db createQuery: queryString error: &error];
-    if (!q) {
-        NSLog(@"Can't create query: %@/%ld", error.domain, (long)error.code);
-        return nil;
-    }
-
-    CBLQueryResultSet* rs = [q execute: &error];
-    if (!rs) {
-        NSLog(@"Can't execute query: %@/%ld", error.domain, (long)error.code);
-        return nil;
-    }
-
-    NSArray<NSNumber*>* vector;
-    CBLQueryResult *result = [rs nextObject];
-    if (result) {
-            id value = [result valueAtIndex:0];
-            if ([value isKindOfClass:[CBLArray class]]) {
-                vector = (NSArray<NSNumber*>*)value;
-                // Additional check to ensure all elements are NSNumber
-                for (id element in vector) {
-                    if (![element isKindOfClass:[NSNumber class]]) {
-                        NSLog(@"Unexpected type in vector array");
-                        return nil;
-                    }
-                }
-            } else {
-                NSLog(@"Query result is not an NSArray");
-            }
-    }
-    return vector;
-}
-
-
-
 /**
  * 1. TestVectorIndexConfigurationDefaultValue
  * Description
@@ -131,7 +212,7 @@
  *     1. Create a VectorIndexConfiguration object.
  *         - expression: "vector"
  *         - dimensions: 300
- *         - centroids: 20
+ *         - centroids: 8
  *     2. Get and check the following property values:
  *         - encoding: 8-Bit Scalar Quantizer Encoding
  *         - metric: Euclidean Distance
@@ -141,9 +222,7 @@
  *        property to the tests for verification.
  */
 - (void) testVectorIndexConfigurationDefaultValue {
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     AssertEqualObjects(config.encoding, [CBLVectorEncoding scalarQuantizerWithType: kCBLSQ8]);
     AssertEqual(config.metric, kCBLDistanceMetricEuclidean);
     AssertEqual(config.minTrainingSize, 25 * config.centroids);
@@ -158,7 +237,7 @@
  *     1. Create a VectorIndexConfiguration object with the following properties.
  *         - expression: "vector"
  *         - dimensions: 300
- *         - centroids: 20
+ *         - centroids: 8
  *         - encoding: None
  *         - metric: Cosine Distance
  *         - minTrainingSize: 100
@@ -174,9 +253,7 @@
  *         - maxTrainingSize: 200
  */
 - (void) testVectorIndexConfigurationSettersAndGetters {
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     CBLVectorEncoding* noneEncoding = [CBLVectorEncoding none];
     config.encoding = noneEncoding;
     config.metric = kCBLDistanceMetricCosine;
@@ -186,7 +263,7 @@
     AssertEqual(config.expression, @"vector");
     AssertEqualObjects(config.expressions, @[@"vector"]);
     AssertEqual(config.dimensions, 300);
-    AssertEqual(config.centroids, 20);
+    AssertEqual(config.centroids, 8);
     AssertEqual(config.encoding, noneEncoding);
     AssertEqual(config.metric, kCBLDistanceMetricCosine);
     AssertEqual(config.minTrainingSize, 100);
@@ -203,7 +280,7 @@
  *     1. Create a VectorIndexConfiguration object.
  *         - expression: "vector"
  *         - dimensions: 2 and 4096
- *         - centroids: 20
+ *         - centroids: 8
  *     2. Check that the config can be created without an error thrown.
  *     3. Use the config to create the index and check that the index
  *       can be created successfully.
@@ -211,35 +288,16 @@
  *     5. Check that an invalid argument exception is thrown.
  */
 - (void) testDimensionsValidation {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(@"vector", 2, 8)];
     
-    CBLVectorIndexConfiguration* config1 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                        dimensions: 2
-                                                                                         centroids: 20];
-    AssertNotNil(config1);
-    Assert([collection createIndexWithName: @"words_index_1" config: config1 error: &error]);
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index_1"]);
-    
-    CBLVectorIndexConfiguration* config2 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                        dimensions: 4096
-                                                                                         centroids: 20];
-    AssertNotNil(config2);
-    Assert([collection createIndexWithName: @"words_index_2" config: config2 error: &error]);
-    names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index_2"]);
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(@"vector", 4096, 8)];
     
     [self expectException: NSInvalidArgumentException in:^{
-        (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                            dimensions: 1
-                                                             centroids: 20];
+        VECTOR_INDEX_CONFIG(@"vector", 1, 8);
     }];
     
     [self expectException: NSInvalidArgumentException in:^{
-        (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector" 
-                                                            dimensions: 4097
-                                                             centroids: 20];
+        VECTOR_INDEX_CONFIG(@"vector", 4097, 8);
     }];
 }
 
@@ -261,31 +319,18 @@
  *     5. Check that an invalid argument exception is thrown.
  */
 - (void) testCentroidsValidation {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    CBLVectorIndexConfiguration* config1 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                        dimensions: 300
-                                                                                         centroids: 1];
-    AssertNotNil(config1);
-    Assert([collection createIndexWithName: @"words_index_1" config: config1 error: &error]);
-    
-    CBLVectorIndexConfiguration* config2 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                        dimensions: 300
-                                                                                         centroids: 64000];
-    AssertNotNil(config2);
-    Assert([collection createIndexWithName: @"words_index_2" config: config2 error: &error]);
+    CBLVectorIndexConfiguration* config1 = VECTOR_INDEX_CONFIG(@"vector", 300, 1);
+    Assert([self.wordsCollection createIndexWithName: @"words_index_1" config: config1 error: nil]);
+
+    CBLVectorIndexConfiguration* config2 = VECTOR_INDEX_CONFIG(@"vector", 300, 64000);
+    Assert([self.wordsCollection createIndexWithName: @"words_index_2" config: config2 error: nil]);
     
     [self expectException: NSInvalidArgumentException in:^{
-        (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector" 
-                                                            dimensions: 300
-                                                             centroids: 0];
+        (void) VECTOR_INDEX_CONFIG(@"vector", 300, 0);
     }];
     
     [self expectException: NSInvalidArgumentException in:^{
-        (void) [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector" 
-                                                            dimensions: 300
-                                                             centroids: 64001];
+        (void) VECTOR_INDEX_CONFIG(@"vector", 300, 64001);
     }];
 }
 
@@ -316,32 +361,10 @@
  *     10. Reset the custom logger.
  */
 - (void) testCreateVectorIndex {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.minTrainingSize = 200;
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(@"vector", 300, 8)];
     
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 20);
-    Assert([self checkIndexWasTrained]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
 }
 
 /**
@@ -378,53 +401,29 @@
  *     11. Reset the custom logger.
  */
 - (void) testUpdateVectorIndex {
-    NSError* error;
-    CBLCollection* wordsCollection = [_db collectionWithName: @"words" scope: nil error: &error];
-    CBLCollection* extWordsCollection = [_db collectionWithName: @"extwords" scope: nil error: &error];
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(@"vector", 300, 8)];
     
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector" 
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    
-    Assert([wordsCollection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    NSArray* names = [wordsCollection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 350)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* results = rs.allObjects;
-    AssertEqual(results.count, 300);
-    Assert([self checkIndexWasTrained]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @350];
+    AssertEqual(rs.allObjects.count, 300);
     
     // Update docs:
-    CBLDocument* extWord1 = [extWordsCollection documentWithID: @"word1" error : &error];
+    NSError* error;
+    CBLDocument* extWord1 = [self.extWordsCollection documentWithID: @"word1" error : &error];
     CBLMutableDocument* word301 = [self createDocument: @"word301" data: [extWord1 toDictionary]];
-    Assert([wordsCollection saveDocument: word301 error: &error]);
+    Assert([self.wordsCollection saveDocument: word301 error: &error]);
     
-    CBLDocument* extWord2 = [extWordsCollection documentWithID: @"word2" error : &error];
+    CBLDocument* extWord2 = [self.extWordsCollection documentWithID: @"word2" error : &error];
     CBLMutableDocument* word302 = [self createDocument: @"word302" data: [extWord2 toDictionary]];
-    Assert([wordsCollection saveDocument: word302 error: &error]);
+    Assert([self.wordsCollection saveDocument: word302 error: &error]);
     
-    CBLDocument* extWord3 = [extWordsCollection documentWithID: @"word3" error : &error];
-    CBLMutableDocument* word1 = [[wordsCollection documentWithID: @"word1" error: &error] toMutable];
+    CBLDocument* extWord3 = [self.extWordsCollection documentWithID: @"word3" error : &error];
+    CBLMutableDocument* word1 = [[self.wordsCollection documentWithID: @"word1" error: &error] toMutable];
     [word1 setData: [extWord3 toDictionary]];
-    Assert([wordsCollection saveDocument: word1 error: &error]);
+    Assert([self.wordsCollection saveDocument: word1 error: &error]);
     
-    [wordsCollection deleteDocument: [wordsCollection documentWithID: @"word2" error :&error] error: &error];
+    [self.wordsCollection deleteDocument: [self.wordsCollection documentWithID: @"word2" error :&error] error: &error];
     
-    rs = [q execute: &error];
-    
+    rs = [self executeWordsQueryWithLimit: @350];
     NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
     AssertEqual(wordMap.count, 301);
     AssertEqualObjects(wordMap[@"word301"], [word301 stringForKey: @"word"]);
@@ -467,48 +466,30 @@
  */
 - (void) testCreateVectorIndexWithInvalidVectors {
     NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
     
     // Update docs:
-    CBLMutableDocument* auxDoc = [[collection documentWithID: @"word1" error: &error] toMutable];
+    CBLMutableDocument* auxDoc = [[self.wordsCollection documentWithID: @"word1" error: &error] toMutable];
     [auxDoc setArray: nil forKey: @"vector"];
-    [collection saveDocument: auxDoc error: &error];
+    [self.wordsCollection saveDocument: auxDoc error: &error];
     
-    auxDoc = [[collection documentWithID: @"word2" error: &error] toMutable];
+    auxDoc = [[self.wordsCollection documentWithID: @"word2" error: &error] toMutable];
     [auxDoc setString: @"string" forKey: @"vector"];
-    [collection saveDocument: auxDoc error: &error];
+    [self.wordsCollection saveDocument: auxDoc error: &error];
     
-    auxDoc = [[collection documentWithID: @"word3" error: &error] toMutable];
+    auxDoc = [[self.wordsCollection documentWithID: @"word3" error: &error] toMutable];
     [auxDoc removeValueForKey: @"vector"];
-    [collection saveDocument: auxDoc error: &error];
+    [self.wordsCollection saveDocument: auxDoc error: &error];
     
-    auxDoc = [[collection documentWithID: @"word4" error: &error] toMutable];
+    auxDoc = [[self.wordsCollection documentWithID: @"word4" error: &error] toMutable];
     CBLMutableArray* vector = [auxDoc arrayForKey: @"vector"];
     [vector removeValueAtIndex: 0];
-    Assert([collection saveDocument: auxDoc error: &error]);
+    Assert([self.wordsCollection saveDocument: auxDoc error: &error]);
     
     // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector" 
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(@"vector", 300, 8)];
     
     // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 350)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @350];
     NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
     AssertEqual(wordMap.count, 296);
     AssertNil(wordMap[@"word1"]);
@@ -517,12 +498,13 @@
     AssertNil(wordMap[@"word4"]);
     Assert([self checkIndexWasTrained]);
     
-    auxDoc = [[collection documentWithID: @"word5" error: &error] toMutable];
+    // Update doc:
+    auxDoc = [[self.wordsCollection documentWithID: @"word5" error: &error] toMutable];
     [auxDoc setString: nil forKey: @"vector"];
-    [collection saveDocument: auxDoc error: &error];
+    [self.wordsCollection saveDocument: auxDoc error: &error];
     
-    rs = [q execute: &error];
-    
+    // Query:
+    rs = [self executeWordsQueryWithLimit: @350];
     wordMap = [self toDocIDWordMap: rs];
     AssertEqual(wordMap.count, 295);
     AssertNil(wordMap[@"word5"]);
@@ -562,70 +544,41 @@
  *     12. Reset the custom logger.
  */
 - (void) testCreateVectorIndexUsingPredictionModel {
-    NSError* error;
-    
-    CBLCollection* wordsCollection = [_db collectionWithName: @"words" scope: nil error: &error];
-    CBLCollection* extWordsCollection = [_db collectionWithName: @"extwords" scope: nil error: &error];
-    
-    CBLDatabase *modelDb = [self openDBNamed: kDatabaseName error: &error];
-    CBLWordEmbeddingModel* model = [[CBLWordEmbeddingModel alloc] initWithDatabase: modelDb];
-    [CBLDatabase.prediction registerModel: model withName: @"WordEmbedding"];
+    [self registerPredictiveModel];
     
     NSString* expr = @"prediction(WordEmbedding,{\"word\": word}).vector";
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: expr
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([wordsCollection createIndexWithName: @"words_pred_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(expr, 300, 8)];
     
-    NSArray* names = [wordsCollection indexes: &error];
-    Assert([names containsObject: @"words_pred_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_pred_index, $vector, 350)";
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_pred_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 300);
-    Assert([self checkIndexWasTrained]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @350];
+    AssertEqual(rs.allObjects.count, 300);
     
     // Create words.word301 with extwords.word1 content
-    CBLDocument* extWord1 = [extWordsCollection documentWithID: @"word1" error : &error];
+    NSError* error;
+    CBLDocument* extWord1 = [self.extWordsCollection documentWithID: @"word1" error : &error];
     CBLMutableDocument* word301 = [self createDocument: @"word301" data: [extWord1 toDictionary]];
-    Assert([wordsCollection saveDocument: word301 error: &error]);
+    Assert([self.wordsCollection saveDocument: word301 error: &error]);
     
     // Create words.word302 with extwords.word2 content
-    CBLDocument* extWord2 = [extWordsCollection documentWithID: @"word2" error : &error];
+    CBLDocument* extWord2 = [self.extWordsCollection documentWithID: @"word2" error : &error];
     CBLMutableDocument* word302 = [self createDocument: @"word302" data: [extWord2 toDictionary]];
-    Assert([wordsCollection saveDocument: word302 error: &error]);
+    Assert([self.wordsCollection saveDocument: word302 error: &error]);
     
     // Update words.word1 with extwords.word3 content
-    CBLDocument* extWord3 = [extWordsCollection documentWithID: @"word3" error : &error];
-    CBLMutableDocument* word1 = [[wordsCollection documentWithID: @"word1" error: &error] toMutable];
+    CBLDocument* extWord3 = [self.extWordsCollection documentWithID: @"word3" error : &error];
+    CBLMutableDocument* word1 = [[self.wordsCollection documentWithID: @"word1" error: &error] toMutable];
     [word1 setData: [extWord3 toDictionary]];
-    Assert([wordsCollection saveDocument: word1 error: &error]);
+    Assert([self.wordsCollection saveDocument: word1 error: &error]);
     
     // Delete words.word2
-    [wordsCollection deleteDocument: [wordsCollection documentWithID: @"word2" error : &error] error: &error];
+    [_wordsCollection deleteDocument: [self.wordsCollection documentWithID: @"word2" error : &error] error: &error];
     
-    rs = [q execute: &error];
-    
+    rs = [self executeWordsQueryWithLimit: @350];
     NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
     AssertEqual(wordMap.count, 301);
     AssertEqualObjects(wordMap[@"word301"], [word301 stringForKey: @"word"]);
     AssertEqualObjects(wordMap[@"word302"], [word302 stringForKey: @"word"]);
     AssertEqualObjects(wordMap[@"word1"], [word1 stringForKey: @"word"]);
     AssertNil(wordMap[@"word2"]);
-    
-    [CBLDatabase.prediction unregisterModelWithName: @"WordEmbedding"];
 }
 
 /**
@@ -663,54 +616,33 @@
  *     13. Reset the custom logger.
  */
 - (void) testCreateVectorIndexUsingPredictionModelWithInvalidVectors {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    CBLDatabase *modelDb = [self openDBNamed: kDatabaseName error: &error];
-    CBLWordEmbeddingModel* model = [[CBLWordEmbeddingModel alloc] initWithDatabase: modelDb];
-    [CBLDatabase.prediction registerModel: model withName: @"WordEmbedding"];
+    [self registerPredictiveModel];
     
     // Update docs:
-    CBLMutableDocument* auxDoc = [[collection documentWithID: @"word1" error: &error] toMutable];
+    NSError* error;
+    CBLMutableDocument* auxDoc = [[self.wordsCollection documentWithID: @"word1" error: &error] toMutable];
     [auxDoc setArray: nil forKey: @"vector"];
-    Assert([collection saveDocument: auxDoc error: &error]);
+    Assert([self.wordsCollection saveDocument: auxDoc error: &error]);
     
-    auxDoc = [[collection documentWithID: @"word2" error: &error] toMutable];
+    auxDoc = [[_wordsCollection documentWithID: @"word2" error: &error] toMutable];
     [auxDoc setString: @"string" forKey: @"vector"];
-    Assert([collection saveDocument:auxDoc error:&error]);
+    Assert([self.wordsCollection saveDocument:auxDoc error:&error]);
     
-    auxDoc = [[collection documentWithID: @"word3" error: &error] toMutable];
+    auxDoc = [[_wordsCollection documentWithID: @"word3" error: &error] toMutable];
     [auxDoc removeValueForKey: @"vector"];
-    Assert([collection saveDocument:auxDoc error:&error]);
+    Assert([self.wordsCollection saveDocument:auxDoc error:&error]);
 
-    auxDoc = [[collection documentWithID: @"word4" error: &error] toMutable];
+    auxDoc = [[_wordsCollection documentWithID: @"word4" error: &error] toMutable];
     CBLMutableArray* vector = [auxDoc arrayForKey: @"vector"];
     [vector removeValueAtIndex: 0];
-    Assert([collection saveDocument: auxDoc error: &error]);
+    Assert([self.wordsCollection saveDocument: auxDoc error: &error]);
 
     // Create vector index
     NSString* expr = @"prediction(WordEmbedding,{\"word\": word}).vector";
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: expr
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_pred_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: VECTOR_INDEX_CONFIG(expr, 300, 8)];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_pred_index"]);
-
     // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_pred_index, $vector, 350)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_pred_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @350];
     NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
     AssertEqual(wordMap.count, 296);
     AssertNil(wordMap[@"word1"]);
@@ -719,17 +651,14 @@
     AssertNil(wordMap[@"word4"]);
     Assert([self checkIndexWasTrained]);
     
-    auxDoc = [[collection documentWithID: @"word5" error: &error] toMutable];
+    auxDoc = [[self.wordsCollection documentWithID: @"word5" error: &error] toMutable];
     [auxDoc setString: @"Fried Chicken" forKey: @"word"];
-    Assert([collection saveDocument: auxDoc error: &error]);
+    Assert([self.wordsCollection saveDocument: auxDoc error: &error]);
 
-    rs = [q execute: &error];
-    
+    rs = [self executeWordsQueryWithLimit: @350];
     wordMap = [self toDocIDWordMap: rs];
     AssertEqual(wordMap.count, 295);
     AssertNil(wordMap[@"word5"]);
-    
-    [CBLDatabase.prediction unregisterModelWithName: @"WordEmbedding"];
 }
 
 /**
@@ -759,58 +688,33 @@
  *     11. Repeat Step 2 – 10 by using SQ6 and SQ8 respectively.
  */
 - (void) testCreateVectorIndexWithSQ {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
     // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector" 
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     config.encoding = [CBLVectorEncoding scalarQuantizerWithType: kCBLSQ4];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 20);
-    Assert([self checkIndexWasTrained]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
     
     // Repeat using SQ6
     [self resetIndexWasTrainedLog];
-    [collection deleteIndexWithName: @"words_index" error: &error];
+    [self deleteWordsIndex];
     config.encoding = [CBLVectorEncoding scalarQuantizerWithType: kCBLSQ6];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
     // Rerun query:
-    rs = [q execute: &error];
-    allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 20);
-    Assert([self checkIndexWasTrained]);
+    rs = [self executeWordsQueryWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
     
     // Repeat using SQ8
     [self resetIndexWasTrainedLog];
-    [collection deleteIndexWithName: @"words_index" error: &error];
+    [self deleteWordsIndex];
     config.encoding = [CBLVectorEncoding scalarQuantizerWithType: kCBLSQ8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
     // Rerun query:
-    rs = [q execute: &error];
-    allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 20);
-    Assert([self checkIndexWasTrained]);
+    rs = [self executeWordsQueryWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
 }
 
 /**
@@ -837,39 +741,16 @@
  *     9. Reset the custom logger.
  */
 - (void) testCreateVectorIndexWithNoneEncoding {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     config.encoding = [CBLVectorEncoding none];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 20);
-    Assert([self checkIndexWasTrained]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
 }
 
 /**
  * FAILED : https://issues.couchbase.com/browse/CBL-5538
- * Disable bits = 12 for now.
  *
  * 12. TestCreateVectorIndexWithPQ
  * Description
@@ -897,42 +778,18 @@
  *     11. Repeat steps 2 to 10 by changing the PQ’s bits to 4 and 12 respectively.
  */
 - (void) testCreateVectorIndexWithPQ {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    for (NSNumber* bit in @[@4, @8, /* @12 */]) {
+    for (NSNumber* bits in @[@4, @8, @12]) {
         // Create vector index
-        CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                           dimensions: 300
-                                                                                            centroids: 8];
-        config.encoding = [CBLVectorEncoding productQuantizerWithSubquantizers: 5 bits: bit.unsignedIntValue];
-        Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-        
-        NSArray* names = [collection indexes: &error];
-        Assert([names containsObject: @"words_index"]);
+        CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+        config.encoding = [CBLVectorEncoding productQuantizerWithSubquantizers: 5 bits: bits.unsignedIntValue];
+        [self createWordsIndexWithConfig: config];
         
         // Query:
-        NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-        CBLQuery* q = [_db createQuery: sql error: &error];
-        
-        CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-        [parameters setValue: kDinnerVector forName: @"vector"];
-        [q setParameters: parameters];
-        
-        NSString* explain = [q explain: &error];
-        Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-        
-        CBLQueryResultSet* rs = [q execute: &error];
-        NSArray* allObjects = rs.allObjects;
-        AssertEqual(allObjects.count, 20);
-        // will re-enable once we increase the dataset
-        // Assert([self checkIndexWasTrained]);
+        CBLQueryResultSet* rs = [self executeWordsQueryNoTrainingCheckWithLimit: @20];
+        AssertEqual(rs.allObjects.count, 20);
         
         // Delete index
-        [collection deleteIndexWithName: @"words_index" error: &error];
-        
-        // Reset log
-        [self resetIndexWasTrainedLog];
+        Assert([self.wordsCollection deleteIndexWithName: @"words_index" error: nil]);
     }
 }
 
@@ -957,41 +814,27 @@
  *     7. Check that an invalid argument exception is thrown.
  */
 - (void) testSubquantizersValidation {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.encoding = [CBLVectorEncoding productQuantizerWithSubquantizers: 2 bits: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     
     // Step 5: Use valid subquantizer values
-    for (NSNumber* subq in @[@3, @4, @5, @6, @10, @12, @15, @20, @25, @30, @50, @60, @75, @100, @150, @300]) {
-        [collection deleteIndexWithName: @"words_index" error: &error];
+    for (NSNumber* subq in @[@3, @4, @5, @150, @300]) {
         config.encoding = [CBLVectorEncoding productQuantizerWithSubquantizers: subq.unsignedIntValue bits: 8];
-        Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+        [self createWordsIndexWithConfig: config];
+        [self deleteWordsIndex];
     }
     
     // Step 7: Check if exception thrown for wrong subquantizers:
-    [self expectException: NSInvalidArgumentException in:^{
-        for (NSNumber* subq in @[@0, @7]) {
-            [collection deleteIndexWithName: @"words_index" error: nil];
-            config.encoding = [CBLVectorEncoding productQuantizerWithSubquantizers: subq.unsignedIntValue bits: 8];
-            [collection createIndexWithName: @"words_index" config: config error: nil];
-        }
-    }];
+    CBLCollection* collection = self.wordsCollection;
+    for (NSNumber* subq in @[@0, @7]) {
+        config.encoding = [CBLVectorEncoding productQuantizerWithSubquantizers: subq.unsignedIntValue bits: 8];
+        [self expectException: NSInvalidArgumentException in: ^{
+            [collection createIndexWithName: kWordsIndexName config: config error: nil];
+        }];
+        [self deleteWordsIndex];
+    }
 }
 
 /**
- * https://issues.couchbase.com/browse/CBL-5537
- * The test will fail when using centroid = 20 as the number of vectors for training
- * the index is not low.
- *
  * 14. TestCreateVectorIndexWithFixedTrainingSize
  * Description
  *     Test that the vector index can be created and trained when minTrainingSize
@@ -1016,37 +859,13 @@
  *     8. Reset the custom logger.
  */
 - (void) testeCreateVectorIndexWithFixedTrainingSize {
-    CBLDatabase.log.console.level = kCBLLogLevelVerbose;
-    
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     config.minTrainingSize = 100;
     config.maxTrainingSize = 100;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 20);
-    Assert([self checkIndexWasTrained]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
 }
 
 /**
@@ -1060,7 +879,7 @@
  *     2. Create a vector index named "words_index" in _default.words collection.
  *         - expression: "vector"
  *         - dimensions: 300
- *         - centroids: 20
+ *         - centroids: 8
  *         - minTrainingSize: 1 and maxTrainingSize: 100
  *     3. Check that the index is created without an error returned.
  *     4. Delete the "words_index"
@@ -1071,35 +890,29 @@
  *     6. Check that an invalid argument exception was thrown for all cases in step 4.
  */
 - (void) testValidateMinMaxTrainingSize {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     config.minTrainingSize = 1;
     config.maxTrainingSize = 100;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
+    NSArray<NSArray<NSNumber *> *> *trainingSizes = @[
+        @[@0, @0],
+        @[@0, @100],
+        @[@10, @9]
+    ];
     
-    // Check if exception thrown for wrong values
-    [self expectException: NSInvalidArgumentException in:^{
-        NSArray<NSArray<NSNumber *> *> *trainingSizes = @[
-            @[@0, @0],
-            @[@0, @100],
-            @[@10, @9]
-        ];
+    CBLCollection* collection = self.wordsCollection;
+    for (size_t i = 0; i < trainingSizes.count; i++) {
+        config.minTrainingSize = trainingSizes[i][0].unsignedIntValue;
+        config.maxTrainingSize = trainingSizes[i][1].unsignedIntValue;
         
-        for (size_t i = 0; i < trainingSizes.count; i++) {
-            [collection deleteIndexWithName: @"words_index" error: nil];
-            config.minTrainingSize = trainingSizes[i][0].unsignedIntValue;
-            config.maxTrainingSize = trainingSizes[i][1].unsignedIntValue;
-            [collection createIndexWithName: @"words_index" config: config error: nil];
-        }
-    }];
+        // Check if exception thrown for wrong values
+        [self expectException: NSInvalidArgumentException in:^{
+            [collection createIndexWithName: kWordsIndexName config: config error: nil];
+        }];
+        
+        [self deleteWordsIndex];
+    }
 }
 
 /**
@@ -1127,35 +940,13 @@
  *     9. Reset the custom logger.
  */
 - (void) testQueryUntrainedVectorIndex {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    // out of bounds (300 words in db)
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     config.minTrainingSize = 400;
     config.maxTrainingSize = 500;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allObjects;
-    AssertEqual(allObjects.count, 20);
+    CBLQueryResultSet* rs = [self executeWordsQueryNoTrainingCheckWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
     AssertFalse([self checkIndexWasTrained]);
 }
 
@@ -1184,38 +975,17 @@
  *     9. Reset the custom logger.
  */
 - (void) testCreateVectorIndexWithCosineDistance {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     config.metric = kCBLDistanceMetricCosine;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word, vector_distance(words_index) from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allResults;
-    AssertEqual(allObjects.count, 20);
-    for(CBLQueryResult* result in rs){
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20 queryDistance: true andClause: false checkTraining: false];
+    NSArray* results = rs.allResults;
+    AssertEqual(results.count, 20);
+    for(CBLQueryResult* result in results){
         Assert([result doubleAtIndex: 3] > 0);
         Assert([result doubleAtIndex: 3] < 1);
     }
-    Assert([self checkIndexWasTrained]);
 }
 
 /**
@@ -1243,37 +1013,16 @@
  *     9. Reset the custom logger.
  */
 - (void) testCreateVectorIndexWithEuclideanDistance {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create vector index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     config.metric = kCBLDistanceMetricEuclidean;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    [self createWordsIndexWithConfig: config];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word, vector_distance(words_index) from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allResults;
-    AssertEqual(allObjects.count, 20);
-    for(CBLQueryResult* result in rs){
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20 queryDistance: true andClause: false checkTraining: false];
+    NSArray* results = rs.allResults;
+    AssertEqual(results.count, 20);
+    for(CBLQueryResult* result in results){
         Assert([result doubleAtIndex: 3] > 0);
     }
-    Assert([self checkIndexWasTrained]);
 }
 
 /**
@@ -1296,21 +1045,12 @@
  *     6. Check that the index is created without an error returned.
  */
 - (void) testCreateVectorIndexWithExistingName {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
+    [self createWordsIndexWithConfig: config];
     
-    // Create and recreate vector index using the same config
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    // Recreate index with same name using different config
-    CBLVectorIndexConfiguration* config2 = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vectors"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
-    Assert([collection createIndexWithName: @"words_index" config: config2 error: &error]);
+    config = VECTOR_INDEX_CONFIG(@"vectors", 300, 8);
+    [self createWordsIndexWithConfig: config];
 }
 
 /**
@@ -1341,41 +1081,17 @@
  *     12. Reset the custom logger.
  */
 - (void) testDeleteVectorIndex {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
     
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20];
+    AssertEqual(rs.allObjects.count, 20);
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allResults;
-    AssertEqual(allObjects.count, 20);
-    Assert([self checkIndexWasTrained]);
-    
-    // Delete index
-    [collection deleteIndexWithName: @"words_index" error: &error];
-    
-    names = [collection indexes: &error];
-    AssertFalse([names containsObject: @"words_index"]);
+    [self deleteWordsIndex];
     
     [self expectError: CBLErrorDomain code: CBLErrorMissingIndex in: ^BOOL(NSError **err) {
-        return [self->_db createQuery: sql error: err];
+        NSString* sql = [self wordsQueryStringWithLimit: @20 queryDistance: false andClause: nil];
+        return [self->_wordDB createQuery: sql error: err] != nil;
     }];
 }
 
@@ -1394,8 +1110,8 @@
  */
 - (void) testVectorMatchOnNonExistingIndex {
     [self expectError: CBLErrorDomain code: CBLErrorMissingIndex in: ^BOOL(NSError **err) {
-        NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-        return [self->_db createQuery: sql error: err];
+        NSString* sql = [self wordsQueryStringWithLimit: @20 queryDistance: false andClause: nil];
+        return [self->_wordDB createQuery: sql error: err] != nil;
     }];
 }
 
@@ -1423,34 +1139,11 @@
  *     9. Reset the custom logger.
  */
 - (void) testVectorMatchDefaultLimit {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: nil];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
     
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* allObjects = rs.allResults;
-    AssertEqual(allObjects.count, 3);
-    Assert([self checkIndexWasTrained]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: nil];
+    AssertEqual(rs.allObjects.count, 3);
 }
 
 /**
@@ -1464,7 +1157,7 @@
  *     2. Create a vector index named "words_index" in _default.words collection.
  *         - expression: "vector"
  *         - dimensions: 300
- *         - centroids: 20
+ *         - centroids: 8
  *     3. Check that the index is created without an error returned.
  *     4. Create an SQL++ query.
  *         - SELECT meta().id, word
@@ -1476,30 +1169,22 @@
  *     7. Check that a CouchbaseLiteException is returned when creating the query.
  */
 - (void) testVectorMatchLimitBoundary {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
     
     // Check valid query with 1 and 10000 set limit
     for (NSNumber* limit in @[@1, @10000]) {
-        NSString* sql = [NSString stringWithFormat: @"select meta().id, word from _default.words where vector_match(words_index, $vector, %d)", limit.unsignedIntValue];
-        Assert([_db createQuery: sql error: &error]);
+        NSError* error;
+        NSString* sql = [self wordsQueryStringWithLimit: limit queryDistance: false andClause: nil];
+        Assert([_wordDB createQuery: sql error: &error]);
         AssertNil(error);
     }
     
     // Check if error thrown for wrong limit values
     for (NSNumber* limit in @[@-1, @0, @10001]) {
         [self expectError: CBLErrorDomain code: CBLErrorInvalidQuery in: ^BOOL(NSError** err) {
-            return [self.db createQuery: [NSString stringWithFormat:@"select meta().id, word from _default.words where vector_match(words_index, $vector, %d)", limit.unsignedIntValue]
-                                  error: err] != nil;
+            NSString* sql = [self wordsQueryStringWithLimit: limit queryDistance: false andClause: nil];
+            return [self->_wordDB createQuery: sql error: err] != nil;
         }];
     }
 }
@@ -1529,37 +1214,19 @@
  *     10. Reset the custom logger.
  */
 - (void) testVectorMatchWithAndExpression {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
     
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @300 
+                                               queryDistance: false
+                                                   andClause: @"AND catid = 'cat1'" 
+                                               checkTraining: true];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query with a single AND:
-    NSString* sql = @"select word, catid from _default.words where vector_match(words_index, $vector, 300) AND catid = 'cat1'";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
     NSArray* results = rs.allResults;
     AssertEqual(results.count, 50);
     for(CBLQueryResult* result in results){
-        AssertEqualObjects([result valueAtIndex: 1], @"cat1");
+        AssertEqualObjects([result valueAtIndex: 2], @"cat1");
     }
-    Assert([self checkIndexWasTrained]);
 }
 
 /**
@@ -1587,37 +1254,19 @@
  *     10. Reset the custom logger.
  */
 - (void) testVectorMatchWithMultipleAndExpression {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
     
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @300
+                                               queryDistance: false
+                                                   andClause: @"AND word is valued AND catid = 'cat1'"
+                                               checkTraining: true];
     
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query with mutiple ANDs:
-    NSString* sql = @"select word, catid from _default.words where (vector_match(words_index, $vector, 300) AND word is valued) AND catid = 'cat1'";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
     NSArray* results = rs.allResults;
     AssertEqual(results.count, 50);
     for(CBLQueryResult* result in results){
-        AssertEqualObjects([result stringAtIndex: 1], @"cat1");
+        AssertEqualObjects([result valueAtIndex: 2], @"cat1");
     }
-    Assert([self checkIndexWasTrained]);
 }
 
 /**
@@ -1638,23 +1287,14 @@
  *     5. Check that a CouchbaseLiteException is returned when creating the query.
  */
 - (void) testInvalidVectorMatchWithOrExpression {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
     
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    NSArray* names = [collection indexes: &error];
-    Assert([names containsObject: @"words_index"]);
-    
-    // Query with OR:
-    NSString* sql = @"select meta().id, word, catid from _default.words where vector_match(words_index, $vector, 300) OR catid = 'cat1'";
-    [self expectError: CBLErrorDomain code: CBLErrorInvalidQuery in: ^BOOL(NSError** err) {
-        return [self.db createQuery: sql
-                              error: err] != nil;
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidQuery in: ^BOOL(NSError **err) {
+        NSString* sql = [self wordsQueryStringWithLimit: @20
+                                          queryDistance: false
+                                              andClause: @"OR catid = 'cat1'"];
+        return [self->_wordDB createQuery: sql error: err] != nil;
     }];
 }
 
@@ -1684,31 +1324,14 @@
  */
 - (void) testIndexVectorInBase64 {
     NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    CBLMutableDocument* doc = [[collection documentWithID: @"word49" error: &error] toMutable];
+    CBLMutableDocument* doc = [[self.wordsCollection documentWithID: @"word49" error: &error] toMutable];
     [doc setString: kLunchVectorBase64 forKey: @"vector"];
-    Assert([collection saveDocument: doc error: &error]);
+    Assert([self.wordsCollection saveDocument: doc error: &error]);
     
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
+    CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
+    [self createWordsIndexWithConfig: config];
     
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector, 20)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"SCAN kv_.words:vector:words_index"].location != NSNotFound);
-    
-    CBLQueryResultSet* rs = [q execute: &error];
+    CBLQueryResultSet* rs = [self executeWordsQueryWithLimit: @20];
     NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
     AssertEqual(wordMap.count, 20);
     AssertNotNil(wordMap[@"word49"]);
@@ -1742,1422 +1365,6 @@
      bits = 4
     */
     AssertEqual(config.encoding.hash, 31872);
-}
-
-#pragma mark - Lazy Vector Index test
-/**
- * Test Spec: https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0002-Lazy-Vector-Index.md
- */
-
-/**
- * 1. TestIsLazyDefaultValue
- * Description
- *     Test that isLazy property is false by default.
- * Steps
- *     1. Create a VectorIndexConfiguration object.
- *         - expression: "vector"
- *         - dimensions: 300
- *         - centroids: 20
- *     2.  Check that isLazy returns false.
- */
-- (void) testIsLazyDefaultValue {
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
-    AssertEqual(config.isLazy, false);
-}
-
-/**
- * 2. TestIsLazyAccessor
- *
- * Description
- * Test that isLazy getter/setter of the VectorIndexConfiguration work as expected.
- *
- * Steps
- * 1. Create a VectorIndexConfiguration object.
- *    - expression: word
- *    - dimensions: 300
- *    - centroids : 20
- * 2. Set isLazy to true
- * 3. Check that isLazy returns true.
- */
-- (void) testIsLazyAccessor {
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"vector"
-                                                                                       dimensions: 300
-                                                                                        centroids: 20];
-    config.isLazy = true;
-    AssertEqual(config.isLazy, true);
-}
-
-/**
- * 3. TestGetNonExistingIndex
- *
- * Description
- * Test that getting non-existing index object by name returning null.
- *
- * Steps
- * 1. Get the default collection from a test database.
- * 2. Get a QueryIndex object from the default collection with the name as
- *   "nonexistingindex".
- * 3. Check that the result is null.
- */
-// CBL-5864
-- (void) _testGetNonExistingIndex {
-    NSError* error;
-    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
-    
-    CBLQueryIndex* qIndex = [defaultCollection indexWithName: @"nonexistingindex" error: &error];
-    AssertNil(qIndex);
-}
-
-/**
- * 4. TestGetExistingNonVectorIndex
- *
- * Description
- * Test that getting non-existing index object by name returning an index object correctly.
- *
- * Steps
- * 1. Get the default collection from a test database.
- * 2. Create a value index named "value_index" in the default collection
- *   with the expression as "value".
- * 3. Get a QueryIndex object from the default collection with the name as
- *   "value_index".
- * 4. Check that the result is not null.
- * 5. Check that the QueryIndex's name is "value_index".
- * 6. Check that the QueryIndex's collection is the same instance that
- *   is used for getting the QueryIndex object.
- */
-- (void) testGetExistingNonVectorIndex {
-    NSError* error;
-    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
-    
-    CBLValueIndexItem* item = [CBLValueIndexItem expression:
-                               [CBLQueryExpression property: @"value"]];
-    CBLValueIndex* vIndex = [CBLIndexBuilder valueIndexWithItems: @[item]];
-    [defaultCollection createIndex: vIndex name: @"value_index" error: &error];
-    AssertNil(error);
-    
-    CBLQueryIndex* qIndex = [defaultCollection indexWithName: @"value_index" error: &error];
-    AssertEqual(qIndex.name, @"value_index");
-    AssertEqual(qIndex.collection, defaultCollection);
-}
-
-/**
- * 5. TestGetExistingVectorIndex
- *
- * Description
- * Test that getting an existing index object by name returning an index object correctly.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "vector"
- *     - dimensions: 300
- *     - centroids : 8
- * 3. Get a QueryIndex object from the words collection with the name as "words_index".
- * 4. Check that the result is not null.
- * 5. Check that the QueryIndex's name is "words_index".
- * 6. Check that the QueryIndex's collection is the same instance that is used for
- *   getting the index.
- */
-- (void) testGetExistingVectorIndex {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    AssertNotNil(qIndex);
-    AssertEqual(qIndex.name, @"words_index");
-    AssertEqual(qIndex.collection, collection);
-}
-
-/**
- * 6. TestGetIndexOnClosedDatabase
- *
- * Description
- * Test that a CouchbaseLiteException is thrown when getting an index object on a closed database.
- *
- * Steps
- * 1. Get the default collection from a test database.
- * 2. Close the test database.
- * 3. Get a QueryIndex object from the default collection with the name as "nonexistingindex".
- * 4. Check that a CouchbaseLiteException with the code NotOpen is thrown.
- */
-- (void) testGetIndexOnClosedDatabase {
-    NSError* error;
-    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
-    
-    [self.db close: &error];
-    
-    [self expectError: CBLErrorDomain code: CBLErrorNotOpen in: ^BOOL(NSError** err) {
-        return [defaultCollection indexWithName: @"nonexistingindex" error: err] != nil;
-    }];
-}
-
-/**
- * 7. TestGetIndexOnDeletedCollection
- *
- * Description
- * Test that a CouchbaseLiteException is thrown when getting an index object on a deleted collection.
- *
- * Steps
- * 1. Create a collection named "collA" in the default scope from a test database.
- * 2. Delete the collection named "collA" in the default scope from the test database.
- * 3. Using the collection object from the step 1, get a QueryIndex object from the default collection
- * with the name as "nonexistingindex".
- * 4. Check that a CouchbaseLiteException with the code NotOpen is thrown.
- */
-- (void) testGetIndexOnDeletedCollection {
-    NSError* error;
-    CBLCollection* colA = [self.db createCollectionWithName: @"collA" scope: nil error: &error];
-    AssertNil(error);
-    
-    [self.db deleteCollectionWithName: @"collA" scope: nil error: &error];
-    
-    [self expectError: CBLErrorDomain code: CBLErrorNotOpen in: ^BOOL(NSError** err) {
-        return [colA indexWithName: @"nonexistingindex" error: err] != nil;
-    }];
-}
-
-/**
- * 8. TestLazyVectorIndexNotAutoUpdatedChangedDocs
- *
- * Description
- * Test that the lazy index is lazy. The index will not be automatically
- * updated when the documents are created or updated.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Create an SQL++ query:
- *     - SELECT word
- *       FROM _default.words
- *       WHERE vector_match(words_index, < dinner vector >)
- * 4. Execute the query and check that 0 results are returned.
- * 5. Update the documents:
- *     - Create _default.words.word301 with the content from _default.extwords.word1
- *     - Update _default.words.word1 with the content from _default.extwords.word3
- * 6. Execute the same query and check that 0 results are returned.
- */
-- (void) testLazyVectorIndexNotAutoUpdatedChangedDocs {
-    NSError* error;
-    CBLCollection* wordsCollection = [_db collectionWithName: @"words" scope: nil error: &error];
-    CBLCollection* extWordsCollection = [_db collectionWithName: @"extwords" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([wordsCollection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    // Query:
-    NSString* sql = @"select meta().id, word from _default.words where vector_match(words_index, $vector)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    NSArray* results = rs.allResults;
-    AssertEqual(results.count, 0);
-    
-    // Update docs:
-    CBLDocument* extWord1 = [extWordsCollection documentWithID: @"word1" error : &error];
-    CBLMutableDocument* word301 = [self createDocument: @"word301" data: [extWord1 toDictionary]];
-    Assert([wordsCollection saveDocument: word301 error: &error]);
-    
-    CBLDocument* extWord3 = [extWordsCollection documentWithID: @"word3" error : &error];
-    CBLMutableDocument* word1 = [[wordsCollection documentWithID: @"word1" error: &error] toMutable];
-    [word1 setData: [extWord3 toDictionary]];
-    Assert([wordsCollection saveDocument: word1 error: &error]);
-    
-    rs = [q execute: &error];
-    results = rs.allResults;
-    AssertEqual(results.count, 0);
-}
-
-/**
- * 9. TestLazyVectorIndexAutoUpdateDeletedDocs
- *
- * Description
- * Test that when the lazy vector index automatically update when documents are
- * deleted.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Call beginUpdate() with limit 1 to get an IndexUpdater object.
- * 4. Check that the IndexUpdater is not null and IndexUpdater.count = 1.
- * 5. With the IndexUpdater object:
- *    - Get the word string from the IndexUpdater.
- *    - Query the vector by word from the _default.words collection.
- *    - Convert the vector result which is an array object to a platform's float array.
- *    - Call setVector() with the platform's float array at the index.
- *    - Call finish()
- * 6. Create an SQL++ query:
- *    - SELECT word
- *      FROM _default.words
- *      WHERE vector_match(words_index, < dinner vector >, 300)
- * 7. Execute the query and check that 1 results are returned.
- * 8. Check that the word gotten from the query result is the same as the word in Step 5.
- * 9. Delete _default.words.word1 doc.
- * 10. Execute the same query as Step again and check that 0 results are returned.
- */
-- (void) testLazyVectorIndexAutoUpdateDeletedDocs {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 1 error: &error];
-    AssertNotNil(indexUpdater);
-    AssertEqual(indexUpdater.count, 1);
-    
-    // Update Index:
-    NSString* word = [indexUpdater stringAtIndex: 0];
-    NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-    [indexUpdater setVector: vector atIndex: 0 error: &error];
-    [indexUpdater finishWithError: &error];
-    AssertNil(error);
-    
-    // Query:
-    NSString* sql = @"select word, meta().id from _default.words where vector_match(words_index, $vector, 300)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    
-    NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
-    AssertEqual(wordMap.count, 1);
-    AssertNotNil(wordMap[word]);
-    
-    [collection deleteDocument:[collection documentWithID: @"word1" error:&error] error:&error];
-    rs = [q execute: &error];
-    AssertEqual(rs.allResults.count, 0);
-}
-
-/**
- * 10. TestLazyVectorIndexAutoUpdatePurgedDocs
- *
- * Description
- * Test that when the lazy vector index automatically update when documents are
- * purged.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Call beginUpdate() with limit 1 to get an IndexUpdater object.
- * 4. Check that the IndexUpdater is not null and IndexUpdater.count = 1.
- * 5. With the IndexUpdater object:
- *    - Get the word string from the IndexUpdater.
- *    - Query the vector by word from the _default.words collection.
- *    - Convert the vector result which is an array object to a platform's float array.
- *    - Call setVector() with the platform's float array at the index.
- * 6. With the IndexUpdater object, call finish()
- * 7. Create an SQL++ query:
- *    - SELECT word
- *      FROM _default.words
- *      WHERE vector_match(words_index, < dinner vector >, 300)
- * 8. Execute the query and check that 1 results are returned.
- * 9. Check that the word gotten from the query result is the same as the word in Step 5.
- * 10. Purge _default.words.word1 doc.
- * 11. Execute the same query as Step again and check that 0 results are returned.
- */
-- (void) testLazyVectorIndexAutoUpdatePurgedDocs {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 1 error: &error];
-    AssertNotNil(indexUpdater);
-    AssertEqual(indexUpdater.count, 1);
-    
-    // Update Index:
-    NSString* word = [indexUpdater stringAtIndex: 0];
-    NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-    [indexUpdater setVector: vector atIndex: 0 error: &error];
-    [indexUpdater finishWithError: &error];
-    AssertNil(error);
-    
-    // Query:
-    NSString* sql = @"select word, meta().id from _default.words where vector_match(words_index, $vector, 300)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    
-    NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
-    AssertEqual(wordMap.count, 1);
-    AssertNotNil(wordMap[word]);
-    
-    [collection purgeDocumentWithID: @"word1" error: &error];
-    rs = [q execute: &error];
-    AssertEqual(rs.allResults.count, 0);
-}
-
-/**
- * 11. TestIndexUpdaterBeginUpdateOnNonVectorIndex
- *
- * Description
- * Test that a CouchbaseLiteException is thrown when calling beginUpdate on
- * a non vector index.
- *
- * Steps
- * 1. Get the default collection from a test database.
- * 2. Create a value index named "value_index" in the default collection with the
- *   expression as "value".
- * 3. Get a QueryIndex object from the default collection with the name as
- *   "value_index".
- * 4. Call beginUpdate() with limit 10 on the QueryIndex object.
- * 5. Check that a CouchbaseLiteException with the code Unsupported is thrown.
- */
-- (void) testIndexUpdaterBeginUpdateOnNonVectorIndex {
-    NSError* error;
-    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
-    AssertNil(error);
-    
-    CBLValueIndexItem* item = [CBLValueIndexItem expression:
-                               [CBLQueryExpression property: @"value"]];
-    CBLValueIndex* vIndex = [CBLIndexBuilder valueIndexWithItems: @[item]];
-    [defaultCollection createIndex: vIndex name: @"value_index" error: &error];
-    
-    AssertNil(error);
-    
-    CBLQueryIndex* qIndex = [defaultCollection indexWithName: @"value_index" error: &error];
-    
-    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
-        return [qIndex beginUpdateWithLimit: 10 error: err] != nil;
-    }];
-}
-
-/**
- * 12. TestIndexUpdaterBeginUpdateOnNonLazyVectorIndex
- *
- * Description
- * Test that a CouchbaseLiteException is thrown when calling beginUpdate
- * on a non lazy vector index.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- * 3. Get a QueryIndex object from the words collection with the name as
- *   "words_index".
- * 4. Call beginUpdate() with limit 10 on the QueryIndex object.
- * 5. Check that a CouchbaseLiteException with the code Unsupported is thrown.
- */
-- (void) testIndexUpdaterBeginUpdateOnNonLazyVectorIndex {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    
-    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
-        return [qIndex beginUpdateWithLimit: 10 error: err] != nil;
-    }];
-}
-
-/**
- * 13. TestIndexUpdaterBeginUpdateWithZeroLimit
- *
- * Description
- * Test that an InvalidArgument exception is returned when calling beginUpdate
- * with zero limit.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Get a QueryIndex object from the words collec
- *    "words_index".
- * 4. Call beginUpdate() with limit 0 on the QueryIndex object.
- * 5. Check that an InvalidArgumentException is thrown.
- */
-- (void) testIndexUpdaterBeginUpdateWithZeroLimit {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** err) {
-        return [qIndex beginUpdateWithLimit: 0 error: err] != nil;
-    }];
-}
-
-/**
- * 14. TestIndexUpdaterBeginUpdateOnLazyVectorIndex
- *
- * Description
- * Test that calling beginUpdate on a lazy vector index returns an IndexUpdater.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Get a QueryIndex object from the words with the name as "words_index".
- * 4. Call beginUpdate() with limit 10 on the QueryIndex object.
- * 5. Check that the returned IndexUpdater is not null.
- * 6. Check that the IndexUpdater.count is 10.
- */
-- (void) testIndexUpdaterBeginUpdateOnLazyVectorIndex {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 10 error: &error];
-    AssertNotNil(indexUpdater);
-    AssertEqual(indexUpdater.count, 10);
-}
-
-/**
- * 15. TestIndexUpdaterGettingValues
- *
- * Description
- * Test all type getters and toArary() from the Array interface. The test
- * may be divided this test into multiple tests per type getter as appropriate.
- *
- * Steps
- * 1. Get the default collection from a test database.
- * 2. Create the followings documents:
- *     - doc-0 : { "value": "a string" }
- *     - doc-1 : { "value": 100 }
- *     - doc-2 : { "value": 20.8 }
- *     - doc-3 : { "value": true }
- *     - doc-4 : { "value": false }
- *     - doc-5 : { "value": Date("2024-05-10T00:00:00.000Z") }
- *     - doc-6 : { "value": Blob(Data("I'm Bob")) }
- *     - doc-7 : { "value": {"name": "Bob"} }
- *     - doc-8 : { "value": ["one", "two", "three"] }
- *     - doc-9 : { "value": null }
- * 3. Create a vector index named "vector_index" in the default collection.
- *     - expression: "value"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 4. Get a QueryIndex object from the default collection with the name as
- *    "vector_index".
- * 5. Call beginUpdate() with limit 10 to get an IndexUpdater object.
- * 6. Check that the IndexUpdater.count is 10.
- * 7. Get string value from each index and check the followings:
- *     - getString(0) : value == "a string"
- *     - getString(1) : value == null
- *     - getString(2) : value == null
- *     - getString(3) : value == null
- *     - getString(4) : value == null
- *     - getString(5) : value == "2024-05-10T00:00:00.000Z"
- *     - getString(6) : value == null
- *     - getString(7) : value == null
- *     - getString(8) : value == null
- *     - getString(9) : value == null
- * 8. Get integer value from each index and check the followings:
- *     - getInt(0) : value == 0
- *     - getInt(1) : value == 100
- *     - getInt(2) : value == 20
- *     - getInt(3) : value == 1
- *     - getInt(4) : value == 0
- *     - getInt(5) : value == 0
- *     - getInt(6) : value == 0
- *     - getInt(7) : value == 0
- *     - getInt(8) : value == 0
- *     - getInt(9) : value == 0
- * 9. Get float value from each index and check the followings:
- *     - getFloat(0) : value == 0.0
- *     - getFloat(1) : value == 100.0
- *     - getFloat(2) : value == 20.8
- *     - getFloat(3) : value == 1.0
- *     - getFloat(4) : value == 0.0
- *     - getFloat(5) : value == 0.0
- *     - getFloat(6) : value == 0.0
- *     - getFloat(7) : value == 0.0
- *     - getFloat(8) : value == 0.0
- *     - getFloat(9) : value == 0.0
- * 10. Get double value from each index and check the followings:
- *     - getDouble(0) : value == 0.0
- *     - getDouble(1) : value == 100.0
- *     - getDouble(2) : value == 20.8
- *     - getDouble(3) : value == 1.0
- *     - getDouble(4) : value == 0.0
- *     - getDouble(5) : value == 0.0
- *     - getDouble(6) : value == 0.0
- *     - getDouble(7) : value == 0.0
- *     - getDouble(8) : value == 0.0
- *     - getDouble(9) : value == 0.0
- * 11. Get boolean value from each index and check the followings:
- *     - getBoolean(0) : value == true
- *     - getBoolean(1) : value == true
- *     - getBoolean(2) : value == true
- *     - getBoolean(3) : value == true
- *     - getBoolean(4) : value == false
- *     - getBoolean(5) : value == true
- *     - getBoolean(6) : value == true
- *     - getBoolean(7) : value == true
- *     - getBoolean(8) : value == true
- *     - getBoolean(9) : value == false
- * 12. Get date value from each index and check the followings:
- *     - getDate(0) : value == "2024-05-10T00:00:00.000Z"
- *     - getDate(1) : value == null
- *     - getDate(2) : value == null
- *     - getDate(3) : value == null
- *     - getDate(4) : value == null
- *     - getDate(5) : value == Date("2024-05-10T00:00:00.000Z")
- *     - getDate(6) : value == null
- *     - getDate(7) : value == null
- *     - getDate(8) : value == null
- *     - getDate(9) : value == null
- * 13. Get blob value from each index and check the followings:
- *     - getBlob(0) : value == null
- *     - getBlob(1) : value == null
- *     - getBlob(2) : value == null
- *     - getBlob(3) : value == null
- *     - getBlob(4) : value == null
- *     - getBlob(5) : value == null
- *     - getBlob(6) : value == Blob(Data("I'm Bob"))
- *     - getBlob(7) : value == null
- *     - getBlob(8) : value == null
- *     - getBlob(9) : value == null
- * 14. Get dictionary object from each index and check the followings:
- *     - getDictionary(0) : value == null
- *     - getDictionary(1) : value == null
- *     - getDictionary(2) : value == null
- *     - getDictionary(3) : value == null
- *     - getDictionary(4) : value == null
- *     - getDictionary(5) : value == null
- *     - getDictionary(6) : value == null
- *     - getDictionary(7) : value == Dictionary({"name": "Bob"})
- *     - getDictionary(8) : value == null
- *     - getDictionary(9) : value == null
- * 15. Get array object from each index and check the followings:
- *     - getArray(0) : value == null
- *     - getArray(1) : value == null
- *     - getArray(2) : value == null
- *     - getArray(3) : value == null
- *     - getArray(4) : value == null
- *     - getArray(5) : value == null
- *     - getArray(6) : value == null
- *     - getArray(7) : value == null
- *     - getArray(8) : value == Array(["one", "two", "three"])
- *     - getArray(9) : value == null
- * 16. Get value from each index and check the followings:
- *     - getValue(0) : value == "a string"
- *     - getValue(1) : value == PlatformNumber(100)
- *     - getValue(2) : value == PlatformNumber(20.8)
- *     - getValue(3) : value == PlatformBoolean(true)
- *     - getValue(4) : value == PlatformBoolean(false)
- *     - getValue(5) : value == Date("2024-05-10T00:00:00.000Z")
- *     - getValue(6) : value == Blob(Data("I'm Bob"))
- *     - getValue(7) : value == Dictionary({"name": "Bob"})
- *     - getValue(8) : value == Array(["one", "two", "three"])
- *     - getValue(9) : value == null
- * 17. Get IndexUodater values as a platform array by calling toArray() and check
- *     that the array contains all values as expected.
- */
-- (void) testIndexUpdaterGettingValues {
-    NSError* error;
-    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
-    AssertNil(error);
-    
-    CBLMutableDocument* mdoc = [self createDocument: @"doc-0"];
-    [mdoc setValue: @"a string" forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-1"];
-    [mdoc setValue: @(100) forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-2"];
-    [mdoc setValue: @(20.8) forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-3"];
-    [mdoc setValue: @(true) forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-4"];
-    [mdoc setValue: @(false) forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-5"];
-    [mdoc setValue: [CBLJSON dateWithJSONObject: @"2024-05-10T00:00:00.000Z"] forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-6"];
-    NSData* content = [@"I'm Blob" dataUsingEncoding: NSUTF8StringEncoding];
-    CBLBlob* blob = [[CBLBlob alloc] initWithContentType:@"text/plain" data: content];
-    [mdoc setValue: blob forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-7"];
-    CBLMutableDictionary* dict = [[CBLMutableDictionary alloc] init];
-    [dict setValue: @"Bob" forKey: @"name"];
-    [mdoc setValue: dict forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-8"];
-    CBLMutableArray* array = [[CBLMutableArray alloc] init];
-    [array addValue: @"one"];
-    [array addValue: @"two"];
-    [array addValue: @"three"];
-    [mdoc setValue: array forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    mdoc = [self createDocument: @"doc-9"];
-    [mdoc setValue: [NSNull null] forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"value"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([defaultCollection createIndexWithName: @"vector_index" config: config error: &error]);
-    
-    CBLQueryIndex* qIndex = [defaultCollection indexWithName: @"vector_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 10 error: &error];
-    AssertEqual(indexUpdater.count, 10);
-    
-    // String getter
-    Assert([[indexUpdater stringAtIndex: 0] isEqual: @"a string"]);
-    AssertEqual([indexUpdater stringAtIndex: 1], nil);
-    AssertEqual([indexUpdater stringAtIndex: 2], nil);
-    AssertEqual([indexUpdater stringAtIndex: 3], nil);
-    AssertEqual([indexUpdater stringAtIndex: 4], nil);
-    Assert([[indexUpdater stringAtIndex: 5] isEqual: @"2024-05-10T00:00:00.000Z"]);
-    AssertEqual([indexUpdater stringAtIndex: 6], nil);
-    AssertEqual([indexUpdater stringAtIndex: 7], nil);
-    AssertEqual([indexUpdater stringAtIndex: 8], nil);
-    AssertEqual([indexUpdater stringAtIndex: 9], nil);
-    
-    // Int getter
-    AssertEqual([indexUpdater integerAtIndex: 0], 0);
-    AssertEqual([indexUpdater integerAtIndex: 1], 100);
-    AssertEqual([indexUpdater integerAtIndex: 2], 20);
-    AssertEqual([indexUpdater integerAtIndex: 3], 1);
-    AssertEqual([indexUpdater integerAtIndex: 4], 0);
-    AssertEqual([indexUpdater integerAtIndex: 5], 0);
-    AssertEqual([indexUpdater integerAtIndex: 6], 0);
-    AssertEqual([indexUpdater integerAtIndex: 7], 0);
-    AssertEqual([indexUpdater integerAtIndex: 8], 0);
-    AssertEqual([indexUpdater integerAtIndex: 9], 0);
-    
-    // Float getter
-    AssertEqual([indexUpdater floatAtIndex: 0], 0.0);
-    AssertEqual([indexUpdater floatAtIndex: 1], 100.0);
-    AssertEqual([indexUpdater floatAtIndex: 2], (float)20.8);
-    AssertEqual([indexUpdater floatAtIndex: 3], 1.0);
-    AssertEqual([indexUpdater floatAtIndex: 4], 0.0);
-    AssertEqual([indexUpdater floatAtIndex: 5], 0.0);
-    AssertEqual([indexUpdater floatAtIndex: 6], 0.0);
-    AssertEqual([indexUpdater floatAtIndex: 7], 0.0);
-    AssertEqual([indexUpdater floatAtIndex: 8], 0.0);
-    AssertEqual([indexUpdater floatAtIndex: 9], 0.0);
-    
-    // Double getter
-    AssertEqual([indexUpdater doubleAtIndex: 0], 0.0);
-    AssertEqual([indexUpdater doubleAtIndex: 1], 100.0);
-    AssertEqual([indexUpdater doubleAtIndex: 2], 20.8);
-    AssertEqual([indexUpdater doubleAtIndex: 3], 1.0);
-    AssertEqual([indexUpdater doubleAtIndex: 4], 0.0);
-    AssertEqual([indexUpdater doubleAtIndex: 5], 0.0);
-    AssertEqual([indexUpdater doubleAtIndex: 6], 0.0);
-    AssertEqual([indexUpdater doubleAtIndex: 7], 0.0);
-    AssertEqual([indexUpdater doubleAtIndex: 8], 0.0);
-    AssertEqual([indexUpdater doubleAtIndex: 9], 0.0);
-    
-    // Boolean getter
-    AssertEqual([indexUpdater booleanAtIndex: 0], true);
-    AssertEqual([indexUpdater booleanAtIndex: 1], true);
-    AssertEqual([indexUpdater booleanAtIndex: 2], true);
-    AssertEqual([indexUpdater booleanAtIndex: 3], true);
-    AssertEqual([indexUpdater booleanAtIndex: 4], false);
-    AssertEqual([indexUpdater booleanAtIndex: 5], true);
-    AssertEqual([indexUpdater booleanAtIndex: 6], true);
-    AssertEqual([indexUpdater booleanAtIndex: 7], true);
-    AssertEqual([indexUpdater booleanAtIndex: 8], true);
-    AssertEqual([indexUpdater booleanAtIndex: 9], false);
-    
-    // Date getter
-    AssertEqual([indexUpdater dateAtIndex: 0], nil);
-    AssertEqual([indexUpdater dateAtIndex: 1], nil);
-    AssertEqual([indexUpdater dateAtIndex: 2], nil);
-    AssertEqual([indexUpdater dateAtIndex: 3], nil);
-    AssertEqual([indexUpdater dateAtIndex: 4], nil);
-    Assert([[indexUpdater dateAtIndex: 5] isEqual: [CBLJSON dateWithJSONObject: @"2024-05-10T00:00:00.000Z"]]);
-    AssertEqual([indexUpdater dateAtIndex: 6], nil);
-    AssertEqual([indexUpdater dateAtIndex: 7], nil);
-    AssertEqual([indexUpdater dateAtIndex: 8], nil);
-    AssertEqual([indexUpdater dateAtIndex: 9], nil);
-    
-    // Blob getter
-    AssertEqual([indexUpdater blobAtIndex: 0], nil);
-    AssertEqual([indexUpdater blobAtIndex: 1], nil);
-    AssertEqual([indexUpdater blobAtIndex: 2], nil);
-    AssertEqual([indexUpdater blobAtIndex: 3], nil);
-    AssertEqual([indexUpdater blobAtIndex: 4], nil);
-    AssertEqual([indexUpdater blobAtIndex: 5], nil);
-    Assert([[indexUpdater blobAtIndex: 6] isEqual: blob]);
-    AssertEqual([indexUpdater blobAtIndex: 7], nil);
-    AssertEqual([indexUpdater blobAtIndex: 8], nil);
-    AssertEqual([indexUpdater blobAtIndex: 9], nil);
-    
-    // Dict getter
-    AssertEqual([indexUpdater dictionaryAtIndex: 0], nil);
-    AssertEqual([indexUpdater dictionaryAtIndex: 1], nil);
-    AssertEqual([indexUpdater dictionaryAtIndex: 2], nil);
-    AssertEqual([indexUpdater dictionaryAtIndex: 3], nil);
-    AssertEqual([indexUpdater dictionaryAtIndex: 4], nil);
-    AssertEqual([indexUpdater dictionaryAtIndex: 5], nil);
-    AssertEqual([indexUpdater dictionaryAtIndex: 6], nil);
-    Assert([[indexUpdater dictionaryAtIndex: 7] isEqual: dict]);
-    AssertEqual([indexUpdater dictionaryAtIndex: 8], nil);
-    AssertEqual([indexUpdater dictionaryAtIndex: 9], nil);
-    
-    // Array getter
-    AssertEqual([indexUpdater arrayAtIndex: 0], nil);
-    AssertEqual([indexUpdater arrayAtIndex: 1], nil);
-    AssertEqual([indexUpdater arrayAtIndex: 2], nil);
-    AssertEqual([indexUpdater arrayAtIndex: 3], nil);
-    AssertEqual([indexUpdater arrayAtIndex: 4], nil);
-    AssertEqual([indexUpdater arrayAtIndex: 5], nil);
-    AssertEqual([indexUpdater arrayAtIndex: 6], nil);
-    AssertEqual([indexUpdater arrayAtIndex: 7], nil);
-    Assert([[indexUpdater arrayAtIndex: 8] isEqual: array]);
-    AssertEqual([indexUpdater arrayAtIndex: 9], nil);
-    
-    // Value getter
-    Assert([[indexUpdater valueAtIndex: 0] isEqual: @"a string"]);
-    Assert([[indexUpdater valueAtIndex: 1] isEqual: @(100)]);
-    Assert([[indexUpdater valueAtIndex: 2] isEqual: @(20.8)]);
-    Assert([[indexUpdater valueAtIndex: 3] isEqual: @(true)]);
-    Assert([[indexUpdater valueAtIndex: 4] isEqual: @(false)]);
-    Assert([[indexUpdater valueAtIndex: 5] isEqual: @"2024-05-10T00:00:00.000Z"]);
-    Assert([[indexUpdater valueAtIndex: 6] isEqual: blob]);
-    Assert([[indexUpdater valueAtIndex: 7] isEqual: dict]);
-    Assert([[indexUpdater valueAtIndex: 8] isEqual: array]);
-    Assert([[indexUpdater valueAtIndex: 9] isEqual: [NSNull null]]);
-    
-    NSArray* trueArray = @[@"a string", @(100), @(20.8), @(true), @(false), @"2024-05-10T00:00:00.000Z", blob, [dict toDictionary], [array toArray], [NSNull null]];
-    NSArray* updaterArray = [indexUpdater toArray];
-    for (NSUInteger i = 0; i < trueArray.count; i++) {
-        NSLog(@"Item: %@", updaterArray[i]);
-        AssertEqualObjects(updaterArray[i], trueArray[i]);
-    }
-}
-
-/**
- * 17. TestIndexUpdaterSetFloatArrayVectors
- *
- * Description
- * Test that setting float array vectors works as expected.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Get a QueryIndex object from the words with the name as "words_index".
- * 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
- * 5. With the IndexUpdater object, for each index from 0 to 9.
- *     - Get the word string from the IndexUpdater and store the word string in a set for verifying
- *        the vector search result.
- *     - Query the vector by word from the _default.words collection.
- *     - Convert the vector result which is an array object to a platform's float array.
- *     - Call setVector() with the platform's float array at the index.
- * 6. With the IndexUpdater object, call finish()
- * 7. Execute a vector search query.
- *     - SELECT word
- *       FROM _default.words
- *       WHERE vector_match(words_index, < dinner vector >, 300)
- * 8. Check that there are 10 words returned.
- * 9. Check that the word is in the word set from the step 5.
- */
-
-- (void) testIndexUpdaterSetFloatArrayVectors {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 10 error: &error];
-    AssertNotNil(indexUpdater);
-    AssertEqual(indexUpdater.count, 10);
-    
-    // Update Index:
-    NSMutableArray<NSString*>* indexedWords = [NSMutableArray array];
-    for(NSUInteger i = 0; i < indexUpdater.count; i++) {
-        NSString* word = [indexUpdater stringAtIndex: i];
-        [indexedWords addObject: word];
-        NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-        [indexUpdater setVector: vector atIndex: i error: &error];
-    }
-    [indexUpdater finishWithError: &error];
-    AssertNil(error);
-    
-    // Query:
-    NSString* sql = @"select word, meta().id from _default.words where vector_match(words_index, $vector, 300)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    
-    NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
-    AssertEqual(wordMap.count, 10);
-    for(NSString* word in indexedWords) {
-        Assert(wordMap[word]);
-    }
-}
-
-/**
- * 20. TestIndexUpdaterSetInvalidVectorDimensions
- *
- * Description
- * Test thta the vector with the invalid dimenions different from the dimensions
- * set to the configuration will not be included in the index.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Get a QueryIndex object from the words with the name as "words_index".
- * 4. Call beginUpdate() with limit 1 to get an IndexUpdater object.
- * 5. With the IndexUpdater object, call setVector() with a float array as [1.0]
- * 6. Check that the setVector throws CouchbaseLiteException with the InvalidParameter error.
- */
-// CBL-5814
-- (void) _testIndexUpdaterSetInvalidVectorDimensions {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 1 error: &error];
-    AssertNotNil(indexUpdater);
-    AssertEqual(indexUpdater.count, 1);
-    
-    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** err) {
-        return [indexUpdater setVector: @[@1.0] atIndex: 0 error: err];
-    }];
-}
-
-/**
- * 21. TestIndexUpdaterSkipVectors
- *
- * Description
- * Test that skipping vectors works as expected.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Get a QueryIndex object from the words with the name as "words_index".
- * 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
- * 5. With the IndexUpdater object, for each index from 0 - 9.
- *     - Get the word string from the IndexUpdater.
- *     - If index % 2 == 0,
- *         - Store the word string in a skipped word set for verifying the
- *           skipped words later.
- *         - Call skipVector at the index.
- *     - If index % 2 != 0,
- *         - Store the word string in a indexed word set for verifying the
- *           vector search result.
- *         - Query the vector by word from the _default.words collection.
- *         - Convert the vector result which is an array object to a platform's float array.
- *         - Call setVector() with the platform's float array at the index.
- * 6. With the IndexUpdater object, call finish()
- * 7. Execute a vector search query.
- *     - SELECT word
- *       FROM _default.words
- *       WHERE vector_match(words_index, < dinner vector >, 300)
- * 8. Check that there are 5 words returned.
- * 9. Check that the word is in the indexed word set from the step 5.
- * 10. Call beginUpdate() with limit 5 to get an IndexUpdater object.
- * 11. With the IndexUpdater object, for each index from 0 - 4.
- *     - Get the word string from the dictionary for the key named "word".
- *     - Check that the word is in the skipped word set from the step 5.
- */
-// CBL-5842
-- (void) _testIndexUpdaterSkipVectors{
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 10 error: &error];
-    
-    AssertNotNil(indexUpdater);
-    AssertEqual(indexUpdater.count, 10);
-    
-    // Update Index:
-    NSMutableArray<NSString*>* skippedWords = [NSMutableArray array];
-    NSMutableArray<NSString*>* indexedWords = [NSMutableArray array];
-    for(NSUInteger i = 0; i < indexUpdater.count; i++) {
-        NSString* word = [indexUpdater stringAtIndex: i];
-        if (i % 2 == 0) {
-            [skippedWords addObject: word];
-            [indexUpdater skipVectorAtIndex: i];
-        } else {
-            [indexedWords addObject: word];
-            NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-            [indexUpdater setVector: vector atIndex: i error: &error];
-        }
-    }
-    [indexUpdater finishWithError: &error];
-    AssertNil(error);
-    AssertEqual(skippedWords.count, 5);
-    AssertEqual(indexedWords.count, 5);
-    
-    // Query:
-    NSString* sql = @"select word, meta().id from _default.words where vector_match(words_index, $vector, 300)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    
-    NSDictionary<NSString*, NSString*>* wordMap = [self toDocIDWordMap: rs];
-    AssertEqual(wordMap.count, 5);
-    for(NSString* word in indexedWords) {
-        Assert(wordMap[word]);
-    }
-    
-    // Update index for the skipped words:
-    indexUpdater = [qIndex beginUpdateWithLimit: 5 error: &error];
-    AssertEqual(indexUpdater.count, 5);
-    for(NSUInteger i = 0; i < indexUpdater.count; i++) {
-        NSString* word = [indexUpdater stringAtIndex: i];
-        Assert([skippedWords containsObject: word]);
-    }
-}
-
-/**
- * 22. TestIndexUpdaterFinishWithIncompletedUpdate
- *
- * Description
- * Test that a CouchbaseLiteException is thrown when calling finish() on
- * an IndexUpdater that has incomplete updated.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Get a QueryIndex object from the words with the name as "words_index".
- * 4. Call beginUpdate() with limit 2 to get an IndexUpdater object.
- * 5. With the IndexUpdater object, call finish().
- * 6. Check that a CouchbaseLiteException with code UnsupportedOperation is thrown.
- * 7. For the index 0,
- *     - Get the word string from the IndexUpdater.
- *     - Query the vector by word from the _default.words collection.
- *     - Convert the vector result which is an array object to a platform's float array.
- *     - Call setVector() with the platform's float array at the index.
- * 8. With the IndexUpdater object, call finish().
- * 9. Check that a CouchbaseLiteException with code UnsupportedOperation is thrown.
- */
-- (void) testIndexUpdaterFinishWithIncompletedUpdate {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 2 error: &error];
-    AssertNotNil(indexUpdater);
-    
-    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
-        return [indexUpdater finishWithError: err];
-    }];
-    
-    NSString* word = [indexUpdater stringAtIndex: 0];
-    NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-    [indexUpdater setVector: vector atIndex: 0 error: &error];
-    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
-        return [indexUpdater finishWithError: err];
-    }];
-}
-
-/**
- * 23. TestIndexUpdaterCaughtUp
- *
- * Description
- * Test that when the lazy vector index is caught up, calling beginUpdate() to
- * get an IndexUpdater will return null.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Call beginUpdate() with limit 100 to get an IndexUpdater object.
- *     - Get the word string from the IndexUpdater.
- *     - Query the vector by word from the _default.words collection.
- *     - Convert the vector result which is an array object to a platform's float array.
- *     - Call setVector() with the platform's float array at the index.
- * 4. Repeat Step 3 two more times.
- * 5. Call beginUpdate() with limit 100 to get an IndexUpdater object.
- * 6. Check that the returned IndexUpdater is null.
- */
-- (void) testIndexUpdaterCaughtUp {
-    NSError* error;
-    CBLIndexUpdater* indexUpdater;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    
-    // Update index 3 times:
-    for(NSUInteger i = 0; i < 3; i++) {
-        indexUpdater = [qIndex beginUpdateWithLimit: 100 error: &error];
-        AssertNotNil(indexUpdater);
-        
-        for(NSUInteger j = 0; j < indexUpdater.count; j++) {
-            NSString* word = [indexUpdater stringAtIndex: j];
-            NSLog(@"%@", word);
-            NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-            [indexUpdater setVector: vector atIndex: j error: &error];
-        }
-        [indexUpdater finishWithError: &error];
-    }
-    
-    indexUpdater = [qIndex beginUpdateWithLimit: 100 error: &error];
-    AssertNil(indexUpdater);
-}
-
-/**
- * 24. TestNonFinishedIndexUpdaterNotUpdateIndex
- *
- * Description
- * Test that the index updater can be released without calling finish(),
- * and the released non-finished index updater doesn't update the index.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Get a QueryIndex object from the words with the name as "words_index".
- * 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
- * 5. With the IndexUpdater object, for each index from 0 - 9.
- *     - Get the word string from the IndexUpdater.
- *     - Query the vector by word from the _default.words collection.
- *     - Convert the vector result which is an array object to a platform's float array.
- *     - Call setVector() with the platform's float array at the index.
- * 6. Release or close the index updater object.
- * 7. Execute a vector search query.
- *     - SELECT word
- *       FROM _default.words
- *       WHERE vector_match(words_index, < dinner vector >, 300)
- * 8. Check that there are 0 words returned.
- */
-
-- (void) testNonFinishedIndexUpdaterNotUpdateIndex {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 10 error: &error];
-    
-    // Update index:
-    for(NSUInteger i = 0; i < indexUpdater.count; i++) {
-        NSString* word = [indexUpdater stringAtIndex: i];
-        NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-        [indexUpdater setVector: vector atIndex: i error: &error];
-    }
-    
-    // "Release" CBLIndexUpdater
-    indexUpdater = nil;
-    
-    // Query:
-    NSString* sql = @"select word, meta().id from _default.words where vector_match(words_index, $vector, 300)";
-    CBLQuery* q = [_db createQuery: sql error: &error];
-    AssertNil(error);
-    
-    CBLQueryParameters* parameters = [[CBLQueryParameters alloc] init];
-    [parameters setValue: kDinnerVector forName: @"vector"];
-    [q setParameters: parameters];
-    
-    CBLQueryResultSet* rs = [q execute: &error];
-    AssertEqual(rs.allObjects.count, 0);
-}
-
-/**
- * 25. TestIndexUpdaterIndexOutOfBounds
- *
- * Description
- * Test that when using getter, setter, and skip function with the index that
- * is out of bounds, an IndexOutOfBounds or InvalidArgument exception
- * is throws.
- *
- * Steps
- * 1. Get the default collection from a test database.
- * 2. Create the followings documents:
- *     - doc-0 : { "value": "a string" }
- * 3. Create a vector index named "vector_index" in the default collection.
- *     - expression: "value"
- *     - dimensions: 3
- *     - centroids : 8
- *     - isLazy : true
- * 4. Get a QueryIndex object from the default collection with the name as
- *    "vector_index".
- * 5. Call beginUpdate() with limit 10 to get an IndexUpdater object.
- * 6. Check that the IndexUpdater.count is 1.
- * 7. Call each getter function with index = -1 and check that
- *    an IndexOutOfBounds or InvalidArgument exception is thrown.
- * 8. Call each getter function with index = 1 and check that
- *    an IndexOutOfBounds or InvalidArgument exception is thrown.
- * 9. Call setVector() function with a vector = [1.0, 2.0, 3.0] and index = -1 and check that
- *    an IndexOutOfBounds or InvalidArgument exception is thrown.
- * 10. Call setVector() function with a vector = [1.0, 2.0, 3.0] and index = 1 and check that
- *    an IndexOutOfBounds or InvalidArgument exception is thrown.
- * 9. Call skipVector() function with index = -1 and check that
- *    an IndexOutOfBounds or InvalidArgument exception is thrown.
- * 10. Call skipVector() function with index = 1 and check that
- *    an IndexOutOfBounds or InvalidArgument exception is thrown.
- */
-- (void) testIndexUpdaterIndexOutOfBounds {
-    NSError* error;
-    CBLCollection* defaultCollection = [self.db defaultCollection: &error];
-    AssertNil(error);
-    
-    CBLMutableDocument* mdoc = [self createDocument: @"doc-0"];
-    [mdoc setValue: @"a string" forKey: @"value"];
-    [defaultCollection saveDocument: mdoc error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"value"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([defaultCollection createIndexWithName: @"vector_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [defaultCollection indexWithName: @"vector_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 10 error: &error];
-    AssertEqual(indexUpdater.count, 1);
-    
-    for(NSNumber* index in @[@-1, @1]) {
-        
-        // This is in line with ArrayProtocol, throws RangeException
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater valueAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater stringAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater numberAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater integerAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater doubleAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater floatAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater longLongAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater dateAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater arrayAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater dictionaryAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        [self expectException: @"NSRangeException" in:^{
-            [indexUpdater booleanAtIndex: [index unsignedIntegerValue]];
-        }];
-        
-        NSArray<NSNumber*>* array = @[@1.0, @2.0, @3.0];
-        [self expectException: @"NSInvalidArgumentException" in:^{
-            NSError* outError;
-            [indexUpdater setVector: array atIndex: [index unsignedIntegerValue] error: &outError];
-            
-            [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in: ^BOOL(NSError** err) {
-                return [indexUpdater setVector: array atIndex: [index unsignedIntegerValue] error: err];
-            }];
-        }];
-        
-        [self expectException: @"NSInvalidArgumentException" in:^{
-            [indexUpdater skipVectorAtIndex: [index unsignedIntegerValue]];
-        }];
-    }
-}
-
-/**
- * 26. TestIndexUpdaterCallFinishTwice
- *
- * Description
- * Test that when calling IndexUpdater's finish() after it was finished,
- * a CuchbaseLiteException is thrown.
- *
- * Steps
- * 1. Copy database words_db.
- * 2. Create a vector index named "words_index" in the _default.words collection.
- *     - expression: "word"
- *     - dimensions: 300
- *     - centroids : 8
- *     - isLazy : true
- * 3. Call beginUpdate() with limit 1 to get an IndexUpdater object.
- *     - Get the word string from the IndexUpdater.
- *     - Query the vector by word from the _default.words collection.
- *     - Convert the vector result which is an array object to a platform's float array.
- *     - Call setVector() with the platform's float array at the index..
- * 8. Call finish() and check that the finish() is successfully called.
- * 9. Call finish() again and check that a CouchbaseLiteException with the code Unsupported is thrown.
- */
-// CBL-5843
-- (void) _testIndexUpdaterCallFinishTwice {
-    NSError* error;
-    CBLCollection* collection = [_db collectionWithName: @"words" scope: nil error: &error];
-    
-    // Create index
-    CBLVectorIndexConfiguration* config = [[CBLVectorIndexConfiguration alloc] initWithExpression: @"word"
-                                                                                       dimensions: 300
-                                                                                        centroids: 8];
-    config.isLazy = true;
-    Assert([collection createIndexWithName: @"words_index" config: config error: &error]);
-    CBLQueryIndex* qIndex = [collection indexWithName: @"words_index" error: &error];
-    CBLIndexUpdater* indexUpdater = [qIndex beginUpdateWithLimit: 1 error: &error];
-    
-    // Update index:
-    NSString* word = [indexUpdater stringAtIndex: 0];
-    NSArray<NSNumber*>* vector = [self vectorArrayForWord: word collection: collection];
-    [indexUpdater setVector: vector atIndex: 0 error: &error];
-    [indexUpdater finishWithError: &error];
-    AssertNotNil(error);
-    
-    [self expectError: CBLErrorDomain code: CBLErrorUnsupported in: ^BOOL(NSError** err) {
-        return [indexUpdater finishWithError: err];
-    }];
 }
 
 @end

--- a/Swift/ArrayObject.swift
+++ b/Swift/ArrayObject.swift
@@ -52,6 +52,7 @@ public protocol ArrayProtocol: ArrayFragment {
     
     func toArray() -> Array<Any>
     
+    func toJSON() -> String
 }
 
 
@@ -64,7 +65,7 @@ public class ArrayObject: ArrayProtocol, Equatable, Hashable, Sequence {
     }
     
     /// Gets the value at the given index. The value types are Blob, ArrayObject,
-    /// DictionaryObject, Number, or String based on the underlying data type.
+    /// DictionaryObject, Number, String, or NSNull based on the underlying data type.
     ///
     /// - Parameter index: The index.
     /// - Returns: The value located at the index.
@@ -188,14 +189,8 @@ public class ArrayObject: ArrayProtocol, Equatable, Hashable, Sequence {
     public func toArray() -> Array<Any> {
         var array: [Any] = []
         for value in self {
-            switch value {
-            case let v as DictionaryObject:
-                array.append(v.toDictionary())
-            case let v as ArrayObject:
-                array.append(v.toArray())
-            default:
-                array.append(value)
-            }
+            let val = DataConverter.toPlainObject(value)
+            array.append(val != nil ? val! : NSNull())
         }
         return array
     }

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -325,6 +325,20 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
         try impl.deleteIndex(withName: name)
     }
     
+    /// Get an index by name. Return nil if the index doesn't exists.
+    public func index(withName name: String) throws -> QueryIndex? {
+        var error: NSError?
+        let index = impl.index(withName: name, error: &error)
+        if let err = error {
+            throw err
+        }
+        
+        guard let indexImpl = index else {
+            return nil
+        }
+        return QueryIndex(indexImpl, collection: self)
+    }
+    
     // MARK: Equatable
     
     public static func == (lhs: Collection, rhs: Collection) -> Bool {

--- a/Swift/CouchbaseLiteSwift.private.modulemap
+++ b/Swift/CouchbaseLiteSwift.private.modulemap
@@ -75,6 +75,7 @@ framework module CouchbaseLiteSwift_Private {
     header "CBLQueryFunction.h"
     header "CBLQueryFullTextExpression.h"
     header "CBLQueryFullTextFunction.h"
+    header "CBLQueryIndex.h"
     header "CBLQueryJoin.h"
     header "CBLQueryLimit.h"
     header "CBLQueryMeta.h"

--- a/Swift/DataConverter.swift
+++ b/Swift/DataConverter.swift
@@ -101,4 +101,14 @@ import CouchbaseLiteSwift_Private
         return result
     }
     
+    static func toPlainObject(_ value: Any?) -> Any? {
+        switch value {
+        case let v as DictionaryObject:
+            return v.toDictionary()
+        case let v as ArrayObject:
+            return v.toArray()
+        default:
+            return value
+        }
+    }
 }

--- a/Swift/DictionaryObject.swift
+++ b/Swift/DictionaryObject.swift
@@ -73,8 +73,8 @@ public class DictionaryObject: DictionaryProtocol, Equatable, Hashable, Sequence
     }
     
     /// Gets a property's value. The value types are Blob, ArrayObject,
-    /// DictionaryObject, Number, or String based on the underlying data type; or nil
-    /// if the value is nil or the property doesn't exist.
+    /// DictionaryObject, Number, String or NSNull based on the underlying data type;
+    /// or nil if the property doesn't exist.
     ///
     /// - Parameter key: The key.
     /// - Returns: The value or nil.

--- a/Swift/Indexable.swift
+++ b/Swift/Indexable.swift
@@ -32,5 +32,7 @@ public protocol Indexable {
     
     /// Delete an index by name.
     func deleteIndex(forName name: String) throws
-
+    
+    /// Return an index object, or nil if the index doesn't exist.
+    func index(withName name: String) throws -> QueryIndex?
 }

--- a/Swift/QueryIndex.swift
+++ b/Swift/QueryIndex.swift
@@ -1,0 +1,66 @@
+//
+//  QueryIndex.swift
+//  CouchbaseLite
+//
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import CouchbaseLiteSwift_Private
+
+/// QueryIndex object representing an existing index in the collection.
+public class QueryIndex {
+    
+    /// The collection.
+    public let collection: Collection
+    
+    /// The index name.
+    public var name: String { impl.name }
+
+#if COUCHBASE_ENTERPRISE
+    
+    /// ENTERPRISE EDITION ONLY
+    ///
+    /// For updating lazy vector indexes only.
+    /// Finds new or updated documents for which vectors need to be (re)computed and
+    /// return an IndexUpdater object used for setting the computed vectors for updating the index.
+    /// The limit parameter is for setting the max number of vectors to be computed.
+    /// - Parameter limit: The limit per update.
+    /// - Returns: IndexUpdater object if there are updates to be done, or nil if the index is up-to-date.
+    public func beginUpdate(limit: UInt64) throws -> IndexUpdater? {
+        var error: NSError?
+        let updater = impl.beginUpdate(withLimit: limit, error: &error)
+        if let err = error {
+            throw err
+        }
+        
+        guard let updaterImpl = updater else {
+            return nil
+        }
+        
+        return IndexUpdater(updaterImpl)
+    }
+#endif
+    
+    // MARK: Internal
+    
+    private let impl: CBLQueryIndex
+    
+    init(_ impl: CBLQueryIndex, collection: Collection) {
+        self.impl = impl
+        self.collection = collection
+    }
+    
+}

--- a/Swift/Result.swift
+++ b/Swift/Result.swift
@@ -154,7 +154,12 @@ public final class Result : ArrayProtocol, DictionaryProtocol, Sequence {
     ///
     /// - Returns: The Array representing all values.
     public func toArray() -> Array<Any> {
-        return impl.toArray()
+        var array: [Any] = []
+        for i in 0..<self.count {
+            let val = DataConverter.toPlainObject(self.value(at: i))
+            array.append(val != nil ? val! : NSNull())
+        }
+        return array
     }
     
     // MARK: ReadOnlyArrayFragment

--- a/Swift/Tests/CollectionTest.swift
+++ b/Swift/Tests/CollectionTest.swift
@@ -819,6 +819,9 @@ class CollectionTest: CBLTestCase {
         expectError(domain: CBLError.domain, code: CBLError.notOpen) {
             let _ = try col.deleteIndex(forName: "index2")
         }
+        expectError(domain: CBLError.domain, code: CBLError.notOpen) {
+            let _ = try col.index(withName: "index1")
+        }
     }
     
     // MARK: 8.7 Use Scope APIs on deleted/closed scenarios

--- a/Swift/Tests/DocumentTest.swift
+++ b/Swift/Tests/DocumentTest.swift
@@ -1835,4 +1835,24 @@ class DocumentTest: CBLTestCase {
             try colB.save(document: doc)
         }
     }
+    
+    func testJSON() throws {
+        let jsonString = """
+        {
+            "name": "John Doe",
+            "foo": null
+        }
+        """
+        
+        if let jsonData = jsonString.data(using: .utf8) {
+            do {
+                // Step 3: Convert Data to dictionary
+                if let jsonDictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any?] {
+                    print(jsonDictionary)
+                }
+            } catch {
+                print("Failed to convert JSON to dictionary: \(error.localizedDescription)")
+            }
+        }
+    }
 }

--- a/Swift/Tests/LazyVectorIndexTest.swift
+++ b/Swift/Tests/LazyVectorIndexTest.swift
@@ -1,0 +1,821 @@
+//
+//  LazyVectorIndex.swift
+//  CouchbaseLite
+//
+//  Copyright (c) 2024 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import CouchbaseLiteSwift
+
+/**
+ * Test Spec :
+ * https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0002-Lazy-Vector-Index.md
+ *
+ * Note:
+ * - Tested in Objective-C
+ *      - Test 4 TestGetExistingNonVectorIndex
+ *      - Test 8 TestLazyVectorIndexNotAutoUpdatedChangedDocs
+ *      - Test 9 TestLazyVectorIndexAutoUpdateDeletedDocs
+ *      - Test 10 TestLazyVectorIndexAutoUpdatePurgedDocs
+ *      - Test 11 TestIndexUpdaterBeginUpdateOnNonVectorIndex
+ *      - Test 20 TestIndexUpdaterSetInvalidVectorDimensions
+ *      - Test 22 TestIndexUpdaterFinishWithIncompletedUpdate
+ *      - Test 23 TestIndexUpdaterCaughtUp
+ *      - Test 24 TestNonFinishedIndexUpdaterNotUpdateIndex
+ *      - Test 26 TestIndexUpdaterCallFinishTwice
+ *      - Test 27 TestIndexUpdaterUseAfterFinished
+ * - Test 6 TestGetIndexOnClosedDatabase is done in CollectionTest.testUseCollectionAPIWhenDatabaseIsClosed()
+ * - Test 7 testInvalidCollection) is done in CollectionTest.testUseCollectionAPIOnDeletedCollection()
+ */
+class LazyVectorIndexTest: VectorSearchTest {
+    func wordsIndex() throws -> QueryIndex {
+        let index = try wordsCollection.index(withName: wordsIndexName)
+        XCTAssertNotNil(index)
+        return index!
+    }
+    
+    func lazyConfig(_ config: VectorIndexConfiguration) -> VectorIndexConfiguration {
+        var nuConfig = config
+        nuConfig.isLazy = true
+        return nuConfig
+    }
+    
+    func vector(forWord word: String) -> [Float]? {
+        let model = WordEmbeddingModel(db: wordDB)
+        if let vector = model.getWordVector(word: word, collection: wordsCollectionName) {
+            return vector.toArray() as? [Float]
+        }
+        if let vector = model.getWordVector(word: word, collection: extWordsCollectionName) {
+            return vector.toArray() as? [Float]
+        }
+        return nil
+    }
+    
+    /// 1. TestIsLazyDefaultValue
+    ///
+    /// Description
+    /// Test that isLazy property is false by default.
+    ///
+    /// Steps
+    /// 1. Create a VectorIndexConfiguration object.
+    ///     - expression: “vector”
+    ///     - dimensions: 300
+    ///     - centroids : 20
+    /// 2. Check that isLazy returns false.
+    func testIsLazyDefaultValue() throws {
+        let config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 20)
+        XCTAssertFalse(config.isLazy)
+    }
+    
+    /// 2. TestIsLazyAccessor
+    ///
+    /// Description
+    /// Test that isLazy getter/setter of the VectorIndexConfiguration work as expected.
+    ///
+    /// Steps
+    /// 1. Create a VectorIndexConfiguration object.
+    ///    - expression: word
+    ///    - dimensions: 300
+    ///    - centroids : 20
+    /// 2. Set isLazy to true
+    /// 3. Check that isLazy returns true.
+    func testIsLazyAccessor() throws {
+        var config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 20)
+        config.isLazy = true
+        XCTAssertTrue(config.isLazy)
+    }
+    
+    /// 3. TestGetNonExistingIndex
+    ///
+    /// Description
+    /// Test that getting non-existing index object by name returning null.
+    ///
+    /// Steps
+    /// 1. Get the default collection from a test database.
+    /// 2. Get a QueryIndex object from the default collection with the name as
+    ///    "nonexistingindex".
+    /// 3. Check that the result is null.
+    func testGetNonExistingIndex() throws {
+        let collection = try db.defaultCollection()
+        let index = try collection.index(withName: "nonexistingindex")
+        XCTAssertNil(index)
+    }
+    
+    /// 5. TestGetExistingVectorIndex
+    ///
+    /// Description
+    /// Test that getting an existing index object by name returning an index object correctly.
+    ///
+    /// Steps
+    /// 1. Copy database words_db.
+    /// 2. Create a vector index named "words_index" in the _default.words collection.
+    ///     - expression: "word"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    /// 3. Get a QueryIndex object from the words collection with the name as
+    ///    "words_index".
+    /// 4. Check that the result is not null.
+    /// 5. Check that the QueryIndex's name is "words_index".
+    /// 6. Check that the QueryIndex's collection is the same instance that is used for
+    ///   getting the index.
+    func testGetExistingVectorIndex() throws {
+        let config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 8)
+        try createWordsIndex(config: config)
+        let index = try wordsIndex()
+        XCTAssertEqual(index.name, wordsIndexName)
+        XCTAssert(index.collection === wordsCollection)
+    }
+    
+    /// 12. TestIndexUpdaterBeginUpdateOnNonLazyVectorIndex
+    ///
+    /// Description
+    /// Test that a CouchbaseLiteException is thrown when calling beginUpdate
+    /// on a non lazy vector index.
+    ///
+    /// Steps
+    /// 1. Copy database words_db.
+    /// 2. Create a vector index named "words_index" in the _default.words collecti
+    ///     - expression: "word"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    /// 3. Get a QueryIndex object from the words collection with the name as
+    ///    "words_index".
+    /// 4. Call beginUpdate() with limit 10 on the QueryIndex object.
+    /// 5. Check that a CouchbaseLiteException with the code Unsupported is thrown.
+    func testIndexUpdaterBeginUpdateOnNonLazyVectorIndex() throws {
+        let config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 8)
+        try createWordsIndex(config: config)
+        
+        let index = try wordsIndex()
+        
+        expectError(domain: CBLError.domain, code: CBLError.unsupported) {
+            _ = try index.beginUpdate(limit: 10)
+        }
+    }
+    
+    /// 13. TestIndexUpdaterBeginUpdateWithZeroLimit
+    ///
+    /// Description
+    /// Test that an InvalidArgument exception is returned when calling beginUpdate
+    /// with zero limit.
+    ///
+    /// Steps
+    /// 1. Copy database words_db.
+    /// 2. Create a vector index named "words_index" in the _default.words collection.
+    ///     - expression: "word"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    ///     - isLazy : true
+    /// 3. Get a QueryIndex object from the words collection with the name as
+    ///    "words_index".
+    /// 4. Call beginUpdate() with limit 0 on the QueryIndex object.
+    /// 5. Check that an InvalidArgumentException is thrown.
+    func testIndexUpdaterBeginUpdateWithZeroLimit() throws {
+        let config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 8)
+        try createWordsIndex(config: config)
+        
+        let index = try wordsIndex()
+        
+        expectExcepion(exception: .invalidArgumentException) {
+            _ = try? index.beginUpdate(limit: 0)
+        }
+    }
+    
+    /// 14. TestIndexUpdaterBeginUpdateOnLazyVectorIndex
+    ///
+    /// Description
+    /// Test that calling beginUpdate on a lazy vector index returns an IndexUpdater.
+    ///
+    /// Steps
+    /// 1. Copy database words_db.
+    /// 2. Create a vector index named "words_index" in the _default.words collection.
+    ///     - expression: "word"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    ///     - isLazy : true
+    /// 3. Get a QueryIndex object from the words with the name as "words_index".
+    /// 4. Call beginUpdate() with limit 10 on the QueryIndex object.
+    /// 5. Check that the returned IndexUpdater is not null.
+    /// 6. Check that the IndexUpdater.count is 10.
+    func testIndexUpdaterBeginUpdateOnLazyVectorIndex() throws {
+        let config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 8)
+        try createWordsIndex(config: lazyConfig(config))
+        
+        let index = try wordsIndex()
+        let updater = try index.beginUpdate(limit: 10)
+        XCTAssertNotNil(updater)
+        XCTAssertEqual(updater?.count, 10)
+    }
+    
+    /// 15. TestIndexUpdaterGettingValues
+    ///
+    /// Description
+    /// Test all type getters and toArary() from the Array interface. The test
+    /// may be divided this test into multiple tests per type getter as appropriate.
+    ///
+    /// Steps
+    /// 1. Get the default collection from a test database.
+    /// 2. Create the followings documents:
+    ///     - doc-0 : { "value": "a string" }
+    ///     - doc-1 : { "value": 100 }
+    ///     - doc-2 : { "value": 20.8 }
+    ///     - doc-3 : { "value": true }
+    ///     - doc-4 : { "value": false }
+    ///     - doc-5 : { "value": Date("2024-05-10T00:00:00.000Z") }
+    ///     - doc-6 : { "value": Blob(Data("I'm Bob")) }
+    ///     - doc-7 : { "value": {"name": "Bob"} }
+    ///     - doc-8 : { "value": ["one", "two", "three"] }
+    ///     - doc-9 : { "value": null }
+    /// 3. Create a vector index named "vector_index" in the default collection.
+    ///     - expression: "value"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    ///     - isLazy : true
+    /// 4. Get a QueryIndex object from the default collection with the name as
+    ///    "vector_index".
+    /// 5. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+    /// 6. Check that the IndexUpdater.count is 10.
+    /// 7. Get string value from each index and check the followings:
+    ///     - getString(0) : value == "a string"
+    ///     - getString(1) : value == null
+    ///     - getString(2) : value == null
+    ///     - getString(3) : value == null
+    ///     - getString(4) : value == null
+    ///     - getString(5) : value == "2024-05-10T00:00:00.000Z"
+    ///     - getString(6) : value == null
+    ///     - getString(7) : value == null
+    ///     - getString(8) : value == null
+    ///     - getString(9) : value == null
+    /// 8. Get integer value from each index and check the followings:
+    ///     - getInt(0) : value == 0
+    ///     - getInt(1) : value == 100
+    ///     - getInt(2) : value == 20
+    ///     - getInt(3) : value == 1
+    ///     - getInt(4) : value == 0
+    ///     - getInt(5) : value == 0
+    ///     - getInt(6) : value == 0
+    ///     - getInt(7) : value == 0
+    ///     - getInt(8) : value == 0
+    ///     - getInt(9) : value == 0
+    /// 9. Get float value from each index and check the followings:
+    ///     - getFloat(0) : value == 0.0
+    ///     - getFloat(1) : value == 100.0
+    ///     - getFloat(2) : value == 20.8
+    ///     - getFloat(3) : value == 1.0
+    ///     - getFloat(4) : value == 0.0
+    ///     - getFloat(5) : value == 0.0
+    ///     - getFloat(6) : value == 0.0
+    ///     - getFloat(7) : value == 0.0
+    ///     - getFloat(8) : value == 0.0
+    ///     - getFloat(9) : value == 0.0
+    /// 10. Get double value from each index and check the followings:
+    ///     - getDouble(0) : value == 0.0
+    ///     - getDouble(1) : value == 100.0
+    ///     - getDouble(2) : value == 20.8
+    ///     - getDouble(3) : value == 1.0
+    ///     - getDouble(4) : value == 0.0
+    ///     - getDouble(5) : value == 0.0
+    ///     - getDouble(6) : value == 0.0
+    ///     - getDouble(7) : value == 0.0
+    ///     - getDouble(8) : value == 0.0
+    ///     - getDouble(9) : value == 0.0
+    /// 11. Get boolean value from each index and check the followings:
+    ///     - getBoolean(0) : value == true
+    ///     - getBoolean(1) : value == true
+    ///     - getBoolean(2) : value == true
+    ///     - getBoolean(3) : value == true
+    ///     - getBoolean(4) : value == false
+    ///     - getBoolean(5) : value == true
+    ///     - getBoolean(6) : value == true
+    ///     - getBoolean(7) : value == true
+    ///     - getBoolean(8) : value == true
+    ///     - getBoolean(9) : value == false
+    /// 12. Get date value from each index and check the followings:
+    ///     - getDate(0) : value == null
+    ///     - getDate(1) : value == null
+    ///     - getDate(2) : value == null
+    ///     - getDate(3) : value == null
+    ///     - getDate(4) : value == null
+    ///     - getDate(5) : value == Date("2024-05-10T00:00:00.000Z")
+    ///     - getDate(6) : value == null
+    ///     - getDate(7) : value == null
+    ///     - getDate(8) : value == null
+    ///     - getDate(9) : value == null
+    /// 13. Get blob value from each index and check the followings:
+    ///     - getBlob(0) : value == null
+    ///     - getBlob(1) : value == null
+    ///     - getBlob(2) : value == null
+    ///     - getBlob(3) : value == null
+    ///     - getBlob(4) : value == null
+    ///     - getBlob(5) : value == null
+    ///     - getBlob(6) : value == Blob(Data("I'm Bob"))
+    ///     - getBlob(7) : value == null
+    ///     - getBlob(8) : value == null
+    ///     - getBlob(9) : value == null
+    /// 14. Get dictionary object from each index and check the followings:
+    ///     - getDictionary(0) : value == null
+    ///     - getDictionary(1) : value == null
+    ///     - getDictionary(2) : value == null
+    ///     - getDictionary(3) : value == null
+    ///     - getDictionary(4) : value == null
+    ///     - getDictionary(5) : value == null
+    ///     - getDictionary(6) : value == null
+    ///     - getDictionary(7) : value == Dictionary({"name": "Bob"})
+    ///     - getDictionary(8) : value == null
+    ///     - getDictionary(9) : value == null
+    /// 15. Get array object from each index and check the followings:
+    ///     - getArray(0) : value == null
+    ///     - getArray(1) : value == null
+    ///     - getArray(2) : value == null
+    ///     - getArray(3) : value == null
+    ///     - getArray(4) : value == null
+    ///     - getArray(5) : value == null
+    ///     - getArray(6) : value == null
+    ///     - getArray(7) : value == null
+    ///     - getArray(8) : value == Array(["one", "two", "three"])
+    ///     - getArray(9) : value == null
+    /// 16. Get value from each index and check the followings:
+    ///     - getValue(0) : value == "a string"
+    ///     - getValue(1) : value == PlatformNumber(100)
+    ///     - getValue(2) : value == PlatformNumber(20.8)
+    ///     - getValue(3) : value == PlatformBoolean(true)
+    ///     - getValue(4) : value == PlatformBoolean(false)
+    ///     - getValue(5) : value == "2024-05-10T00:00:00.000Z"
+    ///     - getValue(6) : value == Blob(Data("I'm Bob"))
+    ///     - getValue(7) : value == PlatformDict({"name": "Bob"})
+    ///     - getValue(8) : value == PlatformArray(["one", "two", "three"])
+    ///     - getValue(9) : value == null
+    /// 17. Get IndexUodater values as a platform array by calling toArray() and check
+    ///     that the array contains all values as expected.
+    func testIndexUpdaterGettingValues() throws {
+        let collection = try db.defaultCollection()
+        
+        let doc0 = createDocument(data: ["value": "a string"])
+        try collection.save(document: doc0)
+        
+        let doc1 = createDocument(data: ["value": 100])
+        try collection.save(document: doc1)
+        
+        let doc2 = createDocument(data: ["value": 20.8])
+        try collection.save(document: doc2)
+        
+        let doc3 = createDocument(data: ["value": true])
+        try collection.save(document: doc3)
+        
+        let doc4 = createDocument(data: ["value": false])
+        try collection.save(document: doc4)
+        
+        let date = dateFromJson("2024-05-10T00:00:00.000Z")
+        let doc5 = createDocument(data: ["value": date])
+        try collection.save(document: doc5)
+        
+        let content = "I'm Bob".data(using: .utf8)!
+        let blob = Blob(contentType: "text/plain", data: content)
+        let doc6 = createDocument(data: ["value": blob])
+        try collection.save(document: doc6)
+        
+        let doc7 = createDocument(data: ["value": ["name": "Bob"]])
+        try collection.save(document: doc7)
+        
+        let doc8 = createDocument(data: ["value": ["one", "two", "three"]])
+        try collection.save(document: doc8)
+        
+        let doc9 = createDocument(data: ["value": NSNull()])
+        try collection.save(document: doc9)
+        
+        let config = VectorIndexConfiguration(expression: "value", dimensions: 300, centroids: 8)
+        try createVectorIndex(collection: collection, name: "vector_index", config: lazyConfig(config))
+        
+        let index = try collection.index(withName: "vector_index")
+        XCTAssertNotNil(index)
+        
+        let indexUpdater = try index!.beginUpdate(limit: 10)
+        XCTAssertNotNil(indexUpdater)
+        XCTAssertEqual(indexUpdater!.count, 10)
+        
+        let updater = indexUpdater!
+        
+        // String:
+        XCTAssertEqual(updater.string(at: 0), "a string")
+        XCTAssertNil(updater.string(at: 1))
+        XCTAssertNil(updater.string(at: 2))
+        XCTAssertNil(updater.string(at: 3))
+        XCTAssertNil(updater.string(at: 4))
+        XCTAssertEqual(updater.string(at: 5), "2024-05-10T00:00:00.000Z")
+        XCTAssertNil(updater.string(at: 6))
+        XCTAssertNil(updater.string(at: 7))
+        XCTAssertNil(updater.string(at: 8))
+        XCTAssertNil(updater.string(at: 9))
+        
+        // Int:
+        XCTAssertEqual(updater.int(at: 0), 0)
+        XCTAssertEqual(updater.int(at: 1), 100)
+        XCTAssertEqual(updater.int(at: 2), 20)
+        XCTAssertEqual(updater.int(at: 3), 1)
+        XCTAssertEqual(updater.int(at: 4), 0)
+        XCTAssertEqual(updater.int(at: 5), 0)
+        XCTAssertEqual(updater.int(at: 6), 0)
+        XCTAssertEqual(updater.int(at: 7), 0)
+        XCTAssertEqual(updater.int(at: 8), 0)
+        XCTAssertEqual(updater.int(at: 9), 0)
+        
+        // Int64:
+        XCTAssertEqual(updater.int64(at: 0), 0)
+        XCTAssertEqual(updater.int64(at: 1), 100)
+        XCTAssertEqual(updater.int64(at: 2), 20)
+        XCTAssertEqual(updater.int64(at: 3), 1)
+        XCTAssertEqual(updater.int64(at: 4), 0)
+        XCTAssertEqual(updater.int64(at: 5), 0)
+        XCTAssertEqual(updater.int64(at: 6), 0)
+        XCTAssertEqual(updater.int64(at: 7), 0)
+        XCTAssertEqual(updater.int64(at: 8), 0)
+        XCTAssertEqual(updater.int64(at: 9), 0)
+        
+        // Float:
+        XCTAssertEqual(updater.float(at: 0), 0.0)
+        XCTAssertEqual(updater.float(at: 1), 100.0)
+        XCTAssertEqual(updater.float(at: 2), 20.8)
+        XCTAssertEqual(updater.float(at: 3), 1.0)
+        XCTAssertEqual(updater.float(at: 4), 0)
+        XCTAssertEqual(updater.float(at: 5), 0)
+        XCTAssertEqual(updater.float(at: 6), 0)
+        XCTAssertEqual(updater.float(at: 7), 0)
+        XCTAssertEqual(updater.float(at: 8), 0)
+        XCTAssertEqual(updater.float(at: 9), 0)
+        
+        // Double:
+        XCTAssertEqual(updater.double(at: 0), 0.0)
+        XCTAssertEqual(updater.double(at: 1), 100.0)
+        XCTAssertEqual(updater.double(at: 2), 20.8)
+        XCTAssertEqual(updater.double(at: 3), 1.0)
+        XCTAssertEqual(updater.double(at: 4), 0)
+        XCTAssertEqual(updater.double(at: 5), 0)
+        XCTAssertEqual(updater.double(at: 6), 0)
+        XCTAssertEqual(updater.double(at: 7), 0)
+        XCTAssertEqual(updater.double(at: 8), 0)
+        XCTAssertEqual(updater.double(at: 9), 0)
+        
+        // Boolean:
+        XCTAssertEqual(updater.boolean(at: 0), true)
+        XCTAssertEqual(updater.boolean(at: 1), true)
+        XCTAssertEqual(updater.boolean(at: 2), true)
+        XCTAssertEqual(updater.boolean(at: 3), true)
+        XCTAssertEqual(updater.boolean(at: 4), false)
+        XCTAssertEqual(updater.boolean(at: 5), true)
+        XCTAssertEqual(updater.boolean(at: 6), true)
+        XCTAssertEqual(updater.boolean(at: 7), true)
+        XCTAssertEqual(updater.boolean(at: 8), true)
+        XCTAssertEqual(updater.boolean(at: 9), false)
+        
+        // Date:
+        XCTAssertNil(updater.date(at: 0))
+        XCTAssertNil(updater.date(at: 1))
+        XCTAssertNil(updater.date(at: 2))
+        XCTAssertNil(updater.date(at: 3))
+        XCTAssertNil(updater.date(at: 4))
+        let getDate = updater.date(at: 5)
+        XCTAssertNotNil(getDate)
+        XCTAssertEqual(jsonFromDate(getDate!), "2024-05-10T00:00:00.000Z")
+        XCTAssertNil(updater.date(at: 6))
+        XCTAssertNil(updater.date(at: 7))
+        XCTAssertNil(updater.date(at: 8))
+        XCTAssertNil(updater.date(at: 9))
+        
+        // Blob:
+        XCTAssertNil(updater.blob(at: 0))
+        XCTAssertNil(updater.blob(at: 1))
+        XCTAssertNil(updater.blob(at: 2))
+        XCTAssertNil(updater.blob(at: 3))
+        XCTAssertNil(updater.blob(at: 4))
+        XCTAssertNil(updater.blob(at: 5))
+        let getBlob = updater.blob(at: 6)
+        XCTAssertNotNil(getBlob)
+        XCTAssertEqual(getBlob!.content, content)
+        XCTAssertNil(updater.blob(at: 7))
+        XCTAssertNil(updater.blob(at: 8))
+        XCTAssertNil(updater.blob(at: 9))
+        
+        // Dict:
+        XCTAssertNil(updater.dictionary(at: 0))
+        XCTAssertNil(updater.dictionary(at: 1))
+        XCTAssertNil(updater.dictionary(at: 2))
+        XCTAssertNil(updater.dictionary(at: 3))
+        XCTAssertNil(updater.dictionary(at: 4))
+        XCTAssertNil(updater.dictionary(at: 5))
+        XCTAssertNil(updater.dictionary(at: 6))
+        let dict = updater.dictionary(at: 7)
+        XCTAssertNotNil(dict)
+        XCTAssertTrue(dict! == doc7.dictionary(forKey: "value"))
+        XCTAssertNil(updater.dictionary(at: 8))
+        XCTAssertNil(updater.dictionary(at: 9))
+        
+        // Array:
+        XCTAssertNil(updater.array(at: 0))
+        XCTAssertNil(updater.array(at: 1))
+        XCTAssertNil(updater.array(at: 2))
+        XCTAssertNil(updater.array(at: 3))
+        XCTAssertNil(updater.array(at: 4))
+        XCTAssertNil(updater.array(at: 5))
+        XCTAssertNil(updater.array(at: 6))
+        XCTAssertNil(updater.array(at: 7))
+        let array = updater.array(at: 8)
+        XCTAssertNotNil(array)
+        XCTAssertTrue(array! == doc8.array(forKey: "value"))
+        XCTAssertNil(updater.array(at: 9))
+        
+        // value:
+        XCTAssertTrue(updater.value(at: 0) as? String == "a string")
+        XCTAssertTrue(updater.value(at: 1) as? Int == 100)
+        XCTAssertTrue(updater.value(at: 2) as? Double == 20.8)
+        XCTAssertTrue(updater.value(at: 3) as? Bool == true)
+        XCTAssertTrue(updater.value(at: 4) as? Bool == false)
+        XCTAssertTrue(updater.value(at: 5) as? String == "2024-05-10T00:00:00.000Z")
+        XCTAssertTrue(updater.value(at: 6) as? Blob == blob)
+        XCTAssertTrue(updater.value(at: 7) as? DictionaryObject == doc7.dictionary(forKey: "value"))
+        XCTAssertTrue(updater.value(at: 8) as? ArrayObject == doc8.array(forKey: "value"))
+        XCTAssertTrue(updater.value(at: 9) as? NSNull == NSNull())
+        
+        // toArray
+        let values = updater.toArray()
+        XCTAssertTrue(values[0] as? String == "a string")
+        XCTAssertTrue(values[1] as? Int == 100)
+        XCTAssertTrue(values[2] as? Double == 20.8)
+        XCTAssertTrue(values[3] as? Bool == true)
+        XCTAssertTrue(values[4] as? Bool == false)
+        XCTAssertTrue(values[5] as? String == "2024-05-10T00:00:00.000Z")
+        XCTAssertTrue(values[6] as? Blob == blob)
+        XCTAssertTrue(values[7] as! Dictionary == doc7.dictionary(forKey: "value")!.toDictionary())
+        XCTAssertTrue(values[8] as! Array == doc8.array(forKey: "value")!.toArray())
+        XCTAssertTrue(values[9] as? NSNull == NSNull())
+        
+        // toJSON
+        XCTAssertTrue(updater.toJSON().count > 0)
+    }
+    
+    /// 16. TestIndexUpdaterArrayIterator
+    ///
+    /// Description
+    /// Test that iterating the index updater using the platform array iterator
+    /// interface works as expected.
+    ///
+    /// Steps
+    /// 1. Copy database words_db.
+    /// 2. Create a vector index named "words_index" in the _default.words collection.
+    ///     - expression: "word"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    ///     - isLazy : true
+    /// 3. Get a QueryIndex object from the words with the name as "words_index".
+    /// 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+    /// 5. Check that the IndexUpdater.count is 10.
+    /// 6. Iterate using the platfrom array iterator.
+    /// 7. For each iteration, check that the value is the same as the value getting
+    ///    from getValue(index).
+    /// 8. Check that there were 10 iteration calls.
+    func testIndexUpdaterArrayIterator() throws {
+        let config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 8)
+        try createWordsIndex(config: lazyConfig(config))
+        
+        let index = try wordsIndex()
+        let updater = try index.beginUpdate(limit: 10)!
+        var i = 0
+        for value in updater {
+            XCTAssertEqual(value as? String, updater[i].string)
+            i = i+1
+        }
+        XCTAssertEqual(i, 10)
+    }
+    
+    /// 17. TestIndexUpdaterSetFloatArrayVectors
+    ///
+    /// Description
+    /// Test that setting float array vectors works as expected.
+    ///
+    /// Steps
+    /// 1. Copy database words_db.
+    /// 2. Create a vector index named "words_index" in the _default.words collection.
+    ///     - expression: "word"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    ///     - isLazy : true
+    /// 3. Get a QueryIndex object from the words with the name as "words_index".
+    /// 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+    /// 5. With the IndexUpdater object, for each index from 0 to 9.
+    ///     - Get the word string from the IndexUpdater and store the word string in a set for verifying
+    ///        the vector search result.
+    ///     - Query the vector by word from the _default.words collection.
+    ///     - Convert the vector result which is an array object to a platform's float array.
+    ///     - Call setVector() with the platform's float array at the index.
+    /// 6. With the IndexUpdater object, call finish()
+    /// 7. Execute a vector search query.
+    ///     - SELECT word
+    ///       FROM _default.words
+    ///       WHERE vector_match(words_index, < dinner vector >, 300)
+    /// 8. Check that there are 10 words returned.
+    /// 9. Check that the word is in the word set from the step 5.
+    func testIndexUpdaterSetFloatArrayVectors() throws {
+        let config = VectorIndexConfiguration(expression: "word", dimensions: 300, centroids: 8)
+        try createWordsIndex(config: lazyConfig(config))
+        
+        let index = try wordsIndex()
+        let updater = try index.beginUpdate(limit: 10)!
+        XCTAssertEqual(updater.count, 10)
+        
+        var words: [String] = [];
+        for i in 0..<updater.count {
+            let word = updater.string(at: i)!
+            let vector = vector(forWord: word)!
+            try updater.setVector(vector, at: i)
+            words.append(word)
+        }
+        try updater.finish()
+        
+        let rs = try executeWordsQuery(limit: 300, checkTraining: false)
+        let resultWords = toDocIDWordMap(rs: rs).values
+        XCTAssertEqual(resultWords.count, 10)
+        for word in resultWords {
+            XCTAssertTrue(words.contains(word))
+        }
+    }
+    
+    /// 21. TestIndexUpdaterSkipVectors
+    ///
+    /// Description
+    /// Test that skipping vectors works as expected.
+    ///
+    /// Steps
+    /// 1. Copy database words_db.
+    /// 2. Create a vector index named "words_index" in the _default.words collection.
+    ///     - expression: "word"
+    ///     - dimensions: 300
+    ///     - centroids : 8
+    ///     - isLazy : true
+    /// 3. Get a QueryIndex object from the words with the name as "words_index".
+    /// 4. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+    /// 5. With the IndexUpdater object, for each index from 0 - 9.
+    ///     - Get the word string from the IndexUpdater.
+    ///     - If index % 2 == 0,
+    ///         - Store the word string in a skipped word set for verifying the skipped words later.
+    ///         - Call skipVector at the index.
+    ///     - If index % 2 != 0,
+    ///         - Query the vector by word from the _default.words collection.
+    ///         - Convert the vector result which is an array object to a platform's float array.
+    ///         - Call setVector() with the platform's float array at the index.
+    /// 6. With the IndexUpdater object, call finish()
+    /// 7. Call beginUpdate with limit 10 to get an IndexUpdater object.
+    /// 8. With the IndexUpdater object, for each index
+    ///     - Get the word string from the dictionary for the key named "word".
+    ///     - Check if the word is in the skipped word set from the Step 5. If the word
+    ///        is in the skipped word set, remove the word from the skipped word set.
+    ///     - Query the vector by word from the _default.words collection.
+    ///         - Convert the vector result which is an array object to a platform's float array.
+    ///         - Call setVector() with the platform's float array at the index
+    /// 9. With the IndexUpdater object, call finish()
+    /// 10. Repeat Step 7, until the returned IndexUpdater is null or the skipped word set
+    ///      has zero words in it.
+    /// 11. Verify that the skipped word set has zero words in it.
+    func testIndexUpdaterSkipVectors() throws {
+        let config = VectorIndexConfiguration(expression: "word", dimensions: 300, centroids: 8)
+        try createWordsIndex(config: lazyConfig(config))
+        
+        let index = try wordsIndex()
+        var updater = try index.beginUpdate(limit: 10)!
+        XCTAssertEqual(updater.count, 10)
+        
+        var skipWords: [String] = [];
+        for i in 0..<updater.count {
+            let word = updater.string(at: i)!
+            if i % 2 == 0 {
+                updater.skipVector(at: i)
+                skipWords.append(word)
+            } else {
+                let vector = vector(forWord: word)!
+                try updater.setVector(vector, at: i)
+            }
+        }
+        try updater.finish()
+        
+        updater = try index.beginUpdate(limit: 10)!
+        for i in 0..<updater.count {
+            let word = updater.string(at: i)!
+            let vector = vector(forWord: word)!
+            try updater.setVector(vector, at: i)
+            
+            if let index = skipWords.firstIndex(of: word) {
+                skipWords.remove(at: index)
+            }
+        }
+        try updater.finish()
+        XCTAssertEqual(skipWords.count, 0)
+    }
+    
+    /// 25. TestIndexUpdaterIndexOutOfBounds
+    ///
+    /// Description
+    /// Test that when using getter, setter, and skip function with the index that
+    /// is out of bounds, an IndexOutOfBounds or InvalidArgument exception
+    /// is throws.
+    ///
+    /// Steps
+    /// 1. Get the default collection from a test database.
+    /// 2. Create the followings documents:
+    ///     - doc-0 : { "value": "a string" }
+    /// 3. Create a vector index named "vector_index" in the default collection.
+    ///     - expression: "value"
+    ///     - dimensions: 3
+    ///     - centroids : 8
+    ///     - isLazy : true
+    /// 4. Get a QueryIndex object from the default collection with the name as
+    ///    "vector_index".
+    /// 5. Call beginUpdate() with limit 10 to get an IndexUpdater object.
+    /// 6. Check that the IndexUpdater.count is 1.
+    /// 7. Call each getter function with index = -1 and check that
+    ///    an IndexOutOfBounds or InvalidArgument exception is thrown.
+    /// 8. Call each getter function with index = 1 and check that
+    ///    an IndexOutOfBounds or InvalidArgument exception is thrown.
+    /// 9. Call setVector() function with a vector = [1.0, 2.0, 3.0] and index = -1 and check that
+    ///    an IndexOutOfBounds or InvalidArgument exception is thrown.
+    /// 10. Call setVector() function with a vector = [1.0, 2.0, 3.0] and index = 1 and check that
+    ///    an IndexOutOfBounds or InvalidArgument exception is thrown.
+    /// 9. Call skipVector() function with index = -1 and check that
+    ///    an IndexOutOfBounds or InvalidArgument exception is thrown.
+    /// 10. Call skipVector() function with index = 1 and check that
+    ///    an IndexOutOfBounds or InvalidArgument exception is thrown.
+    func testIndexUpdaterIndexOutOfBounds() throws {
+        let collection = try db.defaultCollection()
+        
+        let doc0 = createDocument(data: ["value": "a string"])
+        try collection.save(document: doc0)
+        
+        let config = VectorIndexConfiguration(expression: "value", dimensions: 300, centroids: 8)
+        try createVectorIndex(collection: collection, name: "vector_index", config: lazyConfig(config))
+        
+        let index = try collection.index(withName: "vector_index")!
+        let updater = try index.beginUpdate(limit: 10)!
+        XCTAssertEqual(updater.count, 1)
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.string(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.int(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.int64(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.float(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.double(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.boolean(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.date(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.blob(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.dictionary(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.array(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            _ = updater.value(at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            try! updater.setVector([1.0, 2.0, 3.0], at: 1)
+        }
+        
+        expectExcepion(exception: .rangeException) {
+            updater.skipVector(at: 1)
+        }
+    }
+}


### PR DESCRIPTION
* Implemented Lazy Vector Index and Test for Swift.
* Fixed missing symbols.
* Refactored VectorSearchTest in both Swift and Objective-C to reduce duplicate codes.
* Updated some API docs.
* The companion change commit is in the EE repo.