### PR TITLE
CBL-6024: Swift MutableDocument's collection is not set when a new document is saved

### DIFF
--- a/Objective-C/Tests/DocumentTest.m
+++ b/Objective-C/Tests/DocumentTest.m
@@ -2237,6 +2237,31 @@
     AssertEqual(blob.length, 0);
 }
 
+- (void) testGetCollectionAfterDocIsSaved {
+    NSError* error;
+    CBLCollection* col1 = [self.db createCollectionWithName:@"collection1" scope: nil error: &error];
+    CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc setString: @"hello" forKey: @"greetings"];
+    [col1 saveDocument: doc error: &error];
+    CBLCollection* docColl = [doc collection];
+    AssertEqual(col1, docColl);
+}
+
+- (void) testDocumentResaveInAnotherCollection {
+    NSError* error;
+    CBLCollection* colA = [self.db createCollectionWithName:@"collA" scope: nil error: &error];
+    CBLCollection* colB = [self.db createCollectionWithName:@"collB" scope: nil error: &error];
+    
+    CBLMutableDocument* doc = [[CBLMutableDocument alloc] initWithID: @"doc1"];
+    [doc setString: @"hello" forKey: @"greetings"];
+    
+    [colA saveDocument: doc error: &error];
+    doc = [[colA documentWithID: @"doc1" error: &error] toMutable];
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidParameter in:^BOOL(NSError** e) {
+        return [colB saveDocument: doc error: e];
+    }];
+}
+
 #pragma clang diagnostic pop
 
 @end

--- a/Swift/Collection.swift
+++ b/Swift/Collection.swift
@@ -101,6 +101,9 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
     /// the database is closed.
     public func save(document: MutableDocument) throws {
         try impl.save(document.impl as! CBLMutableDocument)
+        if (document.collection == nil) {
+            document.collection = self
+        }
     }
     
     /// Save a document into the collection with a specified concurrency control. When specifying
@@ -123,6 +126,9 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
                 return false
             }
             throw err
+        }
+        if (document.collection == nil) {
+            document.collection = self
         }
         return result
     }
@@ -151,6 +157,9 @@ public final class Collection : CollectionChangeObservable, Indexable, Equatable
                 return false
             }
             throw err
+        }
+        if (document.collection == nil) {
+            document.collection = self
         }
         return result
     }

--- a/Swift/Document.swift
+++ b/Swift/Document.swift
@@ -42,7 +42,7 @@ public class Document : DictionaryProtocol, Equatable, Hashable, Sequence {
     }
     
     /// The collection that the document belongs to.
-    public let collection: Collection?
+    internal(set) public var collection: Collection?
     
     // MARK: Edit
     

--- a/Swift/MutableDocument.swift
+++ b/Swift/MutableDocument.swift
@@ -93,8 +93,7 @@ public final class MutableDocument : Document, MutableDictionaryProtocol {
     }
     
     // MARK: Edit
-    
-    // TODO: Implement copy
+
     /// Returns the same MutableDocument object.
     ///
     /// - Returns: The MutableDocument object.
@@ -306,5 +305,4 @@ public final class MutableDocument : Document, MutableDictionaryProtocol {
     private var docImpl: CBLMutableDocument {
         return impl as! CBLMutableDocument
     }
-    
 }

--- a/Swift/Tests/DocumentTest.swift
+++ b/Swift/Tests/DocumentTest.swift
@@ -1789,6 +1789,27 @@ class DocumentTest: CBLTestCase {
                                                             Blob.blobLengthProperty: blob.length])
         XCTAssertNil(retrivedBlob)
         XCTAssertEqual(retrivedBlob?.length ?? 0, 0)
+    }
+    
+    func testGetCollectionAfterDocIsSaved() throws {
+        let col1 = try db.createCollection(name: "collection1")
+        let doc = MutableDocument(id: "doc1")
+        doc.setString("hello", forKey: "greeting")
+        try col1.save(document: doc)
+        XCTAssert(doc.collection == col1)
+    }
+    
+    func testDocumentResaveInAnotherCollection() throws {
+        let colA = try db.createCollection(name: "collA")
+        let colB = try db.createCollection(name: "collB")
         
+        var doc = MutableDocument(id: "doc1")
+        doc.setString("hello", forKey: "greeting")
+        
+        try colA.save(document: doc)
+        doc = try colA.document(id: "doc1")!.toMutable()
+        self.expectError(domain: CBLError.domain, code: CBLError.invalidParameter) {
+            try colB.save(document: doc)
+        }
     }
 }


### PR DESCRIPTION
Port the [fix](https://github.com/couchbase/couchbase-lite-ios/commit/87d307b0b8c005a2dc29d52691e0a1cf33c20af1) from release/3.2 branch.