### PR TITLE
Fix ArrayIndexConfiguration constructor

### DIFF
--- a/Objective-C/CBLArrayIndexConfiguration.m
+++ b/Objective-C/CBLArrayIndexConfiguration.m
@@ -33,10 +33,10 @@
     } else if ([expressions count] == 0 || [expressions[0] length] == 0) {
         [NSException raise: NSInvalidArgumentException format:
          @"Empty expressions is not allowed, use nil instead"];
+    } else {
+        self = [super initWithIndexType: kC4ArrayIndex
+                            expressions: expressions];
     }
-    
-    self = [super initWithIndexType: kC4ArrayIndex
-                        expressions: expressions];
     
     if (self) {
         _path = path;

--- a/Objective-C/CBLIndexConfiguration.m
+++ b/Objective-C/CBLIndexConfiguration.m
@@ -42,7 +42,7 @@
     return self;
 }
 
-- (NSString*) getIndexSpecs {
+- (NSString*) getIndexSpecs {  
     return [_expressions componentsJoinedByString: @","];
 }
 


### PR DESCRIPTION
- nil wasn't correctly captured and it would've been overwriting, causing a crash in getIndexSpecs - caught by Jenkins on release build pipeline
- runtime warning is ONLY shown on CE target... don't know why that's the case