### PR TITLE
CBL-5567 : Implement log replicator heiroglyphics

### DIFF
--- a/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
+++ b/Objective-C/Internal/Replicator/CBLReplicator+Backgrounding.m
@@ -33,7 +33,7 @@
         return;
     }
     
-    CBLLogInfo(Sync, @"%@: Starting backgrounding monitor...", self);
+    CBLLogInfo(Sync, @"%@ Starting backgrounding monitor...", self);
     NSFileProtectionType prot = self.fileProtection;
     if ([prot isEqual: NSFileProtectionComplete] ||
         [prot isEqual: NSFileProtectionCompleteUnlessOpen]) {
@@ -70,7 +70,7 @@
         return;
     }
     
-    CBLLogInfo(Sync, @"%@: Ending backgrounding monitor...", self);
+    CBLLogInfo(Sync, @"%@ Ending backgrounding monitor...", self);
     [NSNotificationCenter.defaultCenter removeObserver: self
                                                   name: UIApplicationProtectedDataWillBecomeUnavailable
                                                 object: nil];


### PR DESCRIPTION
* Implemented Replicator log heiroglyphics by using symbols to describe replicator.

* Removed ":" that separates log meesage and the replicator heiroglyphics as it seems to be redundant.