### PR TITLE
CBL-6023 : Sometimes query becomes nil before is stopped

### DIFF
--- a/Objective-C/Internal/CBLQueryObserver.m
+++ b/Objective-C/Internal/CBLQueryObserver.m
@@ -164,6 +164,7 @@ static void liveQueryCallback(C4QueryObserver *c4obs, C4Query *c4query, void *co
 
 - (void) postQueryChange: (C4QueryEnumerator*)enumerator {
     CBLChangeListenerToken<CBLQueryChange*>* token;
+    CBLQuery* query;
     CBL_LOCK(self) {
         if ([self isStopped]) {
             c4queryenum_release( enumerator);
@@ -171,12 +172,13 @@ static void liveQueryCallback(C4QueryObserver *c4obs, C4Query *c4query, void *co
             return;
         }
         token = _token;
+        query = _query;
     }
     
-    CBLQueryResultSet* rs = [[CBLQueryResultSet alloc] initWithQuery: _query 
+    CBLQueryResultSet* rs = [[CBLQueryResultSet alloc] initWithQuery: query
                                                           enumerator: enumerator
                                                          columnNames: _columnNames];
-    [token postChange: [[CBLQueryChange alloc] initWithQuery: _query results: rs error: nil]];
+    [token postChange: [[CBLQueryChange alloc] initWithQuery: query results: rs error: nil]];
 }
 
 @end


### PR DESCRIPTION
* Make sure the query is retained and not nil when using it.

* Port the [fix](https://github.com/couchbase/couchbase-lite-ios/pull/3292/commits/7656730f3f22ded3e02454f37627fbb176eeaa59) from releae/3.2 branch.