### PR TITLE
CBL-6813: Deprecate removeChangeListenerWithToken for Replicator and Query

### DIFF
--- a/Objective-C/CBLQuery.h
+++ b/Objective-C/CBLQuery.h
@@ -99,6 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param token The listener token.
  */
 - (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token;
+__deprecated_msg("Use [ListenerToken remove] instead.");
 
 
 /** Not available */

--- a/Objective-C/CBLQuery.h
+++ b/Objective-C/CBLQuery.h
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param token The listener token.
  */
-- (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token;
+- (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token
 __deprecated_msg("Use [ListenerToken remove] instead.");
 
 

--- a/Objective-C/CBLQuery.mm
+++ b/Objective-C/CBLQuery.mm
@@ -307,10 +307,12 @@ using namespace fleece;
 }
 
 #pragma mark delegate(CBLRemovableListenerToken)
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void) removeToken: (id)token {
     [self removeChangeListenerWithToken: token];
 }
+#pragma clang diagnostic pop
 
 #pragma mark - Internal
 

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -136,6 +136,7 @@ the replicator change notification.
  @param token The listener token;
  */
 - (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token;
+__deprecated_msg("Use [ListenerToken remove] instead.");
 
 /**
  Get pending document ids for default collection. If the default collection is not part of the

--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -135,7 +135,7 @@ the replicator change notification.
  
  @param token The listener token;
  */
-- (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token;
+- (void) removeChangeListenerWithToken: (id<CBLListenerToken>)token
 __deprecated_msg("Use [ListenerToken remove] instead.");
 
 /**

--- a/Objective-C/Tests/DocumentExpirationTest.m
+++ b/Objective-C/Tests/DocumentExpirationTest.m
@@ -126,7 +126,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: nil];
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testDocumentNotShowUpInQueryAfterExpiration {
@@ -159,7 +159,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: nil];
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) verifyQueryResultCount: (NSUInteger)count deletedCount: (NSUInteger)deletedCount {
@@ -207,7 +207,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: nil];
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testSetExpirationAndThenCloseDatabase {
@@ -269,7 +269,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: nil];
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testExpiredDocumentPurgedOnDifferentDBInstance {
@@ -309,7 +309,7 @@
     AssertNil([otherDB documentWithID: doc.id]);
     
     // Remove listener
-    [otherDB removeChangeListenerWithToken: token];
+    [token remove];
     
     // Close otherDB
     Assert([otherDB close: nil]);
@@ -353,7 +353,7 @@
     Assert(purgeTime - begin >= 2.0);
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testOverrideExpirationWithCloserDate {
@@ -392,7 +392,7 @@
     Assert(purgeTime - begin < 3.0);
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testRemoveExpirationDate {
@@ -471,7 +471,7 @@
     AssertEqual(count, 2);
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testSetExpirationOnDeletedDocument {
@@ -513,7 +513,7 @@
     AssertEqual(count, 2);
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testPurgeImmediately {
@@ -553,7 +553,7 @@
     Assert(delta < 2);
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testWhetherDatabaseEventTrigged {
@@ -580,7 +580,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: nil];
     
     // Remove listener
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 #pragma clang diagnostic pop

--- a/Objective-C/Tests/NotificationTest.m
+++ b/Objective-C/Tests/NotificationTest.m
@@ -51,7 +51,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: NULL];
     
     // Remove listener:
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testDocumentChange {
@@ -95,9 +95,9 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: NULL];
     
     // Remove listeners:
-    [_db removeChangeListenerWithToken:listener1];
-    [_db removeChangeListenerWithToken:listener2];
-    [_db removeChangeListenerWithToken:listener3];
+    [listener1 remove];
+    [listener2 remove];
+    [listener3 remove];
 }
 
 - (void) testAddSameChangeListeners {
@@ -130,9 +130,9 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: NULL];
     
     // Remove listeners:
-    [_db removeChangeListenerWithToken:listener1];
-    [_db removeChangeListenerWithToken:listener2];
-    [_db removeChangeListenerWithToken:listener3];
+    [listener1 remove];
+    [listener2 remove];
+    [listener3 remove];
 }
 
 - (void) testRemoveDocumentChangeListener {
@@ -156,7 +156,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: NULL];
     
     // Remove change listener:
-    [_db removeChangeListenerWithToken:listener1];
+    [listener1 remove];
     
     // Update doc1 again:
     [doc1 setValue: @"Scott Tiger" forKey: @"name"];
@@ -171,7 +171,7 @@
     [self waitForExpectationsWithTimeout: kExpTimeout handler: NULL];
     
     // Remove again:
-    [_db removeChangeListenerWithToken:listener1];
+    [listener1 remove];
 }
 
 #pragma clang diagnostic pop

--- a/Objective-C/Tests/QueryTest+Main.m
+++ b/Objective-C/Tests/QueryTest+Main.m
@@ -1842,7 +1842,7 @@
     [self createDocNumbered: -1 of: 100];
     
     [self waitForExpectations: @[second] timeout: kExpTimeout];
-    [q removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testLiveQueryNoUpdate {
@@ -1886,7 +1886,7 @@
     NSLog(@"Done!");
     
     AssertEqual(count, 1);
-    [q removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 // CBSE-15957: Crash when creating multiple live queries concurrently
@@ -1953,8 +1953,8 @@
     [self waitForExpectations: @[firstA] timeout: kExpTimeout];
     AssertEqual(count2, 1);
     AssertEqual(count, 1);
-    [q removeChangeListenerWithToken: token1];
-    [q removeChangeListenerWithToken: token2];
+    [token1 remove];
+    [token2 remove];
 }
 
 - (void) testLiveQueryReturnsEmptyResultSet {
@@ -1966,8 +1966,9 @@
         AssertEqual(rows.count, 0);
         [first fulfill];
     }];
+
     [self waitForExpectations: @[first] timeout: kExpTimeout];
-    [q removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 /**
@@ -2033,8 +2034,8 @@
     [self createDocNumbered: -1 of: 100];
     
     [self waitForExpectations: @[second1, second2] timeout: kExpTimeout];
-    [q removeChangeListenerWithToken: token1];
-    [q removeChangeListenerWithToken: token2];
+    [token1 remove];
+    [token2 remove];
 }
 
 - (void) testLiveQueryUpdateQueryParam {
@@ -2069,7 +2070,7 @@
     
     [self waitForExpectations: @[second] timeout: 10.0];
     AssertEqual(count, 2);
-    [q removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 // CBSE-16662, CBL-5631: thread_mutex crash issue

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -392,7 +392,7 @@
     // make sure only single listener event is fired when conflict occured.
     AssertEqual(docIds.count, 1u);
     AssertEqualObjects(docIds.firstObject, docId);
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     
     // resolve any un-resolved conflict through pull replication.
     [self run: [self config: kCBLReplicatorTypePull] errorCode: 0 errorDomain: nil];
@@ -488,8 +488,9 @@
     NSString* warning = [NSString stringWithFormat: @"The document ID of the resolved document '%@'"
                          " is not matching with the document ID of the conflicting document '%@'.",
                          wrongDocID, docId];
+
     Assert([logSink.lines containsObject: warning]);
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     CBLLogSinks.custom = nil;
 }
 
@@ -526,7 +527,7 @@
     AssertEqual(errors.lastObject.code, CBLErrorConflict);
     AssertEqualObjects(errors.lastObject.domain, CBLErrorDomain);
     AssertEqualObjects([self.db documentWithID: docId].toDictionary, localData);
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     
     // should be solved when the replicator runs next time!!
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
@@ -569,7 +570,7 @@
     AssertEqual(errors.lastObject.code, CBLErrorConflict);
     AssertEqualObjects(errors.lastObject.domain, CBLErrorDomain);
     AssertEqualObjects([self.db documentWithID: docId].toDictionary, localData);
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     
     // should be solved when the replicator runs next time!!
     resolver = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* con) {
@@ -883,8 +884,8 @@
     Assert([logSink.lines containsObject: @"Unable to select conflicting revision for doc1, "
             "the conflict may have been resolved..."]);
     
-    [replicator removeChangeListenerWithToken: changeToken];
-    [replicator removeChangeListenerWithToken: docReplToken];
+    [changeToken remove];
+    [docReplToken remove];
     
     CBLLogSinks.custom = nil;
 }
@@ -915,7 +916,7 @@
             AssertNil(docRepl.documents.firstObject.error);
         }];
     }];
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     
     // using blob from remote document of user's- which is a different database
     CBLDocument* otherDBDoc = [self.otherDB documentWithID: docID];
@@ -941,7 +942,7 @@
     AssertNotNil(error);
     AssertEqual(error.code, CBLErrorUnexpectedError);
     AssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey], kCBLErrorMessageBlobDifferentDatabase);
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testConflictResolverWhenDocumentIsPurged {
@@ -976,7 +977,7 @@
     
     AssertEqual(errors.count, 1u);
     AssertEqual(errors.firstObject.code, CBLErrorNotFound);
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testConflictResolverPreservesFlags {

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -273,8 +273,9 @@
         
         NSLog(@"****** Start Replicator ******");
         [r start];
+
         [self waitForExpectations: @[x] timeout: kExpTimeout];
-        [r removeChangeListenerWithToken: token];
+        [token remove];
     }
     r = nil;
 }
@@ -389,7 +390,7 @@
     AssertEqual(foregroundCount, numRounds + 1);
     AssertEqual(backgroundCount, numRounds);
     
-    [r removeChangeListenerWithToken: token];
+    [token remove];
     r = nil;
 }
 
@@ -427,7 +428,7 @@
     [r stop];
     [self waitForExpectations: @[stopped] timeout: kExpTimeout];
 
-    [r removeChangeListenerWithToken: token];
+    [token remove];
     r = nil;
 }
 
@@ -474,7 +475,7 @@
                                    selector: @selector(main) userInfo: nil repeats: NO];
     [self waitForExpectations: @[done] timeout: kExpTimeout];
     
-    [r removeChangeListenerWithToken: token];
+    [token remove];
     r = nil;
 }
 
@@ -530,7 +531,7 @@
     [replicator setSuspended: NO];
     
     [self waitForExpectations: @[stop] timeout: kExpTimeout];
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     
     // make sure the doc with blob transferred successfully!
     AssertEqual(self.otherDB.count, 1);
@@ -613,7 +614,7 @@
     // Wait until the replicator is stopped:
     [self waitForExpectations: @[stopped] timeout: kExpTimeout];
     
-    [r removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 #endif // TARGET_OS_IPHONE
@@ -857,7 +858,7 @@
     Assert([self.db saveDocument: doc4 error: &error]);
     
     // Remove document replication listener:
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     
     // Run the replicator again:
     [self runWithReplicator: replicator errorCode: 0 errorDomain: 0];
@@ -883,8 +884,9 @@
     
     // --- 2. Start then stop after IDLE
     [r start];
+
     [self waitForExpectations: @[xc1] timeout: kExpTimeout];
-    [r removeChangeListenerWithToken: token1];
+    [token1 remove];
     
     // --- 3. Add some documents to the database
     NSError* error;
@@ -917,8 +919,9 @@
         }
     }];
     [r start];
+
     [self waitForExpectations: @[xc2] timeout: kExpTimeout];
-    [r removeChangeListenerWithToken: token2];
+    [token2 remove];
     
     // --- 6. There should be some document replication events notified
     AssertEqual(array.count, 2u);
@@ -967,7 +970,7 @@
     Assert((docs[0].flags & kCBLDocumentFlagsAccessRemoved) != kCBLDocumentFlagsAccessRemoved);
     
     // Remove document replication listener:
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testDocumentReplicationEventWithPullConflict {
@@ -1007,7 +1010,7 @@
     Assert((docs[0].flags & kCBLDocumentFlagsAccessRemoved) != kCBLDocumentFlagsAccessRemoved);
     
     // Remove document replication listener:
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testDocumentReplicationEventWithDeletion {
@@ -1048,7 +1051,7 @@
     Assert((docs[0].flags & kCBLDocumentFlagsAccessRemoved) != kCBLDocumentFlagsAccessRemoved);
     
     // Remove document replication listener:
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
 }
 
 - (void) testRemoveDocumentReplicationListener {
@@ -1273,8 +1276,8 @@
     
     AssertEqual(self.db.count, 0u);
     AssertEqual(self.otherDB.count, 1u);
-    [self.db removeChangeListenerWithToken: docChangeToken];
-    [replicator removeChangeListenerWithToken: docReplToken];
+    [docChangeToken remove];
+    [docReplToken remove];
 }
 
 #pragma mark Removed Doc with Filter

--- a/Objective-C/Tests/ReplicatorTest+MessageEndPoint.m
+++ b/Objective-C/Tests/ReplicatorTest+MessageEndPoint.m
@@ -42,7 +42,7 @@
     token = [listener addChangeListener:^(CBLMessageEndpointListenerChange* change) {
         if(change.status.activity == kCBLReplicatorIdle) {
             [x fulfill];
-            [wListener removeChangeListenerWithToken:token];
+            [token remove];
         }
     }];
     
@@ -56,7 +56,7 @@
     token = [listener addChangeListener: ^(CBLMessageEndpointListenerChange * change) {
         if(change.status.activity == kCBLReplicatorStopped) {
             [x fulfill];
-            [wListener removeChangeListenerWithToken:token];
+            [token remove];
         }
     }];
     return x;
@@ -327,7 +327,7 @@
     
     [listener closeAll];
     [self waitForExpectations: @[listenerStop1, listenerStop2] timeout: kExpTimeout];
-    [listener removeChangeListenerWithToken: listenerToken];
+    [listenerToken remove];
     [self waitForExpectations: @[stop1, stop2] timeout: kExpTimeout];
     AssertNotNil(replicator.status.error);
     AssertNotNil(replicator2.status.error);

--- a/Objective-C/Tests/ReplicatorTest+SG.m
+++ b/Objective-C/Tests/ReplicatorTest+SG.m
@@ -144,8 +144,9 @@
     }];
     
     [r start];
+
     [self waitForExpectations: @[x1, x2] timeout: kExpTimeout];
-    [repl removeChangeListenerWithToken: token];
+    [token remove];
     r = nil;
 }
 
@@ -254,8 +255,9 @@
     AssertNil(err);
     
     // Wait for the document get expired.
+
     [self waitForExpectations: @[expectation] timeout: kExpTimeout];
-    [self.db removeChangeListenerWithToken: token];
+    [token remove];
     
     // Erase remote data:
     [self eraseRemoteEndpoint: target];

--- a/Objective-C/Tests/ReplicatorTest.m
+++ b/Objective-C/Tests/ReplicatorTest.m
@@ -435,7 +435,7 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady {
     @finally {
         if (replicator.status.activity != kCBLReplicatorStopped)
             [replicator stop];
-        [replicator removeChangeListenerWithToken: token];
+        [token remove];
     }
     
     // Workaround:
@@ -476,7 +476,7 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady {
     token = [replicator addChangeListener:^(CBLReplicatorChange * _Nonnull change) {
         if(change.status.progress.completed >= progress && change.status.activity == kCBLReplicatorIdle) {
             [x fulfill];
-            [wReplicator removeChangeListenerWithToken:token];
+            [token remove];
         }
     }];
     
@@ -490,7 +490,7 @@ onReplicatorReady: (nullable void (^)(CBLReplicator*))onReplicatorReady {
     token = [replicator addChangeListener:^(CBLReplicatorChange * _Nonnull change) {
         if(change.status.activity == kCBLReplicatorStopped) {
             [x fulfill];
-            [wReplicator removeChangeListenerWithToken:token];
+            [token remove];
         }
     }];
     

--- a/Objective-C/Tests/URLEndpointListenerTest+Main.m
+++ b/Objective-C/Tests/URLEndpointListenerTest+Main.m
@@ -109,8 +109,8 @@
     }
     
     // cleanup
-    [repl1 removeChangeListenerWithToken: token1];
-    [repl2 removeChangeListenerWithToken: token2];
+    [token1 remove];
+    [token2 remove];
     repl1 = nil;
     repl2 = nil;
     Assert([db1 close: &err], @"Failed to close db1 %@", err);
@@ -188,8 +188,8 @@
     }
     
     [self waitForExpectations: @[stopExp1, stopExp2] timeout: kExpTimeout];
-    [repl1 removeChangeListenerWithToken: token1];
-    [repl2 removeChangeListenerWithToken: token2];
+    [token1 remove];
+    [token2 remove];
     [self stopListen];
 }
 
@@ -240,7 +240,7 @@
     [self waitForExpectations: @[stopExp] timeout: kExpTimeout];
     
     // cleanup
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     [self stopListener: listener1];
     [self stopListener: listener2];
 }
@@ -389,7 +389,7 @@
     
     [replicator start];
     [self waitForExpectations: @[pullFilterBusy, replicatorStop] timeout: kExpTimeout];
-    [replicator removeChangeListenerWithToken: token];
+    [token remove];
     
     AssertEqual(maxActiveCount, 1);
     AssertEqual(maxConnectionCount, 1);

--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -150,6 +150,7 @@ public class Query {
     /// Removes a change listener wih the given listener token.
     ///
     /// - Parameter token: The listener token.
+    @available(*, deprecated, message: "Use token.remove() instead.")
     public func removeChangeListener(withToken token: ListenerToken) {
         token.remove()
     }

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -193,6 +193,7 @@ public final class Replicator {
     /// Removes a change listener with the given listener token.
     ///
     /// - Parameter token: The listener token.
+    @available(*, deprecated, message: "Use token.remove() instead.")
     public func removeChangeListener(withToken token: ListenerToken) {
         impl.removeChangeListener(with: token.impl)
     }

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1887,7 +1887,7 @@ class QueryTest: CBLTestCase {
         try! self.createDoc(numbered: -1, of: 100)
         
         wait(for: [x2], timeout: expTimeout)
-        query.removeChangeListener(withToken: token)
+        token.remove()
     }
     
     func testLiveQueryNoUpdate() throws {
@@ -1907,7 +1907,7 @@ class QueryTest: CBLTestCase {
         
         wait(for: [x1], timeout: expTimeout)
         XCTAssertEqual(count, 1)
-        q.removeChangeListener(withToken: token)
+        token.remove()
     }
     
     // When adding a second listener after the first listener is notified, the second listener
@@ -1949,8 +1949,8 @@ class QueryTest: CBLTestCase {
         }        
         
         wait(for: [x2], timeout: expTimeout)
-        query.removeChangeListener(withToken: token)
-        query.removeChangeListener(withToken: token2)
+        token.remove()
+        token2.remove()
         XCTAssertEqual(count, 1)
         XCTAssertEqual(count2, 1)
     }
@@ -1981,8 +1981,9 @@ class QueryTest: CBLTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             try! self.defaultCollection!.purge(id: "doc1")
         }
+
         wait(for: [x1], timeout: expTimeout)
-        query.removeChangeListener(withToken: token)
+        token.remove()
         XCTAssertEqual(count, 2)
     }
     
@@ -2000,7 +2001,7 @@ class QueryTest: CBLTestCase {
         let x1 = expectation(description: "1st change")
         let x2 = expectation(description: "2nd change")
         var count1 = 0;
-        let token1 = query.addChangeListener { (change) in
+        let token = query.addChangeListener { (change) in
             count1 = count1 + 1
             guard let results = change.results else {
                 XCTFail("Results are empty")
@@ -2058,8 +2059,8 @@ class QueryTest: CBLTestCase {
         
         wait(for: [x2, y2], timeout: expTimeout)
         
-        query.removeChangeListener(withToken: token1)
-        query.removeChangeListener(withToken: token2)
+        token.remove()
+        token2.remove()
         XCTAssertEqual(count1, 2)
         XCTAssertEqual(count2, 2)
     }

--- a/Swift/Tests/ReplicatorTest+CustomConflict.swift
+++ b/Swift/Tests/ReplicatorTest+CustomConflict.swift
@@ -332,7 +332,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         // make sure only single listener event is fired when conflict occured.
         XCTAssertEqual(docIds.count, 1)
         XCTAssertEqual(docIds.first!, docID)
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
         
         // resolve any un-resolved conflict through pull replication.
         run(config: getConfig(.pull), expectedError: nil)
@@ -378,7 +378,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
                 XCTAssertNil(docRepl.documents.first?.error)
             }
         })
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
         
         // validate wrong doc-id is resolved successfully
         XCTAssertEqual(defaultCollection!.count, 1)
@@ -427,7 +427,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         XCTAssertEqual(error.code, CBLError.conflict)
         XCTAssertEqual(error.domain, CBLError.domain)
         
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
         resolver = TestConflictResolver() { (conflict) -> Document? in
             return conflict.remoteDocument
         }
@@ -474,7 +474,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         }
         
         XCTAssertNotNil(error)
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
         resolver = TestConflictResolver() { (conflict) -> Document? in
             return conflict.remoteDocument
         }
@@ -636,7 +636,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
                 XCTAssertNil(docRepl.documents.first?.error)
             })
         })
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
         
         // using blob from remote document of user's- which is a different database
         let oDBDoc = try otherDB_defaultCollection!.document(id: docID)!
@@ -665,7 +665,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         XCTAssert((error?.userInfo[NSLocalizedDescriptionKey] as! String) ==
             "A document contains a blob that was saved to a different " +
             "database. The save operation cannot complete.")
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
     }
     
     func testNonBlockingDatabaseOperationConflictResolver() throws {
@@ -770,7 +770,7 @@ class ReplicatorTest_CustomConflict: ReplicatorTest {
         })
         XCTAssertNotNil(error)
         XCTAssertEqual(error?.code, CBLError.notFound)
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
     }
     
     #endif

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -142,7 +142,7 @@ class ReplicatorTest: CBLTestCase {
         if replicator.status.activity != .stopped {
             replicator.stop()
         }
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
     }
 }
 
@@ -307,7 +307,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         try defaultCollection!.save(document: doc4)
         
         // Remove document replication listener:
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
         
         // Run the replicator again:
         self.run(replicator: replicator, expectedError: nil)
@@ -379,7 +379,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertFalse(docs[0].flags.contains(.accessRemoved))
         
         // Remove document replication listener:
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
     }
     
     func testDocumentReplicationEventWithPullConflict() throws {
@@ -419,7 +419,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertFalse(docs[0].flags.contains(.accessRemoved))
         
         // Remove document replication listener:
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
     }
     
     func testDocumentReplicationEventWithDeletion() throws {
@@ -436,11 +436,9 @@ class ReplicatorTest_Main: ReplicatorTest {
         var config = self.config(target: target, type: .push, continuous: false)
         config.addCollection(defaultCollection!)
         
-        var replicator: Replicator!
         var token: ListenerToken!
         var docs: [ReplicatedDocument] = []
         self.run(config: config, reset: false, expectedError: nil) { (r) in
-            replicator = r
             token = r.addDocumentReplicationListener({ (replication) in
                 XCTAssert(replication.isPush)
                 for doc in replication.documents {
@@ -457,7 +455,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertFalse(docs[0].flags.contains(.accessRemoved))
         
         // Remove document replication listener:
-        replicator.removeChangeListener(withToken: token)
+        token.remove()
     }
     
     func testSingleShotPushFilter() throws {
@@ -649,7 +647,7 @@ class ReplicatorTest_Main: ReplicatorTest {
         
         waitForExpectations(timeout: 5.0)
         
-        replicator.removeChangeListener(withToken: docReplicationToken)
+        docReplicationToken.remove()
         docChangeToken.remove()
         
         XCTAssertEqual(self.defaultCollection!.count, 0)

--- a/Swift/Tests/URLEndpointListenerTest.swift
+++ b/Swift/Tests/URLEndpointListenerTest.swift
@@ -189,7 +189,7 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
             }
             
         }
-        let token1 = repl1.addChangeListener(changeListener)
+        let token = repl1.addChangeListener(changeListener)
         let token2 = repl2.addChangeListener(changeListener)
         
         repl1.start()
@@ -207,8 +207,8 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
             XCTAssertEqual(db2.count, count + 1); // existing docs + pulls one doc from db#1
         }
         
-        repl1.removeChangeListener(withToken: token1)
-        repl2.removeChangeListener(withToken: token2)
+        token.remove()
+        token2.remove()
         
         try db1.close()
         try db2.close()
@@ -255,7 +255,7 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
                 }
             }
         }
-        let token1 = repl1.addChangeListener(changeListener)
+        let token = repl1.addChangeListener(changeListener)
         let token2 = repl2.addChangeListener(changeListener)
         repl1.start()
         repl2.start()
@@ -269,9 +269,9 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
             try self.otherDB!.close()
         }
         
-        wait(for: [stopExp1, stopExp2], timeout: expTimeout)
-        repl1.removeChangeListener(withToken: token1)
-        repl2.removeChangeListener(withToken: token2)
+
+        token.remove()
+        token2.remove()
         try stopListener()
     }
     
@@ -298,7 +298,7 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
         let repl1 = createReplicator(db: self.otherDB!,
                                      target: listener1.localURLEndpoint,
                                      serverCert: listener1.tlsIdentity!.certs[0])
-        let token1 = repl1.addChangeListener({ (change: ReplicatorChange) in
+        let token = repl1.addChangeListener({ (change: ReplicatorChange) in
             if change.status.activity == .idle && change.status.progress.completed == change.status.progress.total {
                 idleExp.fulfill()
                 
@@ -318,7 +318,7 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
         wait(for: [stopExp], timeout: expTimeout)
         
         // cleanup
-        repl1.removeChangeListener(withToken: token1)
+        token.remove()
         try stopListener(listener: listener1)
         try stopListener(listener: listener2)
     }
@@ -690,8 +690,9 @@ class URLEndpointListenerTest_Main: URLEndpointListenerTest {
         }
         
         repl.start()
+
         wait(for: [pullFilterBusy, replicatorStop], timeout: expTimeout)
-        repl.removeChangeListener(withToken: token)
+        token.remove()
         
         XCTAssertEqual(maxConnectionCount, 1)
         XCTAssertEqual(maxActiveCount, 1)


### PR DESCRIPTION
I've also update tests.