### PR TITLE
Fix build error as fleece/PlatformCompat.hh not found

### DIFF
--- a/xcconfigs/CBL_ObjC_Tests_iOS_App.xcconfig
+++ b/xcconfigs/CBL_ObjC_Tests_iOS_App.xcconfig
@@ -19,7 +19,7 @@
 
 #include "CBL_OS_Target_Versions.xcconfig"
 
-HEADER_SEARCH_PATHS                        = $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece/Support
+HEADER_SEARCH_PATHS                        = $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/API   $(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/Fleece/Support
 ASSETCATALOG_COMPILER_APPICON_NAME         = AppIcon
 CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO
 CODE_SIGN_IDENTITY                         = iPhone Developer


### PR DESCRIPTION
Added a required `$(SRCROOT)/vendor/couchbase-lite-core/vendor/fleece/API` to the header search paths of the `CBL_ObjC_Tests_iOS_App` target for the `TunesPerfTest`.