### PR TITLE
CBL-6191 : Fix null URL when creating proxy CONNECT request

### DIFF
--- a/Objective-C/Internal/Replicator/CBLHTTPLogic.m
+++ b/Objective-C/Internal/Replicator/CBLHTTPLogic.m
@@ -143,11 +143,13 @@ static NSDictionary* sOverrideProxySettings;
     // Create the CFHTTPMessage:
     CFHTTPMessageRef httpMsg;
     if (_proxyType == kCBLHTTPProxy && _useProxyCONNECT) {
-        NSURL *requestURL = [NSURL URLWithString: $sprintf(@"%@:%d", url.host, url.my_effectivePort)];
+        NSString *destination = $sprintf(@"%@:%d", url.host, url.my_effectivePort);
+        CFURLRef requestURL = CFURLCreateWithString(kCFAllocatorDefault, (__bridge CFStringRef)destination, false);
         httpMsg = CFHTTPMessageCreateRequest(NULL,
                                              CFSTR("CONNECT"),
-                                             (__bridge CFURLRef)requestURL,
+                                             requestURL,
                                              kCFHTTPVersion1_1);
+        CFRelease(requestURL);
     } else {
         httpMsg = CFHTTPMessageCreateRequest(NULL,
                                              (__bridge CFStringRef)_urlRequest.HTTPMethod,


### PR DESCRIPTION
NSURL cannot be created with only host and port anymore starting from iOS 17. Changed to use CFURLCreateWithString directly.