### PR TITLE
CBL-6987: Keep test consistent

### DIFF
--- a/Swift/Tests/PublisherTest.swift
+++ b/Swift/Tests/PublisherTest.swift
@@ -39,7 +39,6 @@ class PublisherTest: CBLTestCase {
     
     func testCollectionChangePublisher() throws {
         let expect = self.expectation(description: "Collection changed")
-        expect.expectedFulfillmentCount = 2
 
         defaultCollection!.changePublisher()
             .sink { change in
@@ -51,14 +50,12 @@ class PublisherTest: CBLTestCase {
         // it also saves the document into the db
         let doc = try generateDocument(withID: "doc1")
         
-        try defaultCollection!.save(document: doc)
         XCTAssert(cancellables.count == 1)
         waitForExpectations(timeout: expTimeout)
     }
     
     func testCollectionDocumentChangePublisher() throws {
         let expect = self.expectation(description: "Document changed")
-        expect.expectedFulfillmentCount = 2
 
         defaultCollection!.documentChangePublisher(for: "doc1")
             .sink { change in
@@ -70,7 +67,6 @@ class PublisherTest: CBLTestCase {
         // it also saves the document into the db
         let doc = try generateDocument(withID: "doc1")
         
-        try defaultCollection!.save(document: doc)
         XCTAssert(cancellables.count == 1)
         waitForExpectations(timeout: expTimeout)
     }


### PR DESCRIPTION
As we cannot guarantee that the number of posted notifications will be equal to the number of time that the doc has been saved, moving these tests back to expect only 1 notification. We're deferring reading the changes out of the observer until later, and so sometimes coalesce happens.