### PR TITLE
CBL-5193 : Partial Index API

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -1846,6 +1846,14 @@
 		AECA89802CADADAA00C7B6BE /* UnnestArrayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECA897C2CADADAA00C7B6BE /* UnnestArrayTest.swift */; };
 		AECD5A162C0E21D900B1247E /* CBLIndexUpdater+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = AECD5A0F2C0E21D900B1247E /* CBLIndexUpdater+Internal.h */; };
 		AECD5A172C0E21D900B1247E /* CBLIndexUpdater+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = AECD5A0F2C0E21D900B1247E /* CBLIndexUpdater+Internal.h */; };
+		AEFEED752D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED742D4A8D6F008AF4C2 /* PartialIndexTest.m */; };
+		AEFEED762D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED742D4A8D6F008AF4C2 /* PartialIndexTest.m */; };
+		AEFEED772D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED742D4A8D6F008AF4C2 /* PartialIndexTest.m */; };
+		AEFEED782D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED742D4A8D6F008AF4C2 /* PartialIndexTest.m */; };
+		AEFEED7A2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED792D4AB994008AF4C2 /* PartialIndexTest.swift */; };
+		AEFEED7B2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED792D4AB994008AF4C2 /* PartialIndexTest.swift */; };
+		AEFEED7C2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED792D4AB994008AF4C2 /* PartialIndexTest.swift */; };
+		AEFEED7D2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFEED792D4AB994008AF4C2 /* PartialIndexTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2886,6 +2894,8 @@
 		AECA897C2CADADAA00C7B6BE /* UnnestArrayTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnnestArrayTest.swift; sourceTree = "<group>"; };
 		AECD59F92C0E137200B1247E /* CBLQueryIndex+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLQueryIndex+Internal.h"; sourceTree = "<group>"; };
 		AECD5A0F2C0E21D900B1247E /* CBLIndexUpdater+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLIndexUpdater+Internal.h"; sourceTree = "<group>"; };
+		AEFEED742D4A8D6F008AF4C2 /* PartialIndexTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PartialIndexTest.m; sourceTree = "<group>"; };
+		AEFEED792D4AB994008AF4C2 /* PartialIndexTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialIndexTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3172,6 +3182,7 @@
 				AE5803A32B99C67D001A1BE3 /* VectorSearchTest.swift */,
 				406F8DFC2C27F097000223FC /* VectorSearchTest+Lazy.swift */,
 				AECA897C2CADADAA00C7B6BE /* UnnestArrayTest.swift */,
+				AEFEED792D4AB994008AF4C2 /* PartialIndexTest.swift */,
 				1AA91DC522B0356000BF0BDE /* CustomLogger.swift */,
 				93249D81246B99FD000A8A6E /* iOS */,
 				939B79241E679017009A70EF /* Info.plist */,
@@ -4254,6 +4265,7 @@
 				AE006DE62B7BB98B00884E2B /* VectorSearchTest.m */,
 				40AA72972C28B1A3007FB1E0 /* VectorSearchTest+Lazy.m */,
 				AE5F25492CAC30DC00AAB7F4 /* UnnestArrayIndexTest.m */,
+				AEFEED742D4A8D6F008AF4C2 /* PartialIndexTest.m */,
 				93DECF3E200DBE5800F44953 /* Support */,
 				936483AA1E4431C6008D08B3 /* iOS */,
 				275FF5FA1E3FBD3B005F90DD /* Performance */,
@@ -6351,6 +6363,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AEFEED7B2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */,
 				1AC7546F2897ADA0006CF48F /* ReplicatorTest+Collection.swift in Sources */,
 				27BE3B4F1E4E65EB0012B74A /* DocumentTest.swift in Sources */,
 				93629D011EC96DE700F79834 /* ArrayTest.swift in Sources */,
@@ -6428,6 +6441,7 @@
 				AE5803A52B99C67D001A1BE3 /* VectorSearchTest.swift in Sources */,
 				AE5803D92B9B5B2A001A1BE3 /* WordEmbeddingModel.swift in Sources */,
 				93BB1C9E246BB2BF004FFA00 /* DatabaseTest.swift in Sources */,
+				AEFEED7D2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */,
 				93BB1C9C246BB2BB004FFA00 /* CBLTestCase.swift in Sources */,
 				93BB1CB8246BB2F4004FFA00 /* ReplicatorTest+CustomConflict.swift in Sources */,
 				406F8E002C27F0AB000223FC /* VectorSearchTest+Lazy.swift in Sources */,
@@ -6893,6 +6907,7 @@
 				9343F145207D61EC00F19A89 /* FragmentTest.m in Sources */,
 				9369A6AE207DD0FD009B5B83 /* DatabaseEncryptionTest.m in Sources */,
 				9343F146207D61EC00F19A89 /* QueryTest.m in Sources */,
+				AEFEED772D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */,
 				1A4160D82283694B0061A567 /* ReplicatorTest+CustomConflict.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6930,6 +6945,7 @@
 				40AA729E2C28B1A3007FB1E0 /* VectorSearchTest+Lazy.m in Sources */,
 				9343F176207D633300F19A89 /* DocumentTest.m in Sources */,
 				1A13DD4228B882A800BC1084 /* URLEndpointListenerTest+Main.m in Sources */,
+				AEFEED782D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */,
 				9388CBAE21BD9187005CA66D /* DocumentExpirationTest.m in Sources */,
 				9343F177207D633300F19A89 /* DictionaryTest.m in Sources */,
 				93EB25CD21CDD12A0006FB88 /* PredictiveQueryTest.m in Sources */,
@@ -6991,6 +7007,7 @@
 				AE5803A42B99C67D001A1BE3 /* VectorSearchTest.swift in Sources */,
 				AE5803D82B9B5B2A001A1BE3 /* WordEmbeddingModel.swift in Sources */,
 				9343F198207D636300F19A89 /* CBLTestCase.swift in Sources */,
+				AEFEED7C2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */,
 				93C50EB021BDFC7B00C7E980 /* DocumentExpirationTest.swift in Sources */,
 				9369A6B7207DEB60009B5B83 /* DatabaseEncryptionTest.swift in Sources */,
 				406F8DFF2C27F0A9000223FC /* VectorSearchTest+Lazy.swift in Sources */,
@@ -7045,6 +7062,7 @@
 				1A4160DF228375990061A567 /* ReplicatorTest+CustomConflict.m in Sources */,
 				93CD01901E95546200AFB3FA /* DictionaryTest.m in Sources */,
 				1ABA63AF28813A8A005835E7 /* ReplicatorTest+Collection.m in Sources */,
+				AEFEED762D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */,
 				1A621D792887DCFC0017F905 /* QueryTest+Collection.m in Sources */,
 				9388CBAC21BD917D005CA66D /* DocumentExpirationTest.m in Sources */,
 				AE5F25592CAC310800AAB7F4 /* UnnestArrayIndexTest.m in Sources */,
@@ -7212,6 +7230,7 @@
 				93DD9BA81EB419BB00E502A2 /* ArrayTest.m in Sources */,
 				931C146A1EAAF08C0094F9B2 /* FragmentTest.m in Sources */,
 				40086B532B803B2B00DA6770 /* CBLBlockConflictResolver.m in Sources */,
+				AEFEED752D4A8D82008AF4C2 /* PartialIndexTest.m in Sources */,
 				9332082C1E774419000D9993 /* QueryTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7225,6 +7244,7 @@
 				93BB1CA2246BB2D3004FFA00 /* DictionaryTest.swift in Sources */,
 				93BB1CB5246BB2F3004FFA00 /* ReplicatorTest+CustomConflict.swift in Sources */,
 				93BB1CA5246BB2D3004FFA00 /* FragmentTest.swift in Sources */,
+				AEFEED7A2D4AB999008AF4C2 /* PartialIndexTest.swift in Sources */,
 				1A8F85082893F317008C4333 /* QueryTest+Collection.swift in Sources */,
 				93BB1CAE246BB2DC004FFA00 /* QueryTest.swift in Sources */,
 				93BB1CAD246BB2DC004FFA00 /* NotificationTest.swift in Sources */,

--- a/Objective-C/CBLFullTextIndexConfiguration.h
+++ b/Objective-C/CBLFullTextIndexConfiguration.h
@@ -2,7 +2,7 @@
 //  CBLFullTextIndexConfiguration.h
 //  CouchbaseLite
 //
-//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2025 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -28,6 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CBLFullTextIndexConfiguration : CBLIndexConfiguration
 
 /**
+ A predicate expression defining conditions for indexing documents.
+ Only documents satisfying the predicate are included, enabling partial indexes.
+ */
+@property (nonatomic, readonly, nullable) NSString* where;
+
+/**
  Set the true value to ignore accents/diacritical marks. 
  */
 @property (nonatomic, readonly) BOOL ignoreAccents;
@@ -41,11 +47,28 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString* language;
 
 /**
- Constructor for creating a full-text index by using an array of expression strings
+ Initializes a full-text index by using an array of expression strings
+ @param expressions The array of expression strings.
+ @param ignoreAccents The flag to ignore accents/diacritical marks.
+ @param language Optional language code which is an ISO-639 language such as "en", "fr", etc.
+ @return The full-text index configuration object.
  */
 - (instancetype) initWithExpression: (NSArray<NSString*>*)expressions
                       ignoreAccents: (BOOL)ignoreAccents
-                           language: (NSString* __nullable)language;
+                           language: (nullable NSString*)language;
+
+/**
+ Initializes a full-text index with an array of expression strings and an optional where clause for a partial index.
+ @param where Optional where clause for partial indexing.
+ @param expressions The array of expression strings.
+ @param ignoreAccents The flag to ignore accents/diacritical marks.
+ @param language Optional language code which is an ISO-639 language such as "en", "fr", etc.
+ @return The full-text index configuration object.
+ */
+- (instancetype) initWithExpression: (NSArray<NSString*>*)expressions
+                              where: (nullable NSString*)where
+                      ignoreAccents: (BOOL)ignoreAccents
+                           language: (nullable NSString*)language;
 
 @end
 

--- a/Objective-C/CBLFullTextIndexConfiguration.m
+++ b/Objective-C/CBLFullTextIndexConfiguration.m
@@ -2,7 +2,7 @@
 //  CBLFullTextIndexConfiguration.m
 //  CouchbaseLite
 //
-//  Copyright (c) 2021 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2025 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -22,14 +22,25 @@
 
 @implementation CBLFullTextIndexConfiguration
 
-@synthesize ignoreAccents=_ignoreAccents, language=_language;
+@synthesize ignoreAccents=_ignoreAccents, language=_language, where=_where;
 
 - (instancetype) initWithExpression: (NSArray<NSString*>*)expressions
                       ignoreAccents: (BOOL)ignoreAccents
-                           language: (NSString* __nullable)language {
+                           language: (nullable NSString*)language {
+    return [self initWithExpression: expressions
+                              where: nil
+                      ignoreAccents: ignoreAccents
+                           language: language];
+}
+
+- (instancetype) initWithExpression: (NSArray<NSString*>*)expressions
+                              where: (nullable NSString*)where
+                      ignoreAccents: (BOOL)ignoreAccents
+                           language: (nullable NSString*)language {
     self = [super initWithIndexType: kC4FullTextIndex
                         expressions: expressions];
     if (self) {
+        _where = where;
         // there is no default 'ignoreAccents', since its NOT an optional argument.
         _ignoreAccents = ignoreAccents;
         _language = language;
@@ -39,12 +50,11 @@
 
 - (C4IndexOptions) indexOptions {
     C4IndexOptions c4options = { };
-    
     if (!_language)
         _language = [[NSLocale currentLocale] objectForKey: NSLocaleLanguageCode];
     c4options.language = _language.UTF8String;
-    
     c4options.ignoreDiacritics = _ignoreAccents;
+    c4options.where = _where.UTF8String;
     return c4options;
 }
 

--- a/Objective-C/CBLValueIndexConfiguration.h
+++ b/Objective-C/CBLValueIndexConfiguration.h
@@ -2,7 +2,7 @@
 //  CBLValueIndexConfiguration.h
 //  CouchbaseLite
 //
-//  Copyright (c) 2024 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2025 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -28,9 +28,26 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CBLValueIndexConfiguration : CBLIndexConfiguration
 
 /**
- Constructor for creating a value index by using an array of expression strings.
+ A predicate expression defining conditions for indexing documents.
+ Only documents satisfying the predicate are included, enabling partial indexes.
+ */
+@property (nonatomic, readonly, nullable) NSString* where;
+
+/**
+ Initializes a value index by using an array of expression strings.
+ @param expressions The array of expression strings.
+ @return The value index configuration object.
  */
 - (instancetype) initWithExpression: (NSArray<NSString*>*)expressions;
+
+/**
+ Initializes a value index with an array of expression strings and an optional where clause for a partial index.
+ @param expressions The array of expression strings.
+ @param where Optional where clause for partial indexing.
+ @return The value index configuration object.
+ */
+- (instancetype) initWithExpression: (NSArray<NSString*>*)expressions
+                              where: (nullable NSString*)where;
 
 @end
 

--- a/Objective-C/CBLValueIndexConfiguration.m
+++ b/Objective-C/CBLValueIndexConfiguration.m
@@ -2,7 +2,7 @@
 //  CBLValueIndexConfiguration.m
 //  CouchbaseLite
 //
-//  Copyright (c) 2021 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2025 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -22,8 +22,25 @@
 
 @implementation CBLValueIndexConfiguration
 
+@synthesize where=_where;
+
 - (instancetype) initWithExpression: (NSArray<NSString*>*)expressions {
-    return [super initWithIndexType: kC4ValueIndex expressions: expressions];
+    return [self initWithExpression: expressions where: nil];
+}
+
+- (instancetype) initWithExpression: (NSArray<NSString*>*)expressions
+                              where: (nullable NSString*)where {
+    self = [super initWithIndexType: kC4ValueIndex expressions: expressions];
+    if (self) {
+        _where = where;
+    }
+    return self;
+}
+
+- (C4IndexOptions) indexOptions {
+    C4IndexOptions c4options = { };
+    c4options.where = _where.UTF8String;
+    return c4options;
 }
 
 @end

--- a/Objective-C/Tests/PartialIndexTest.m
+++ b/Objective-C/Tests/PartialIndexTest.m
@@ -1,0 +1,123 @@
+//
+//  PartialIndexTest.m
+//  CouchbaseLite
+//
+//  Copyright (c) 2025 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "CBLTestCase.h"
+
+/**
+ Test Spec v1.0.3:
+ https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0007-Partial-Index.md
+ */
+
+@interface PartialIndexTest : CBLTestCase
+
+@end
+
+@implementation PartialIndexTest
+
+/**
+ * 1. TestCreatePartialValueIndex
+ *
+ * Description
+ * Test that a partial value index is successfully created.
+ *
+ * Steps
+ * 1. Create a partial value index named "numIndex" in the default collection.
+ *     - expression: "num"
+ *     - where: "type = 'number'"
+ * 2. Check that the index is successfully created.
+ * 3. Create a query object with an SQL++ string:
+ *     - SELECT *
+ *       FROM _
+ *       WHERE type = 'number' AND num > 1000
+ * 4. Get the query plan from the query object and check that the plan contains "USING INDEX numIndex" string.
+ * 5. Create a query object with an SQL++ string:
+ *     - SELECT *
+ *       FROM _
+ *       WHERE type = 'foo' AND num > 1000
+ * 6. Get the query plan from the query object and check that the plan doesn't contain "USING INDEX numIndex" string.
+ */
+- (void) testCreatePartialValueIndex {
+    NSError* error;
+    CBLCollection* collection = [self.db defaultCollection: &error];
+
+    CBLValueIndexConfiguration* config = [[CBLValueIndexConfiguration alloc] initWithExpression: @[@"num"] where: @"type='number'"];
+    Assert([collection createIndexWithName: @"numIndex" config: config error: nil]);
+    
+    NSString* sql = @"SELECT * FROM _ WHERE type = 'number' AND num > 1000";
+    CBLQuery* q = [_db createQuery: sql error: &error];
+    AssertNotNil(q);
+    NSString* explain = [q explain: &error];
+    Assert([explain rangeOfString: @"USING INDEX numIndex"].location != NSNotFound);
+    
+    sql = @"SELECT * FROM _ WHERE type = 'foo' AND num > 1000";
+    q = [_db createQuery: sql error: &error];
+    explain = [q explain: &error];
+    AssertFalse([explain rangeOfString: @"USING INDEX numIndex"].location != NSNotFound);
+}
+
+/**
+ * 2. TestCreatePartialFullTextIndex
+ *
+ * Description
+ * Test that a partial full text index is successfully created.
+ *
+ * Steps
+ * 1. Create following two documents with the following bodies in the default collection.
+ *     - { "content" : "Couchbase Lite is a database." }
+ *     - { "content" : "Couchbase Lite is a NoSQL syncable database." }
+ * 2. Create a partial full text index named "contentIndex" in the default collection.
+ *     - expression: "content"
+ *     - where: "length(content) > 30"
+ * 3. Check that the index is successfully created.
+ * 4. Create a query object with an SQL++ string:
+ *     - SELECT content
+ *       FROM _
+ *       WHERE match(contentIndex, "database")
+ * 4. Execute the query and check that:
+ *     - The query returns the second document.
+ * 5. Create a query object with an SQL++ string:
+ *     - There is one result returned
+ *     - The returned content is "Couchbase Lite is a NoSQL syncable database.".
+ */
+- (void) testCreatePartialFullTextIndex {
+    NSError* error;
+    CBLCollection* collection = [self.db defaultCollection: &error];
+    NSString* json1 = @"{\"content\":\"Couchbase Lite is a database.\"}";
+    NSString* json2 = @"{\"content\":\"Couchbase Lite is a NoSQL syncable database.\"}";
+    
+    [collection saveDocument:[[CBLMutableDocument alloc] initWithJSON:json1 error:&error]
+                       error:&error];
+    
+    [collection saveDocument:[[CBLMutableDocument alloc] initWithJSON:json2 error:&error]
+                       error:&error];
+
+    CBLFullTextIndexConfiguration* config = [[CBLFullTextIndexConfiguration alloc] initWithExpression: @[@"content"]
+                                                                                                where: @"length(content)>30"
+                                                                                        ignoreAccents: false
+                                                                                             language: nil];
+    Assert([collection createIndexWithName: @"contentIndex" config: config error: nil]);
+    
+    NSString* sql = @"SELECT content FROM _ WHERE match(contentIndex, 'database')";
+    CBLQuery* q = [_db createQuery: sql error: &error];
+    AssertNotNil(q);
+    NSArray* results = [[q execute: &error] allResults];
+    AssertEqual(results.count, 1);
+    AssertEqualObjects([results[0] toJSON], json2);
+}
+
+@end

--- a/Objective-C/Tests/VectorSearchTest.h
+++ b/Objective-C/Tests/VectorSearchTest.h
@@ -54,22 +54,22 @@ NS_ASSUME_NONNULL_BEGIN
 /** For the test subclasses to override the default vector expression. */
 - (NSString*) wordsQueryDefaultExpression;
 
-- (NSString*) wordsQueryStringWithLimit: (NSUInteger)limit
+- (NSString*) wordsQueryStringWithLimit: (NSInteger)limit
                                  metric: (nullable NSString*)metric
                        vectorExpression: (nullable NSString*)vectorExpression
                             whereClause: (nullable NSString*)whereClause;
 
-- (NSString*) wordsQueryStringWithLimit: (NSUInteger)limit;
+- (NSString*) wordsQueryStringWithLimit: (NSInteger)limit;
 
-- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSUInteger)limit
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSInteger)limit
                                            metric: (nullable NSString*)metric
                                  vectorExpression: (nullable NSString*)vectorExpression
                                       whereClause: (nullable NSString*)whereClause
                                     checkTraining: (BOOL) checkTraining;
 
-- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSUInteger)limit;
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSInteger)limit;
 
-- (CBLQueryResultSet*) executeWordsQueryNoTrainingCheckWithLimit: (NSUInteger)limit;
+- (CBLQueryResultSet*) executeWordsQueryNoTrainingCheckWithLimit: (NSInteger)limit;
 
 - (NSDictionary<NSString*, NSString*>*) toDocIDWordMap: (CBLQueryResultSet*)resultSet;
 

--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -143,7 +143,7 @@
     return @"vector";
 }
 
-- (NSString*) wordsQueryStringWithLimit: (NSUInteger)limit
+- (NSString*) wordsQueryStringWithLimit: (NSInteger)limit
                                  metric: (nullable NSString*)metric
                        vectorExpression: (nullable NSString*)vectorExpression
                             whereClause: (nullable NSString*)whereClause {
@@ -163,17 +163,16 @@
         sql = [sql stringByAppendingFormat: @"ORDER BY APPROX_VECTOR_DISTANCE(%@, $vector) ", vectorExpression];
     }
     
-    
-    sql = [sql stringByAppendingFormat: @"LIMIT %lu", (unsigned long)limit];
-    
+    sql = [sql stringByAppendingFormat: @"LIMIT %ld", (long)limit];
+
     return sql;
 }
 
-- (NSString*) wordsQueryStringWithLimit: (NSUInteger)limit {
+- (NSString*) wordsQueryStringWithLimit: (NSInteger)limit {
     return [self wordsQueryStringWithLimit: limit metric: nil vectorExpression: nil whereClause: nil];
 }
 
-- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSUInteger)limit
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSInteger)limit
                                            metric: (NSString*)metric
                                  vectorExpression: (NSString*)vectorExpression
                                       whereClause: (NSString*)whereClause
@@ -203,16 +202,16 @@
     return rs;
 }
 
-- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSUInteger)limit {
-    return [self executeWordsQueryWithLimit: limit 
+- (CBLQueryResultSet*) executeWordsQueryWithLimit: (NSInteger)limit {
+    return [self executeWordsQueryWithLimit: limit
                                      metric: nil
                            vectorExpression: nil
                                 whereClause: nil
                               checkTraining: true];
 }
 
-- (CBLQueryResultSet*) executeWordsQueryNoTrainingCheckWithLimit: (NSUInteger)limit {
-    return [self executeWordsQueryWithLimit: limit 
+- (CBLQueryResultSet*) executeWordsQueryNoTrainingCheckWithLimit: (NSInteger)limit {
+    return [self executeWordsQueryWithLimit: limit
                                      metric: nil
                            vectorExpression: nil
                                 whereClause: nil
@@ -1177,17 +1176,17 @@
     CBLVectorIndexConfiguration* config = VECTOR_INDEX_CONFIG(@"vector", 300, 8);
     [self createWordsIndexWithConfig: config];
     
-    // Check valid query with 1 and 10000 set limit
+    // Check valid query with -1, 0, 1 and 10000 set limit
     for (NSNumber* limit in @[@-1, @0, @1, @10000]) {
         NSError* error;
-        NSString* sql = [self wordsQueryStringWithLimit: [limit unsignedIntegerValue]];
+        NSString* sql = [self wordsQueryStringWithLimit: [limit integerValue]];
         Assert([self.wordDB createQuery: sql error: &error]);
         AssertNil(error);
     }
     
     // Check if error thrown for wrong limit values
     [self expectError: CBLErrorDomain code: CBLErrorInvalidQuery in: ^BOOL(NSError** err) {
-        NSString* sql = [self wordsQueryStringWithLimit: [@10001 unsignedIntegerValue]];
+        NSString* sql = [self wordsQueryStringWithLimit: 10001];
         return [self.wordDB createQuery: sql error: err] != nil;
     }];
 }

--- a/Objective-C/Tests/VectorSearchTest.m
+++ b/Objective-C/Tests/VectorSearchTest.m
@@ -1178,7 +1178,7 @@
     [self createWordsIndexWithConfig: config];
     
     // Check valid query with 1 and 10000 set limit
-    for (NSNumber* limit in @[@1, @10000]) {
+    for (NSNumber* limit in @[@-1, @0, @1, @10000]) {
         NSError* error;
         NSString* sql = [self wordsQueryStringWithLimit: [limit unsignedIntegerValue]];
         Assert([self.wordDB createQuery: sql error: &error]);
@@ -1186,12 +1186,10 @@
     }
     
     // Check if error thrown for wrong limit values
-    for (NSNumber* limit in @[@-1, @0, @10001]) {
-        [self expectError: CBLErrorDomain code: CBLErrorInvalidQuery in: ^BOOL(NSError** err) {
-            NSString* sql = [self wordsQueryStringWithLimit: [limit unsignedIntegerValue]];
-            return [self.wordDB createQuery: sql error: err] != nil;
-        }];
-    }
+    [self expectError: CBLErrorDomain code: CBLErrorInvalidQuery in: ^BOOL(NSError** err) {
+        NSString* sql = [self wordsQueryStringWithLimit: [@10001 unsignedIntegerValue]];
+        return [self.wordDB createQuery: sql error: err] != nil;
+    }];
 }
 
 /**

--- a/Swift/IndexConfiguration.swift
+++ b/Swift/IndexConfiguration.swift
@@ -2,7 +2,7 @@
 //  IndexConfiguration.swift
 //  CouchbaseLite
 //
-//  Copyright (c) 2021 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2025 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -28,6 +28,10 @@ public struct FullTextIndexConfiguration: IndexConfiguration, IndexConfigConvert
     /// Gets the expressions to use to create the index.
     public let expressions: [String]
     
+    /// A predicate expression defining conditions for indexing documents.
+    /// Only documents satisfying the predicate are included, enabling partial indexes.
+    public let `where`: String?
+    
     /// Set the true value to ignore accents/diacritical marks.
     /// The default value is ``FullTextIndexConfiguration.defaultIgnoreAccents``.
     public let ignoreAccents: Bool
@@ -36,19 +40,25 @@ public struct FullTextIndexConfiguration: IndexConfiguration, IndexConfigConvert
     /// Setting the language code affects how word breaks and word stems are parsed.
     /// Without setting the value, the current locale's language will be used. Setting
     /// a nil or "" value to disable the language features.
-    public var language: String?
+    public let language: String?
     
-    /// Constructor for creating a full-text index by using an array of N1QL expression strings
-    public init(_ expressions: [String], ignoreAccents: Bool? = FullTextIndexConfiguration.defaultIgnoreAccents, language: String? = nil) {
+    /// Initializes a full-text index using an array of N1QL expression strings, with an optional where clause for partial indexing.
+    ///  - Parameter expressions The array of expression strings.
+    ///  - Parameter ignoreAccents Optional to ignore accents/diacritical marks.
+    ///  - Parameter language Optional language code which is an ISO-639 language such as "en", "fr", etc.
+    ///  - Parameter where Optional where clause for partial indexing.
+    ///  - Returns The value index configuration object.
+    public init(_ expressions: [String], where: String? = nil, ignoreAccents: Bool? = FullTextIndexConfiguration.defaultIgnoreAccents, language: String? = nil) {
         self.expressions = expressions
         self.ignoreAccents = ignoreAccents ?? FullTextIndexConfiguration.defaultIgnoreAccents
         self.language = language
+        self.where = `where`
     }
     
     // MARK: Internal
     
     func toImpl() -> CBLIndexConfiguration {
-        return CBLFullTextIndexConfiguration(expression: expressions, ignoreAccents: ignoreAccents, language: language)
+        return CBLFullTextIndexConfiguration(expression: expressions, where: `where`, ignoreAccents: ignoreAccents, language: language)
     }
 }
 
@@ -57,15 +67,24 @@ public struct ValueIndexConfiguration: IndexConfiguration, IndexConfigConvertabl
     /// Gets the expressions to use to create the index.
     public let expressions: [String]
     
-    /// Constructor for creating a value index by using an array of N1QL expression strings.
-    public init(_ expressions: [String]) {
+    
+    /// A predicate expression defining conditions for indexing documents.
+    /// Only documents satisfying the predicate are included, enabling partial indexes.
+    public let `where`: String?
+    
+    /// Initializes a value index using an array of N1QL expression strings, with an optional where clause for partial indexing.
+    ///  - Parameter expressions The array of expression strings.
+    ///  - Parameter where Optional where clause for partial indexing.
+    ///  - Returns The value index configuration object.
+    public init(_ expressions: [String], where: String? = nil) {
         self.expressions = expressions
+        self.where = `where`
     }
     
     // MARK: Internal
     
     func toImpl() -> CBLIndexConfiguration {
-        return CBLValueIndexConfiguration(expression: expressions)
+        return CBLValueIndexConfiguration(expression: expressions, where: `where`)
     }
 }
 

--- a/Swift/Tests/PartialIndexTest.swift
+++ b/Swift/Tests/PartialIndexTest.swift
@@ -1,0 +1,99 @@
+//
+//  PartialIndexTest.swift
+//  CouchbaseLite
+//
+//  Copyright (c) 2025 Couchbase, Inc. All rights reserved.
+//
+//  Licensed under the Couchbase License Agreement (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  https://info.couchbase.com/rs/302-GJY-034/images/2017-10-30_License_Agreement.pdf
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import CouchbaseLiteSwift
+
+/// Test Spec v1.0.3:
+/// https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0007-Partial-Index.md
+
+class PartialIndexTest: CBLTestCase {
+    
+    /// 1. TestCreatePartialValueIndex
+    /// Description
+    ///     Test that a partial value index is successfully created.
+    /// Steps
+    ///     1. Create a partial value index named "numIndex" in the default collection.
+    ///         - expression: "num"
+    ///         - where: "type = 'number'"
+    ///     2. Check that the index is successfully created.
+    ///     3. Create a query object with an SQL++ string:
+    ///         - SELECT *
+    ///           FROM _
+    ///           WHERE type = 'number' AND num > 1000
+    ///     4. Get the query plan from the query object and check that the plan contains "USING INDEX numIndex" string.
+    ///     5. Create a query object with an SQL++ string:
+    ///         - SELECT *
+    ///           FROM _
+    ///           WHERE type = 'foo' AND num > 1000
+    ///     6. Get the query plan from the query object and check that the plan doesn't contain "USING INDEX numIndex" string.
+    func testCreatePartialValueIndex() throws {
+        let collection = try db.defaultCollection()
+        
+        let config = ValueIndexConfiguration(["num"], where: "type='number'")
+        try collection.createIndex(withName: "numIndex", config: config)
+
+        var sql = "SELECT * FROM _ WHERE type = 'number' AND num > 1000"
+        var q = try db.createQuery(sql)
+        var explain = try q.explain()
+        XCTAssert(explain.contains("USING INDEX numIndex"))
+        
+        sql = "SELECT * FROM _ WHERE type = 'foo' AND num > 1000"
+        q = try db.createQuery(sql)
+        explain = try q.explain()
+        XCTAssertFalse(explain.contains("USING INDEX numIndex"))
+    }
+    
+    /// 2. TestCreatePartialFullTextIndex
+    /// Description
+    ///     Test that a partial full text index is successfully created.
+    /// Steps
+    ///     1. Create following two documents with the following bodies in the default collection.
+    ///         - { "content" : "Couchbase Lite is a database." }
+    ///         - { "content" : "Couchbase Lite is a NoSQL syncable database." }
+    ///     2. Create a partial value index named "numIndex" in the default collection.
+    ///         - expression: "content"
+    ///         - where: "length(content) > 30"
+    ///     3. Check that the index is successfully created.
+    ///     4. Create a query object with an SQL++ string:
+    ///         - SELECT content
+    ///           FROM _
+    ///           WHERE match(contentIndex, "database")
+    ///     4.  Execute the query and check that:
+    ///         - The query returns the second docume
+    ///     5. Create a query object with an SQL++ string:
+    ///         - There is one result returned
+    ///         - The returned content is "Couchbase Lite is a NoSQL syncable database."
+    func testCreatePartialFullTextIndex() throws {
+        let collection = try db.defaultCollection()
+        let json1 = "{\"content\":\"Couchbase Lite is a database.\"}"
+        let json2 = "{\"content\":\"Couchbase Lite is a NoSQL syncable database.\"}"
+        
+        try collection.save(document: MutableDocument(json: json1))
+        try collection.save(document: MutableDocument(json: json2))
+        
+        let config = FullTextIndexConfiguration(["content"], where: "length(content)>30")
+        try collection.createIndex(withName: "contentIndex", config: config)
+
+        let sql = "SELECT content FROM _ WHERE match(contentIndex, 'database')"
+        let q = try db.createQuery(sql)
+        let result = try q.execute().allResults()
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].toJSON(), json2)
+    }
+}

--- a/Swift/Tests/VectorSearchTest.swift
+++ b/Swift/Tests/VectorSearchTest.swift
@@ -1064,15 +1064,13 @@ class VectorSearchTest_Main: VectorSearchTest {
         try createWordsIndex(config: config)
         
         // Check valid query with 1 and 10000 set limit
-        for limit in [1, 10000] {
+        for limit in [-1, 0, 1, 10000] {
             _ = try executeWordsQuery(limit: limit)
         }
         
         // Check if error thrown for wrong limit values
-        for limit in [-1, 0, 10001] {
-            self.expectError(domain: CBLError.domain, code: CBLError.invalidQuery) {
-                _ = try self.executeWordsQuery(limit: limit)
-            }
+        self.expectError(domain: CBLError.domain, code: CBLError.invalidQuery) {
+            _ = try self.executeWordsQuery(limit: 10001)
         }
     }
     

--- a/Swift/Tests/VectorSearchTest.swift
+++ b/Swift/Tests/VectorSearchTest.swift
@@ -1063,7 +1063,7 @@ class VectorSearchTest_Main: VectorSearchTest {
         let config = VectorIndexConfiguration(expression: "vector", dimensions: 300, centroids: 8)
         try createWordsIndex(config: config)
         
-        // Check valid query with 1 and 10000 set limit
+        // Check valid query with -1, 0, 1 and 10000 set limit
         for limit in [-1, 0, 1, 10000] {
             _ = try executeWordsQuery(limit: limit)
         }


### PR DESCRIPTION
- CBL-5193
- CBL-5194

For Swift, `where` is a reserved keyword. So I had to escape it via backticks. There is no impact for the user.

- LiteCore 3.2.2-8
- update testVectorMatchLimitBoundary to expect exception only on more than 10k

