### PR TITLE
CBL-5927 : Fix Duplicate CBLQueryIndex Interface Definition

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -4325,6 +4325,8 @@
 				93FD618A2020757500E7F6A1 /* CBLIndex.m */,
 				93FD615F20204E3600E7F6A1 /* CBLIndexBuilder.h */,
 				93FD616020204E3600E7F6A1 /* CBLIndexBuilder.m */,
+				AE83D07A2C06242F0055D2CF /* CBLQueryIndex.h */,
+				AE83D07B2C06242F0055D2CF /* CBLQueryIndex.mm */,
 				93EC42CB1FB3801E00D54BB4 /* CBLValueIndex.h */,
 				93EC42CC1FB3801E00D54BB4 /* CBLValueIndex.m */,
 				1A3470BF266F3E7C0042C6BA /* CBLIndexConfiguration.h */,
@@ -4333,8 +4335,6 @@
 				1A3471482671C87F0042C6BA /* CBLFullTextIndexConfiguration.m */,
 				1A34715C2671C9230042C6BA /* CBLValueIndexConfiguration.h */,
 				1A34715D2671C9230042C6BA /* CBLValueIndexConfiguration.m */,
-				AE83D07A2C06242F0055D2CF /* CBLQueryIndex.h */,
-				AE83D07B2C06242F0055D2CF /* CBLQueryIndex.mm */,
 			);
 			name = Index;
 			sourceTree = "<group>";

--- a/Objective-C/CBLCollection.h
+++ b/Objective-C/CBLCollection.h
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+#import <Foundation/Foundation.h>
 #import <CouchbaseLite/CBLCollectionChangeObservable.h>
 #import <CouchbaseLite/CBLIndexable.h>
 #import <CouchbaseLite/CBLCollectionTypes.h>
@@ -27,7 +28,6 @@
 @class CBLDocumentFragment;
 @class CBLMutableDocument;
 @class CBLScope;
-@class CBLQueryIndex;
 @protocol CBLListenerToken;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -28,7 +28,6 @@
 #import "CBLDocumentChangeNotifier.h"
 #import "CBLDocument+Internal.h"
 #import "CBLErrorMessage.h"
-#import "CBLIndexable.h"
 #import "CBLIndexConfiguration+Internal.h"
 #import "CBLIndex+Internal.h"
 #import "CBLQueryIndex+Internal.h"

--- a/Objective-C/CBLIndexable.h
+++ b/Objective-C/CBLIndexable.h
@@ -17,11 +17,14 @@
 //  limitations under the License.
 //
 
-#import <CouchbaseLite/CBLIndexConfiguration.h>
-#import <CouchbaseLite/CBLIndex.h>
-#import <CouchbaseLite/CBLQueryIndex.h>
+#import <Foundation/Foundation.h>
+
+@class CBLIndex;
+@class CBLIndexConfiguration;
+@class CBLQueryIndex;
 
 NS_ASSUME_NONNULL_BEGIN
+
 /** The Indexable interface defines a set of functions for managing the query indexes. */
 @protocol CBLIndexable <NSObject>
 

--- a/Objective-C/CBLQueryIndex.h
+++ b/Objective-C/CBLQueryIndex.h
@@ -18,11 +18,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <CouchbaseLite/CBLCollection.h>
 
 #ifdef COUCHBASE_ENTERPRISE
 #import <CouchbaseLite/CBLIndexUpdater.h>
 #endif
+
+@class CBLCollection;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2242,7 +2242,7 @@
     Assert(nudb, @"Cannot open the new database: %@", error);
     
     [self expectError: NSPOSIXErrorDomain code: EEXIST in: ^BOOL(NSError** error2) {
-        return [CBLDatabase copyFromPath: _db.path toDatabase: dbName withConfig: config error: error2];
+        return [CBLDatabase copyFromPath: self->_db.path toDatabase: dbName withConfig: config error: error2];
     }];
     
     // Clean up:

--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -111,7 +111,7 @@
     __block NSError *error = nil;
     // to skip test exception breakpoint  
     [self ignoreException:^{
-        AssertFalse([_db saveDocument: doc error: &error]);
+        AssertFalse([self->_db saveDocument: doc error: &error]);
     }];
     AssertEqual(error.code, CBLErrorBadDocID);
     AssertEqualObjects(error.domain, CBLErrorDomain);
@@ -1558,7 +1558,7 @@
  
     // Purge before save:
     [self expectError: CBLErrorDomain code: CBLErrorNotFound in: ^BOOL(NSError** err) {
-        return [_db purgeDocument: doc1 error: err];
+        return [self->_db purgeDocument: doc1 error: err];
     }];
     
     // Save:

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -152,7 +152,6 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     /// the database is closed.
     public func save(document: MutableDocument,
               conflictHandler: @escaping (MutableDocument, Document?) -> Bool) throws -> Bool {
-        
         var error: NSError?
         let result = impl.save(
             document.impl as! CBLMutableDocument,


### PR DESCRIPTION
* Fixed the circular reference b/w CBLCollection and CBLQueryIndex.
* Fixed warning in tests.