### PR TITLE
UserAgent and some test fixing

### DIFF
--- a/Objective-C/Internal/CBLVersion.m
+++ b/Objective-C/Internal/CBLVersion.m
@@ -52,7 +52,7 @@
         
         NSString* liteCoreCommit = [liteCoreString substringFromIndex:[liteCoreString rangeOfString:@"("].location];
         
-        sUserAgent = [NSString stringWithFormat: @"CouchbaseLite/%s (%@; %@) Build/%d %@ LiteCore%@",
+        sUserAgent = [NSString stringWithFormat: @"CouchbaseLite/%s (%@; %@) Build/%d %@ LiteCore/0.0.0 %@",
                       CBL_VERSION_STRING, platform, system, CBL_BUILD_NUMBER, commit, liteCoreCommit];
         
         c4slice_free(liteCoreVers);

--- a/Swift/Tests/PublisherTest.swift
+++ b/Swift/Tests/PublisherTest.swift
@@ -39,7 +39,7 @@ class PublisherTest: CBLTestCase {
     
     func testCollectionChangePublisher() throws {
         let expect = self.expectation(description: "Collection changed")
-        expect.expectedFulfillmentCount = 2
+        expect.expectedFulfillmentCount = 1
 
         defaultCollection!.changePublisher()
             .sink { change in
@@ -51,14 +51,13 @@ class PublisherTest: CBLTestCase {
         // it also saves the document into the db
         let doc = try generateDocument(withID: "doc1")
         
-        try defaultCollection!.save(document: doc)
         XCTAssert(cancellables.count == 1)
         waitForExpectations(timeout: expTimeout)
     }
     
     func testCollectionDocumentChangePublisher() throws {
         let expect = self.expectation(description: "Document changed")
-        expect.expectedFulfillmentCount = 2
+        expect.expectedFulfillmentCount = 1
 
         defaultCollection!.documentChangePublisher(for: "doc1")
             .sink { change in
@@ -70,7 +69,6 @@ class PublisherTest: CBLTestCase {
         // it also saves the document into the db
         let doc = try generateDocument(withID: "doc1")
         
-        try defaultCollection!.save(document: doc)
         XCTAssert(cancellables.count == 1)
         waitForExpectations(timeout: expTimeout)
     }


### PR DESCRIPTION
- example of userAgent string `CouchbaseLite/3.2.x (Swift; macOS 15.3.1) Build/0 Commit/f7601574+CHANGES LiteCore/0.0.0 (6cc2f7f1e2a09767+64d62a79715ceeff)`
- moved publisher tests to expect only 1 notification/1 save as we can't guarantee the same amount. Expecting 2 changes on the same document was very flaky