### PR TITLE
CBL-5859 : Allow explicitly enable vector search

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -366,6 +366,11 @@
 		40086B552B803B2B00DA6770 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */; };
 		40086B572B803B4300DA6770 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */; };
 		40086B582B803B4E00DA6770 /* CBLBlockConflictResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */; };
+		400AAFDB2C2A843B00DB6223 /* CBLExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 400AAFCD2C2A843B00DB6223 /* CBLExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		400AAFDC2C2A843B00DB6223 /* CBLExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 400AAFCD2C2A843B00DB6223 /* CBLExtension.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		400AAFDD2C2A843B00DB6223 /* CBLExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400AAFDA2C2A843B00DB6223 /* CBLExtension.mm */; };
+		400AAFDE2C2A843B00DB6223 /* CBLExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400AAFDA2C2A843B00DB6223 /* CBLExtension.mm */; };
+		400AAFE02C2A845E00DB6223 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400AAFDF2C2A845E00DB6223 /* Extension.swift */; };
 		4017E4652BED6E5400A438EE /* CBLContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4017E4572BED6E5400A438EE /* CBLContextManager.h */; };
 		4017E4662BED6E5400A438EE /* CBLContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4017E4572BED6E5400A438EE /* CBLContextManager.h */; };
 		4017E4672BED6E5400A438EE /* CBLContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4017E4572BED6E5400A438EE /* CBLContextManager.h */; };
@@ -2275,6 +2280,9 @@
 		40086B172B7EDDD400DA6770 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		40086B452B803B2A00DA6770 /* CBLBlockConflictResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLBlockConflictResolver.h; sourceTree = "<group>"; };
 		40086B522B803B2B00DA6770 /* CBLBlockConflictResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLBlockConflictResolver.m; sourceTree = "<group>"; };
+		400AAFCD2C2A843B00DB6223 /* CBLExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLExtension.h; sourceTree = "<group>"; };
+		400AAFDA2C2A843B00DB6223 /* CBLExtension.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLExtension.mm; sourceTree = "<group>"; };
+		400AAFDF2C2A845E00DB6223 /* Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
 		4017E4572BED6E5400A438EE /* CBLContextManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CBLContextManager.h; sourceTree = "<group>"; };
 		4017E4642BED6E5400A438EE /* CBLContextManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CBLContextManager.m; sourceTree = "<group>"; };
 		406F8DEA2C26901A000223FC /* QueryIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryIndex.swift; sourceTree = "<group>"; };
@@ -3169,6 +3177,8 @@
 				40FC1AA52B9286E700394276 /* CBLDatabaseConfiguration+Encryption.h */,
 				40FC1AA72B9286E700394276 /* CBLEncryptionKey.h */,
 				40FC1AA32B9286E700394276 /* CBLEncryptionKey.m */,
+				400AAFCD2C2A843B00DB6223 /* CBLExtension.h */,
+				400AAFDA2C2A843B00DB6223 /* CBLExtension.mm */,
 			);
 			path = Database;
 			sourceTree = "<group>";
@@ -3382,6 +3392,7 @@
 			children = (
 				40FC1C3A2B928C1600394276 /* Database+Encryption.swift */,
 				40FC1C3B2B928C1600394276 /* EncryptionKey.swift */,
+				400AAFDF2C2A845E00DB6223 /* Extension.swift */,
 			);
 			path = Database;
 			sourceTree = "<group>";
@@ -4549,6 +4560,7 @@
 				40FC1BD82B928A4F00394276 /* CBLIndexBuilder+Prediction.h in Headers */,
 				9343EFA9207D611600F19A89 /* CBLDatabase.h in Headers */,
 				9343EFAA207D611600F19A89 /* CBLQueryExpression+Internal.h in Headers */,
+				400AAFDB2C2A843B00DB6223 /* CBLExtension.h in Headers */,
 				9343EFAB207D611600F19A89 /* CBLAuthenticator+Internal.h in Headers */,
 				1AAFB671284A260A00878453 /* CBLCollectionChangeObservable.h in Headers */,
 				9343EFAC207D611600F19A89 /* CBLListenerToken.h in Headers */,
@@ -4845,6 +4857,7 @@
 				40FC1B842B9288A800394276 /* CBLMessageEndpoint.h in Headers */,
 				40FC1B742B92889800394276 /* CBLReplicatorConfiguration+ServerCert.h in Headers */,
 				9343F0F1207D61AB00F19A89 /* CBLSessionAuthenticator.h in Headers */,
+				400AAFDC2C2A843B00DB6223 /* CBLExtension.h in Headers */,
 				1A53B2932966EA2A0010A73E /* CBLQueryFullTextIndexExpressionProtocol.h in Headers */,
 				9343F0F2207D61AB00F19A89 /* CBLReplicator.h in Headers */,
 				9343F0F3207D61AB00F19A89 /* CBLQueryVariableExpression.h in Headers */,
@@ -6321,6 +6334,7 @@
 				9343EF59207D611600F19A89 /* CBLReplicator.mm in Sources */,
 				40FC1B5F2B9287BD00394276 /* CBLURLEndpointListener.mm in Sources */,
 				9343EF5A207D611600F19A89 /* CBLBlobStream.mm in Sources */,
+				400AAFDD2C2A843B00DB6223 /* CBLExtension.mm in Sources */,
 				40FC1B542B92873C00394276 /* CBLEncryptionKey.m in Sources */,
 				69ABB5ED2976A5DF00DA0229 /* CBLDNSService.mm in Sources */,
 				9343EF5B207D611600F19A89 /* CBLQueryFunction.m in Sources */,
@@ -6413,6 +6427,7 @@
 				9343F017207D61AB00F19A89 /* Authenticator.swift in Sources */,
 				93EB261C21DDC34C0006FB88 /* IndexBuilder.swift in Sources */,
 				9343F018207D61AB00F19A89 /* CBLAuthenticator.m in Sources */,
+				400AAFE02C2A845E00DB6223 /* Extension.swift in Sources */,
 				6932D4A4295478B000D28C18 /* CBLQueryFullTextIndexExpression.m in Sources */,
 				9343F019207D61AB00F19A89 /* CBLBlobStream.mm in Sources */,
 				9343F01A207D61AB00F19A89 /* CBLQuerySelectResult.m in Sources */,
@@ -6536,6 +6551,7 @@
 				1AA2EDFB28A676E100DEB47E /* CBLConflictResolverBridge.m in Sources */,
 				1AAFB66A284A260A00878453 /* CBLCollectionChange.m in Sources */,
 				40FC1BF52B928A4F00394276 /* CBLDatabase+Prediction.m in Sources */,
+				400AAFDE2C2A843B00DB6223 /* CBLExtension.mm in Sources */,
 				9343F063207D61AB00F19A89 /* Fragment.swift in Sources */,
 				9343F064207D61AB00F19A89 /* VariableExpression.swift in Sources */,
 				9343F065207D61AB00F19A89 /* Query.swift in Sources */,

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -126,21 +126,7 @@ static const C4DatabaseConfig2 kDBConfig = {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         [self checkFileLogging];
-        [self setExtensionPath];
     });
-}
-
-/** Detect and set extension path  */
-+ (void) setExtensionPath {
-#ifdef COUCHBASE_ENTERPRISE
-    // Note: For non app, the bundle will not be found.
-    NSBundle* vsBundle = [NSBundle bundleWithIdentifier: kVectorSearchExtIdentifier];
-    if (vsBundle.bundlePath) {
-        CBLLogInfo(Database, @"Set extension path : %@", vsBundle.bundlePath);
-        CBLStringBytes path(vsBundle.bundlePath);
-        c4_setExtensionPath(path);
-    }
-#endif
 }
 
 /** Check and show warning if file logging is not configured. */

--- a/Objective-C/CouchbaseLite.h
+++ b/Objective-C/CouchbaseLite.h
@@ -111,6 +111,7 @@ FOUNDATION_EXPORT const unsigned char CouchbaseLiteVersionString[];
 #import <CouchbaseLite/CBLDatabaseConfiguration+Encryption.h>
 #import <CouchbaseLite/CBLDatabaseEndpoint.h>
 #import <CouchbaseLite/CBLEncryptionKey.h>
+#import <CouchbaseLite/CBLExtension.h>
 #import <CouchbaseLite/CBLIndexBuilder+Prediction.h>
 #import <CouchbaseLite/CBLIndexUpdater.h>
 #import <CouchbaseLite/CBLListenerAuthenticator.h>

--- a/Objective-C/Exports/CBL_EE.txt
+++ b/Objective-C/Exports/CBL_EE.txt
@@ -23,6 +23,7 @@
 .objc_class_name_CBLClientCertificateAuthenticator
 .objc_class_name_CBLDatabaseEndpoint
 .objc_class_name_CBLEncryptionKey
+.objc_class_name_CBLExtension
 .objc_class_name_CBLIndexUpdater
 .objc_class_name_CBLListenerCertificateAuthenticator
 .objc_class_name_CBLListenerPasswordAuthenticator

--- a/Objective-C/Tests/VectorSearchTest.h
+++ b/Objective-C/Tests/VectorSearchTest.h
@@ -35,7 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #define VECTOR_INDEX_CONFIG(E, D, C) [[CBLVectorIndexConfiguration alloc] initWithExpression: (E) dimensions: (D) centroids: (C)]
 
-
 @interface VectorSearchTest : CBLTestCase
 
 @property (nonatomic, readonly) CBLDatabase* wordDB;

--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -63,6 +63,7 @@
     [super setUp];
 
     NSError* error;
+    Assert([CBLExtension enableVectorSearch: &error]);
     
     CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
     config.directory = self.directory;

--- a/Swift/Tests/VectorSearchTest.swift
+++ b/Swift/Tests/VectorSearchTest.swift
@@ -49,6 +49,8 @@ class VectorSearchTest: CBLTestCase {
         
         super.setUp()
         
+        try! Extension.enableVectorSearch()
+        
         var config = DatabaseConfiguration()
         config.directory = self.directory
         let res = ("Support/databases/vectorsearch" as NSString).appendingPathComponent("words_db")


### PR DESCRIPTION
* Implemented Extension.enableVectorSearch in both Objective-C and Swift.

* Moved the logic from CBLDatabase.mm to CBLExtension in ee repo.

* Used LiteCore 61cfa302d61b8baef2c2cfeeb79c24653e1603a0 temporarily to allow the function to be implemented.