### PR TITLE
CBL-5329 : Fix Replicator ListenerToken.remove() (#3213)

### DIFF
--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -429,7 +429,7 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
 - (id<CBLListenerToken>) addChangeListenerWithQueue: (dispatch_queue_t)queue
                                            listener: (void (^)(CBLReplicatorChange*))listener
 {
-    return [_changeNotifier addChangeListenerWithQueue: queue listener: listener delegate: nil];
+    return [_changeNotifier addChangeListenerWithQueue: queue listener: listener delegate: self];
 }
 
 - (id<CBLListenerToken>) addDocumentReplicationListener: (void (^)(CBLDocumentReplication*))listener {
@@ -441,7 +441,7 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
 {
     CBL_LOCK(self) {
         [self setProgressLevel: kCBLProgressLevelPerDocument];
-        return [_docReplicationNotifier addChangeListenerWithQueue: queue listener: listener delegate: nil];
+        return [_docReplicationNotifier addChangeListenerWithQueue: queue listener: listener delegate: self];
     }
 }
 


### PR DESCRIPTION
* Fixed the bug that the Replicator’s ListenerToken was created without the CBLRemovableListenerToken delegate being set.

* Ported the [fix](https://github.com/couchbase/couchbase-lite-ios/commit/b17116c75033b38474b37446a44ee4aa38f94685) from release/3.2 branch.