### PR TITLE
CBL-6066: Implement Database Full-Sync Option

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1023,7 +1023,7 @@ static BOOL setupDatabaseDirectory(NSString *dir, NSError **outError)
 static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
     C4DatabaseConfig2 c4config = kDBConfig;
 
-    if (config.isFullSync)
+    if (config.fullSync)
         c4config.flags |= kC4DB_DiskSyncFull;
 #ifdef COUCHBASE_ENTERPRISE
     if (config.encryptionKey)

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1023,6 +1023,8 @@ static BOOL setupDatabaseDirectory(NSString *dir, NSError **outError)
 static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
     C4DatabaseConfig2 c4config = kDBConfig;
 
+    if (config.isFullSync)
+        c4config.flags |= kC4DB_DiskSyncFull;
 #ifdef COUCHBASE_ENTERPRISE
     if (config.encryptionKey)
         c4config.encryptionKey = [CBLDatabase c4EncryptionKey: config.encryptionKey];

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1152,4 +1152,10 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
     });
 }
 
+#pragma mark - Private for test
+
+- (C4DatabaseConfig2) getC4DBConfig2: (CBLDatabaseConfiguration*) config {
+    return c4DatabaseConfig2(config);
+}
+
 @end

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -1154,8 +1154,8 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
 
 #pragma mark - Private for test
 
-- (C4DatabaseConfig2) getC4DBConfig2: (CBLDatabaseConfiguration*) config {
-    return c4DatabaseConfig2(config);
+- (const C4DatabaseConfig2*) getC4DBConfig {
+    return c4db_getConfig2(_c4db);
 }
 
 @end

--- a/Objective-C/CBLDatabaseConfiguration.h
+++ b/Objective-C/CBLDatabaseConfiguration.h
@@ -30,6 +30,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy) NSString* directory;
 
+/** 
+ As Couchbase Lite normally configures its databases, There is a very
+ small (though non-zero) chance that a power failure at just the wrong
+ time could cause the most recently committed transaction's changes to
+ be lost. This would cause the database to appear as it did immediately
+ before that transaction.
+ 
+ Setting this mode true ensures that an operating system crash or
+ power failure will not cause the loss of any data.  FULL synchronous
+ is very safe but it is also dramatically slower.
+ */
 @property (nonatomic) BOOL isFullSync;
 
 /**

--- a/Objective-C/CBLDatabaseConfiguration.h
+++ b/Objective-C/CBLDatabaseConfiguration.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy) NSString* directory;
 
+@property (nonatomic) BOOL isFullSync;
+
 /**
  Initializes the CBLDatabaseConfiguration object.
  */

--- a/Objective-C/CBLDatabaseConfiguration.h
+++ b/Objective-C/CBLDatabaseConfiguration.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  power failure will not cause the loss of any data.  FULL synchronous
  is very safe but it is also dramatically slower.
  */
-@property (nonatomic) BOOL isFullSync;
+@property (nonatomic) BOOL fullSync;
 
 /**
  Initializes the CBLDatabaseConfiguration object.

--- a/Objective-C/CBLDatabaseConfiguration.h
+++ b/Objective-C/CBLDatabaseConfiguration.h
@@ -31,14 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString* directory;
 
 /** 
- As Couchbase Lite normally configures its databases, There is a very
+ As Couchbase Lite normally configures its databases, there is a very
  small (though non-zero) chance that a power failure at just the wrong
  time could cause the most recently committed transaction's changes to
  be lost. This would cause the database to appear as it did immediately
  before that transaction.
  
  Setting this mode true ensures that an operating system crash or
- power failure will not cause the loss of any data.  FULL synchronous
+ power failure will not cause the loss of any data. FULL synchronous
  is very safe but it is also dramatically slower.
  */
 @property (nonatomic) BOOL fullSync;

--- a/Objective-C/CBLDatabaseConfiguration.m
+++ b/Objective-C/CBLDatabaseConfiguration.m
@@ -25,8 +25,7 @@
     BOOL _readonly;
 }
 
-@synthesize directory=_directory;
-@synthesize isFullSync=_isFullSync;
+@synthesize directory=_directory, isFullSync=_isFullSync;
 
 #ifdef COUCHBASE_ENTERPRISE
 @synthesize encryptionKey=_encryptionKey;
@@ -55,7 +54,6 @@
 #endif
         } else
             _directory = [CBLDatabaseConfiguration defaultDirectory];
-            _isFullSync = kCBLDefaultDatabaseFullSync;
     }
     return self;
 }
@@ -66,12 +64,6 @@
     [self checkReadonly];
     
     _directory = directory;
-}
-
-- (void) setFullSync: (BOOL)isFullSync {
-    [self checkReadonly];
-    
-    _isFullSync = isFullSync;
 }
 
 #pragma mark - Internal

--- a/Objective-C/CBLDatabaseConfiguration.m
+++ b/Objective-C/CBLDatabaseConfiguration.m
@@ -19,12 +19,14 @@
 
 #import "CBLDatabaseConfiguration.h"
 #import "CBLDatabase+Internal.h"
+#import "CBLDefaults.h"
 
 @implementation CBLDatabaseConfiguration {
     BOOL _readonly;
 }
 
 @synthesize directory=_directory;
+@synthesize isFullSync=_isFullSync;
 
 #ifdef COUCHBASE_ENTERPRISE
 @synthesize encryptionKey=_encryptionKey;
@@ -47,11 +49,13 @@
         
         if (config) {
             _directory = config.directory;
+            _isFullSync = config.isFullSync;
 #ifdef COUCHBASE_ENTERPRISE
             _encryptionKey = config.encryptionKey;
 #endif
         } else
             _directory = [CBLDatabaseConfiguration defaultDirectory];
+            _isFullSync = kCBLDefaultDatabaseFullSync;
     }
     return self;
 }
@@ -62,6 +66,12 @@
     [self checkReadonly];
     
     _directory = directory;
+}
+
+- (void) setFullSync: (BOOL)isFullSync {
+    [self checkReadonly];
+    
+    _isFullSync = isFullSync;
 }
 
 #pragma mark - Internal

--- a/Objective-C/CBLDatabaseConfiguration.m
+++ b/Objective-C/CBLDatabaseConfiguration.m
@@ -25,7 +25,7 @@
     BOOL _readonly;
 }
 
-@synthesize directory=_directory, isFullSync=_isFullSync;
+@synthesize directory=_directory, fullSync=_fullSync;
 
 #ifdef COUCHBASE_ENTERPRISE
 @synthesize encryptionKey=_encryptionKey;
@@ -48,12 +48,14 @@
         
         if (config) {
             _directory = config.directory;
-            _isFullSync = config.isFullSync;
+            _fullSync = config.fullSync;
 #ifdef COUCHBASE_ENTERPRISE
             _encryptionKey = config.encryptionKey;
 #endif
-        } else
+        } else {
             _directory = [CBLDatabaseConfiguration defaultDirectory];
+            _fullSync = kCBLDefaultDatabaseFullSync;
+        }
     }
     return self;
 }

--- a/Objective-C/CBLDefaults.h
+++ b/Objective-C/CBLDefaults.h
@@ -22,6 +22,11 @@
 
 #import "CBLReplicatorTypes.h"
 
+#pragma mark - CBLDatabaseConfiguration
+
+/** [NO] Full sync is off by default because the performance hit is seldom worth the benefit */
+extern const BOOL kCBLDefaultDatabaseFullSync;
+
 #pragma mark - CBLLogFileConfiguration
 
 /** [NO] Plaintext is not used, and instead binary encoding is used in log files */

--- a/Objective-C/CBLDefaults.m
+++ b/Objective-C/CBLDefaults.m
@@ -22,6 +22,9 @@
 
 #import "CBLDefaults.h"
 
+#pragma mark - CBLDatabaseConfiguration
+
+const BOOL kCBLDefaultDatabaseFullSync = NO;
 
 #pragma mark - CBLLogFileConfiguration
 

--- a/Objective-C/Exports/CBL.txt
+++ b/Objective-C/Exports/CBL.txt
@@ -91,6 +91,7 @@ _kCBLBlobContentTypeProperty
 _kCBLBlobDigestProperty
 _kCBLBlobLengthProperty
 _kCBLBlobType
+_kCBLDefaultDatabaseFullSync
 _kCBLDefaultCollectionName
 _kCBLDefaultFullTextIndexIgnoreAccents
 _kCBLDefaultListenerDisableTls

--- a/Objective-C/Exports/Generated/CBL.exp
+++ b/Objective-C/Exports/Generated/CBL.exp
@@ -71,6 +71,7 @@ _kCBLBlobDigestProperty
 _kCBLBlobLengthProperty
 _kCBLBlobType
 _kCBLDefaultCollectionName
+_kCBLDefaultDatabaseFullSync
 _kCBLDefaultFullTextIndexIgnoreAccents
 _kCBLDefaultListenerDisableTls
 _kCBLDefaultListenerEnableDeltaSync

--- a/Objective-C/Exports/Generated/CBL_EE.exp
+++ b/Objective-C/Exports/Generated/CBL_EE.exp
@@ -105,6 +105,7 @@ _kCBLCertAttrStateOrProvince
 _kCBLCertAttrSurname
 _kCBLCertAttrURL
 _kCBLDefaultCollectionName
+_kCBLDefaultDatabaseFullSync
 _kCBLDefaultFullTextIndexIgnoreAccents
 _kCBLDefaultListenerDisableTls
 _kCBLDefaultListenerEnableDeltaSync

--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -46,7 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// CBLDatabase:
 
-
 @interface CBLDatabase () <CBLLockable, CBLRemovableListenerToken>
 
 @property (readonly, nonatomic, nullable) C4Database* c4db;
@@ -76,6 +75,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (CBLCollection*) defaultCollectionOrThrow;
 
 - (id) mutex;
+
+#pragma mark - Private for test
+
+- (C4DatabaseConfig2) getC4DBConfig2: (CBLDatabaseConfiguration*) config;
 
 @end
 

--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Private for test
 
-- (C4DatabaseConfig2) getC4DBConfig2: (CBLDatabaseConfiguration*) config;
+- (const C4DatabaseConfig2*) getC4DBConfig;
 
 @end
 

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2815,6 +2815,75 @@
     [token remove];
 }
 
+#pragma mark - Full Sync Option
+
+/** 
+ Test Spec for Database Full Sync Option https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0003-SQLite-Options.md
+ */
+
+/**
+ 1. TestSQLiteFullSyncConfig
+ Description
+    Test that the FullSync default is as expected and that it's setter and getter work.
+ Steps
+    1. Create a DatabaseConfiguration object.
+    2. Get and check the value of the FullSync property: it should be false.
+    3. Set the FullSync property true
+    4. Get the config FullSync property and verify that it is true
+    5. Set the FullSync property false
+    6. Get the config FullSync property and verify that it is false
+ */
+- (void) testSQLiteFullSyncConfig {
+    CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
+    AssertFalse(config.isFullSync);
+    
+    config.isFullSync = true;
+    Assert(config.isFullSync);
+    
+    config.isFullSync = false;
+    AssertFalse(config.isFullSync);
+}
+
+/**
+ 2. TestDBWithFullSync
+ Description
+    Test that a Database respects the FullSync property
+ Steps
+    1. Create a DatabaseConfiguration object and set Full Sync false
+    2. Create a database with the config
+    3. Get the configuration object from the Database and verify that FullSync is false
+    4. Use c4db_config2 (perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_DiskSyncFull flag
+    5. Set the config's FullSync property true
+    6. Create a database with the config
+    7. Get the configuration object from the Database and verify that FullSync is true
+    8. Use c4db_config2 to confirm that its config contains the kC4DB_DiskSyncFull flag
+ */
+- (void) testDBWithFullSync {
+    NSError* error;
+    NSString* dbName = @"fullsyncdb";
+    [CBLDatabase deleteDatabase: dbName inDirectory: self.directory error: nil];
+    AssertFalse([CBLDatabase databaseExists: dbName inDirectory: self.directory]);
+    
+    CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
+    config.directory = self.directory;
+    CBLDatabase* db = [[CBLDatabase alloc] initWithName: dbName
+                                                 config: config
+                                                  error: &error];
+    AssertNil(error);
+    AssertNotNil(db, @"Couldn't open db: %@", error);
+    AssertFalse([db config].isFullSync);
+    [self closeDatabase: db];
+    
+    config.isFullSync = true;
+    db = [[CBLDatabase alloc] initWithName: dbName
+                                    config: config
+                                     error: &error];
+    AssertNil(error);
+    AssertNotNil(db, @"Couldn't open db: %@", error);
+    Assert([db config].isFullSync);
+    [self closeDatabase: db];
+}
+
 #pragma clang diagnostic pop
 
 @end

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2852,11 +2852,11 @@
     1. Create a DatabaseConfiguration object and set Full Sync false.
     2. Create a database with the config.
     3. Get the configuration object from the Database and verify that FullSync is false.
-    4. Use c4db_config2 (perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_DiskSyncFull flag
-    5. Set the config's FullSync property true
-    6. Create a database with the config
-    7. Get the configuration object from the Database and verify that FullSync is true
-    8. Use c4db_config2 to confirm that its config contains the kC4DB_DiskSyncFull flag
+    4. Use c4db_config2 (perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_DiskSyncFull flag.
+    5. Set the config's FullSync property true.
+    6. Create a database with the config.
+    7. Get the configuration object from the Database and verify that FullSync is true.
+    8. Use c4db_config2 to confirm that its config contains the kC4DB_DiskSyncFull flag.
  */
 - (void) testDBWithFullSync {
     NSString* dbName = @"fullsyncdb";
@@ -2872,6 +2872,9 @@
     AssertNil(error);
     AssertNotNil(db, @"Couldn't open db: %@", error);
     AssertFalse([db config].isFullSync);
+    C4DatabaseConfig2 c4config = [db getC4DBConfig2: [db config]];
+    AssertFalse((c4config.flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
+    
     [self closeDatabase: db];
     
     config.isFullSync = true;
@@ -2881,6 +2884,9 @@
     AssertNil(error);
     AssertNotNil(db, @"Couldn't open db: %@", error);
     Assert([db config].isFullSync);
+    c4config = [db getC4DBConfig2: [db config]];
+    Assert((c4config.flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
+
     [self closeDatabase: db];
 }
 

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2835,13 +2835,13 @@
  */
 - (void) testSQLiteFullSyncConfig {
     CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
-    AssertFalse(config.isFullSync);
+    AssertFalse(config.fullSync);
     
-    config.isFullSync = true;
-    Assert(config.isFullSync);
+    config.fullSync = true;
+    Assert(config.fullSync);
     
-    config.isFullSync = false;
-    AssertFalse(config.isFullSync);
+    config.fullSync = false;
+    AssertFalse(config.fullSync);
 }
 
 /**
@@ -2871,19 +2871,19 @@
                                                   error: &error];
     AssertNil(error);
     AssertNotNil(db, @"Couldn't open db: %@", error);
-    AssertFalse([db config].isFullSync);
+    AssertFalse([db config].fullSync);
     C4DatabaseConfig2 c4config = [db getC4DBConfig2: [db config]];
     AssertFalse((c4config.flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
     
     [self closeDatabase: db];
     
-    config.isFullSync = true;
+    config.fullSync = true;
     db = [[CBLDatabase alloc] initWithName: dbName
                                     config: config
                                      error: &error];
     AssertNil(error);
     AssertNotNil(db, @"Couldn't open db: %@", error);
-    Assert([db config].isFullSync);
+    Assert([db config].fullSync);
     c4config = [db getC4DBConfig2: [db config]];
     Assert((c4config.flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
 

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2591,7 +2591,7 @@
     Assert([(@[@"collection1", @"_default"]) containsObject: collections[1].name]);
     
     // Create in Custom Scope
-    c = [self.db createCollectionWithName: @"collection2" scope: @"scope1" error: &error];
+    [self.db createCollectionWithName: @"collection2" scope: @"scope1" error: &error];
     
     // verify
     collections = [self.db collections: @"scope1" error: &error];
@@ -2633,8 +2633,8 @@
     [self checkCollections: collections expCollectionNames: @[@"collection1", @"_default"]];
     
     // Create in Custom Scope
-    c1 = [self.db createCollectionWithName: @"collection2" scope: @"scope1" error: &error];
-    c2 = [self.db createCollectionWithName: @"collection2" scope: @"scope1" error: &error];
+    [self.db createCollectionWithName: @"collection2" scope: @"scope1" error: &error];
+    [self.db createCollectionWithName: @"collection2" scope: @"scope1" error: &error];
     
     // verify no duplicate is created.
     collections = [self.db collections: @"scope1" error: &error];
@@ -2828,10 +2828,10 @@
  Steps
     1. Create a DatabaseConfiguration object.
     2. Get and check the value of the FullSync property: it should be false.
-    3. Set the FullSync property true
-    4. Get the config FullSync property and verify that it is true
-    5. Set the FullSync property false
-    6. Get the config FullSync property and verify that it is false
+    3. Set the FullSync property true.
+    4. Get the config FullSync property and verify that it is true.
+    5. Set the FullSync property false.
+    6. Get the config FullSync property and verify that it is false.
  */
 - (void) testSQLiteFullSyncConfig {
     CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
@@ -2847,11 +2847,11 @@
 /**
  2. TestDBWithFullSync
  Description
-    Test that a Database respects the FullSync property
+    Test that a Database respects the FullSync property.
  Steps
-    1. Create a DatabaseConfiguration object and set Full Sync false
-    2. Create a database with the config
-    3. Get the configuration object from the Database and verify that FullSync is false
+    1. Create a DatabaseConfiguration object and set Full Sync false.
+    2. Create a database with the config.
+    3. Get the configuration object from the Database and verify that FullSync is false.
     4. Use c4db_config2 (perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_DiskSyncFull flag
     5. Set the config's FullSync property true
     6. Create a database with the config
@@ -2859,13 +2859,13 @@
     8. Use c4db_config2 to confirm that its config contains the kC4DB_DiskSyncFull flag
  */
 - (void) testDBWithFullSync {
-    NSError* error;
     NSString* dbName = @"fullsyncdb";
     [CBLDatabase deleteDatabase: dbName inDirectory: self.directory error: nil];
     AssertFalse([CBLDatabase databaseExists: dbName inDirectory: self.directory]);
     
     CBLDatabaseConfiguration* config = [[CBLDatabaseConfiguration alloc] init];
     config.directory = self.directory;
+    NSError* error;
     CBLDatabase* db = [[CBLDatabase alloc] initWithName: dbName
                                                  config: config
                                                   error: &error];

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2872,8 +2872,7 @@
     AssertNil(error);
     AssertNotNil(db, @"Couldn't open db: %@", error);
     AssertFalse([db config].fullSync);
-    C4DatabaseConfig2 c4config = [db getC4DBConfig2: [db config]];
-    AssertFalse((c4config.flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
+    AssertFalse(([db getC4DBConfig]->flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
     
     [self closeDatabase: db];
     
@@ -2884,8 +2883,7 @@
     AssertNil(error);
     AssertNotNil(db, @"Couldn't open db: %@", error);
     Assert([db config].fullSync);
-    c4config = [db getC4DBConfig2: [db config]];
-    Assert((c4config.flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
+    Assert(([db getC4DBConfig]->flags & kC4DB_DiskSyncFull) == kC4DB_DiskSyncFull);
 
     [self closeDatabase: db];
 }

--- a/Swift/DatabaseConfiguration.swift
+++ b/Swift/DatabaseConfiguration.swift
@@ -35,7 +35,7 @@ public struct DatabaseConfiguration {
     /// Setting this mode true ensures that an operating system crash or
     /// power failure will not cause the loss of any data.  FULL synchronous
     /// is very safe but it is also dramatically slower.
-    public var isFullSync: Bool = defaultFullSync
+    public var fullSync: Bool = defaultFullSync
     
     #if COUCHBASE_ENTERPRISE
     /// The key to encrypt the database with.
@@ -51,7 +51,7 @@ public struct DatabaseConfiguration {
     public init(config: DatabaseConfiguration?) {
         if let c = config {
             self.directory = c.directory
-            self.isFullSync = c.isFullSync
+            self.fullSync = c.fullSync
             #if COUCHBASE_ENTERPRISE
             self.encryptionKey = c.encryptionKey
             #endif
@@ -63,7 +63,7 @@ public struct DatabaseConfiguration {
     func toImpl() -> CBLDatabaseConfiguration {
         let config = CBLDatabaseConfiguration()
         config.directory = self.directory
-        config.isFullSync = self.isFullSync
+        config.fullSync = self.fullSync
         #if COUCHBASE_ENTERPRISE
         config.encryptionKey = self.encryptionKey?.impl
         #endif

--- a/Swift/DatabaseConfiguration.swift
+++ b/Swift/DatabaseConfiguration.swift
@@ -2,7 +2,7 @@
 //  DatabaseConfiguration.swift
 //  CouchbaseLite
 //
-//  Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -26,6 +26,17 @@ public struct DatabaseConfiguration {
     /// Path to the directory to store the database in.
     public var directory: String = CBLDatabaseConfiguration().directory
     
+    /// As Couchbase Lite normally configures its databases, There is a very
+    /// small (though non-zero) chance that a power failure at just the wrong
+    /// time could cause the most recently committed transaction's changes to
+    /// be lost. This would cause the database to appear as it did immediately
+    /// before that transaction.
+    ///
+    /// Setting this mode true ensures that an operating system crash or
+    /// power failure will not cause the loss of any data.  FULL synchronous
+    /// is very safe but it is also dramatically slower.
+    public var isFullSync: Bool = defaultFullSync
+    
     #if COUCHBASE_ENTERPRISE
     /// The key to encrypt the database with.
     public var encryptionKey: EncryptionKey?
@@ -40,6 +51,7 @@ public struct DatabaseConfiguration {
     public init(config: DatabaseConfiguration?) {
         if let c = config {
             self.directory = c.directory
+            self.isFullSync = c.isFullSync
             #if COUCHBASE_ENTERPRISE
             self.encryptionKey = c.encryptionKey
             #endif
@@ -51,6 +63,7 @@ public struct DatabaseConfiguration {
     func toImpl() -> CBLDatabaseConfiguration {
         let config = CBLDatabaseConfiguration()
         config.directory = self.directory
+        config.isFullSync = self.isFullSync
         #if COUCHBASE_ENTERPRISE
         config.encryptionKey = self.encryptionKey?.impl
         #endif

--- a/Swift/Defaults.swift
+++ b/Swift/Defaults.swift
@@ -22,6 +22,13 @@
 
 import Foundation
 
+public extension DatabaseConfiguration {
+
+    /// [false] Full sync is off by default because the performance hit is seldom worth the benefit
+    static let defaultFullSync: Bool = kCBLDefaultDatabaseFullSync.boolValue
+
+}
+
 public extension LogFileConfiguration {
     /// [false] Plaintext is not used, and instead binary encoding is used in log files
     static let defaultUsePlainText: Bool = kCBLDefaultLogFileUsePlainText.boolValue

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -1544,13 +1544,13 @@ class DatabaseTest: CBLTestCase {
     ///     6. Get the config FullSync property and verify that it is false.
     func testSQLiteFullSyncConfig() {
         var config = DatabaseConfiguration()
-        XCTAssertFalse(config.isFullSync)
+        XCTAssertFalse(config.fullSync)
         
-        config.isFullSync = true
-        XCTAssert(config.isFullSync)
+        config.fullSync = true
+        XCTAssert(config.fullSync)
         
-        config.isFullSync = false
-        XCTAssertFalse(config.isFullSync)
+        config.fullSync = false
+        XCTAssertFalse(config.fullSync)
     }
     
     /// 2. TestDBWithFullSync
@@ -1573,11 +1573,11 @@ class DatabaseTest: CBLTestCase {
         var config = DatabaseConfiguration()
         config.directory = self.directory
         db = try Database(name: dbName, config: config)
-        XCTAssertFalse(DatabaseConfiguration(config: config).isFullSync)
+        XCTAssertFalse(DatabaseConfiguration(config: config).fullSync)
         
         db = nil
-        config.isFullSync = true
+        config.fullSync = true
         db = try Database(name: dbName, config: config)
-        XCTAssert(DatabaseConfiguration(config: config).isFullSync)
+        XCTAssert(DatabaseConfiguration(config: config).fullSync)
     }
 }

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -2,7 +2,7 @@
 //  DatabaseTest.swift
 //  CouchbaseLite
 //
-//  Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -1526,5 +1526,58 @@ class DatabaseTest: CBLTestCase {
         #if COUCHBASE_ENTERPRISE
         XCTAssertNotNil(db.config.encryptionKey)
         #endif
+    }
+    
+    // MARK: Full Sync Option
+    /// Test Spec for Database Full Sync Option
+    /// https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0003-SQLite-Options.md
+    
+    /// 1. TestSQLiteFullSyncConfig
+    /// Description:
+    ///     Test that the FullSync default is as expected and that it's setter and getter work.
+    /// Steps
+    ///     1. Create a DatabaseConfiguration object.
+    ///     2. Get and check the value of the FullSync property: it should be false.
+    ///     3. Set the FullSync property true.
+    ///     4. Get the config FullSync property and verify that it is true.
+    ///     5. Set the FullSync property false.
+    ///     6. Get the config FullSync property and verify that it is false.
+    func testSQLiteFullSyncConfig() {
+        var config = DatabaseConfiguration()
+        XCTAssertFalse(config.isFullSync)
+        
+        config.isFullSync = true
+        XCTAssert(config.isFullSync)
+        
+        config.isFullSync = false
+        XCTAssertFalse(config.isFullSync)
+    }
+    
+    /// 2. TestDBWithFullSync
+    /// Description:
+    ///     Test that the FullSync default is as expected and that it's setter and getter work.
+    /// Steps
+    ///     1. Create a DatabaseConfiguration object and set Full Sync false.
+    ///     2. Create a database with the config.
+    ///     3. Get the configuration object from the Database and verify that FullSync is false.
+    ///     4. Use c4db_config2 (perhaps necessary only for this test) to confirm that its config does not contain the kC4DB_DiskSyncFull flag. - done in Obj-C
+    ///     5. Set the config's FullSync property true.
+    ///     6. Create a database with the config.
+    ///     7. Get the configuration object from the Database and verify that FullSync is true.
+    ///     8. Use c4db_config2 to confirm that its config contains the kC4DB_DiskSyncFull flag. - done in Obj-C
+    func testDBWithFullSync() throws {
+        let dbName = "fullsyncdb"
+        try deleteDB(name: dbName)
+        XCTAssertFalse(Database.exists(withName: dbName, inDirectory: self.directory))
+        
+        var config = DatabaseConfiguration()
+        config.directory = self.directory
+        db = try Database(name: dbName, config: config)
+        XCTAssertFalse(DatabaseConfiguration(config: config).isFullSync)
+        
+        db = nil
+        config.isFullSync = true
+        db = try Database(name: dbName, config: config)
+        XCTAssert(DatabaseConfiguration(config: config).isFullSync)
     }
 }


### PR DESCRIPTION
- Implemented FullSync DatabaseConfiguration property.
- Only Obj-C tests do check for c4db_config2 kC4DB_DiskSyncFull flag
- Updated LiteCore to 3.1.9-5