### PR TITLE
CBL-6144: Add testConcurrentCreateAndQuery to verify query's lock

### DIFF
--- a/Objective-C/Tests/ConcurrentTest.m
+++ b/Objective-C/Tests/ConcurrentTest.m
@@ -292,7 +292,6 @@
     }];
 }
 
-#if 0
 - (void) testDatabaseChange {
     XCTestExpectation* exp1 = [self expectationWithDescription: @"Create"];
     XCTestExpectation* exp2 = [self expectationWithDescription: @"Change"];
@@ -302,15 +301,13 @@
     }];
     
     [self concurrentRuns: 1 waitUntilDone: NO withBlock: ^(NSUInteger rIndex) {
-        [_db saveDocument: [[CBLMutableDocument alloc] initWithID: @"doc1"]  error: nil];
+        [self->_db saveDocument: [[CBLMutableDocument alloc] initWithID: @"doc1"]  error: nil];
         [exp1 fulfill];
     }];
     
     [self waitForExpectations: @[exp2] timeout: 10.0]; // Test deadlock
 }
-#endif //TEMP
 
-#if 0 //TEMP
 - (void) testDocumentChange {
     XCTestExpectation* exp1 = [self expectationWithDescription: @"Create"];
     XCTestExpectation* exp2 = [self expectationWithDescription: @"Change"];
@@ -320,13 +317,12 @@
     }];
     
     [self concurrentRuns: 1 waitUntilDone: NO withBlock: ^(NSUInteger rIndex) {
-        [_db saveDocument: [[CBLMutableDocument alloc] initWithID: @"doc1"]  error: nil];
+        [self->_db saveDocument: [[CBLMutableDocument alloc] initWithID: @"doc1"]  error: nil];
         [exp1 fulfill];
     }];
     
     [self waitForExpectations: @[exp2] timeout: 10.0]; // Test deadlock
 }
-#endif
 
 - (void) testConcurrentCreateAndQuery {
     NSError* outError;


### PR DESCRIPTION
- port ee8b753424854cf70f0a923f68d54125c058b832 from `release/3.1`
- re-enable 2 additional tests