### PR TITLE
ArrayIndexConfiguration constructor fix

### DIFF
--- a/Swift/IndexConfiguration.swift
+++ b/Swift/IndexConfiguration.swift
@@ -88,7 +88,7 @@ public struct ArrayIndexConfiguration: IndexConfiguration, IndexConfigConvertabl
     ///     represents an expression defining the values within the array to be indexed.
     ///     If the array specified by the path contains scalar values, this parameter can be null.
     /// - Returns The ArrayIndexConfiguration object.
-    public init(path: String, _ expressions: [String]? = nil) {
+    public init(path: String, expressions: [String]? = nil) {
         if let expressions = expressions {
                 if expressions.isEmpty || (expressions.count == 1 && expressions[0].isEmpty) {
                     NSException(name: .invalidArgumentException,

--- a/Swift/Tests/UnnestArrayTest.swift
+++ b/Swift/Tests/UnnestArrayTest.swift
@@ -33,11 +33,11 @@ class UnnestArrayTest: CBLTestCase {
     ///     2. Check that an invalid arument exception is thrown.
     func testArrayIndexConfigInvalidExpressions() throws {
         expectException(exception: .invalidArgumentException) {
-            _ = ArrayIndexConfiguration(path: "contacts", [])
+            _ = ArrayIndexConfiguration(path: "contacts", expressions: [])
         }
         
         expectException(exception: .invalidArgumentException) {
-            _ = ArrayIndexConfiguration(path: "contacts", [""])
+            _ = ArrayIndexConfiguration(path: "contacts", expressions: [""])
         }
     }
     
@@ -76,7 +76,7 @@ class UnnestArrayTest: CBLTestCase {
     func testCreateArrayIndexWithPathAndExpressions() throws {
         let profiles = try db.createCollection(name: "profiles")
         try loadJSONResource("profiles_100", collection: profiles)
-        let config = ArrayIndexConfiguration(path: "contacts", ["address.city", "address.state"])
+        let config = ArrayIndexConfiguration(path: "contacts",expressions: ["address.city", "address.state"])
         try profiles.createIndex(withName: "contacts", config: config)
         let indexes = try profiles.indexesInfo()
         XCTAssertEqual(indexes!.count, 1)


### PR DESCRIPTION
raised from reviewing docs snippets.. now ArrayIndexConfiguration needs explicit attr name expressions on set