### PR TITLE
Project.config version bump 3.2.3

### DIFF
--- a/xcconfigs/Project.xcconfig
+++ b/xcconfigs/Project.xcconfig
@@ -17,7 +17,7 @@
 //  limitations under the License.
 //
 
-CBL_VERSION_STRING                 = 3.2.2
+CBL_VERSION_STRING                 = 3.2.3
 CBL_BUILD_NUMBER                   = 0
 CBL_COPYRIGHT_YEAR                 = 2024
 


### PR DESCRIPTION
Need new LiteCore to pass the test.

`error: -[MiscTest testCBLVersionAndLiteCoreVersion] : ((cblVersion) equal to (liteVersion)) failed: ("3.2.3") is not equal to ("3.2.2")`