### PR TITLE
Fix LogSinks using wrong class initialize method

### DIFF
--- a/Objective-C/CBLLog.mm
+++ b/Objective-C/CBLLog.mm
@@ -51,7 +51,7 @@
     self = [super init];
     if (self) {
         // Initialize new logging system
-        [CBLLogSinks init];
+        CBLAssertNotNil(CBLLogSinks.self);
         
         // Create console logger:
         _console = [[CBLConsoleLogger alloc] initWithDefault];

--- a/Objective-C/Internal/CBLLogSinks+Internal.h
+++ b/Objective-C/Internal/CBLLogSinks+Internal.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSUInteger, CBLLogAPI) {
 
 + (void) writeCBLLog: (C4LogDomain)domain level: (C4LogLevel)level message: (NSString*)message;
 
-+ (void) checkLogApiVersion: (id<CBLLogApiSource>) source;
++ (void) checkLogApiVersion: (nullable id<CBLLogApiSource>) source;
 
 @end
 

--- a/Objective-C/LogSink/CBLLogSinks.mm
+++ b/Objective-C/LogSink/CBLLogSinks.mm
@@ -50,7 +50,7 @@ static CBLFileLogSink* _file = nil;
 static CBLLogAPI _vAPI;
 NSDictionary* domainDictionary = nil;
 
-+ (void) init {
++ (void) initialize {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         // Cache log domain for logging from the platforms:


### PR DESCRIPTION
The class initialize method is + initialize instead of + init.