### PR TITLE
CBL-7077 : Stop Multipeer Replicator when database is closed

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -258,8 +258,8 @@
 		1ACDD8C323FF5BB200AF5D56 /* ReplicatorTest+PendingDocIds.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ACDD8C223FF5BB200AF5D56 /* ReplicatorTest+PendingDocIds.m */; };
 		1ACDD8D423FF5C4400AF5D56 /* ReplicatorTest+PendingDocIds.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ACDD8C223FF5BB200AF5D56 /* ReplicatorTest+PendingDocIds.m */; };
 		1ADA05392240218F0068F745 /* AuthenticatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1ADA05382240218F0068F745 /* AuthenticatorTest.m */; };
-		1AECFF7B24AE988F0015C9F8 /* CBLStoppable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AECFF7A24AE988F0015C9F8 /* CBLStoppable.h */; };
-		1AECFF8724AE98A30015C9F8 /* CBLStoppable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AECFF7A24AE988F0015C9F8 /* CBLStoppable.h */; };
+		1AECFF7B24AE988F0015C9F8 /* CBLDatabaseService.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AECFF7A24AE988F0015C9F8 /* CBLDatabaseService.h */; };
+		1AECFF8724AE98A30015C9F8 /* CBLDatabaseService.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AECFF7A24AE988F0015C9F8 /* CBLDatabaseService.h */; };
 		1AEF0585283380D500D5DDEA /* CBLScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AEF0583283380D500D5DDEA /* CBLScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AEF0586283380D500D5DDEA /* CBLScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AEF0583283380D500D5DDEA /* CBLScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1AEF0587283380D500D5DDEA /* CBLScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AEF0583283380D500D5DDEA /* CBLScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2436,7 +2436,7 @@
 		1ACDD8C223FF5BB200AF5D56 /* ReplicatorTest+PendingDocIds.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ReplicatorTest+PendingDocIds.m"; sourceTree = "<group>"; };
 		1ACEB9662256B74A00DED54C /* TrustCheckTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TrustCheckTest.m; sourceTree = "<group>"; };
 		1ADA05382240218F0068F745 /* AuthenticatorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AuthenticatorTest.m; sourceTree = "<group>"; };
-		1AECFF7A24AE988F0015C9F8 /* CBLStoppable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLStoppable.h; sourceTree = "<group>"; };
+		1AECFF7A24AE988F0015C9F8 /* CBLDatabaseService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLDatabaseService.h; sourceTree = "<group>"; };
 		1AEF0583283380D500D5DDEA /* CBLScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLScope.h; sourceTree = "<group>"; };
 		1AEF0598283380F800D5DDEA /* CBLCollection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLCollection.h; sourceTree = "<group>"; };
 		1AEF0599283380F800D5DDEA /* CBLCollection.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CBLCollection.mm; sourceTree = "<group>"; };
@@ -3312,7 +3312,6 @@
 				93292D9C22BD448400A0862A /* CBLReplicatorConfiguration+Swift.h */,
 				93292D9D22BD448400A0862A /* CBLReplicatorConfiguration+Swift.m */,
 				40E46B122DD6A7B5007E495D /* CBLReplicatorStatus+Internal.h */,
-				1AECFF7A24AE988F0015C9F8 /* CBLStoppable.h */,
 				276740B51EE7381E0036DE42 /* CBLTrustCheck.h */,
 				276740B61EE7381E0036DE42 /* CBLTrustCheck.mm */,
 				9374A851201165AE00BA0D9E /* CBLURLEndpoint+Internal.h */,
@@ -3971,6 +3970,7 @@
 				9369A6A5207DC7CB009B5B83 /* CBLDatabase+EncryptionInternal.h */,
 				934F4C981E241FB500F90659 /* CBLDatabase+Internal.h */,
 				933F83A221F9819B0093EC88 /* CBLDatabase+Swift.h */,
+				1AECFF7A24AE988F0015C9F8 /* CBLDatabaseService.h */,
 				27CDE75E207407280082D458 /* CBLDocumentChangeNotifier.h */,
 				27CDE75F207407280082D458 /* CBLDocumentChangeNotifier.mm */,
 				1A1612A8283DE8A200AA4987 /* CBLScope+Internal.h */,
@@ -5029,7 +5029,7 @@
 				9343EFAE207D611600F19A89 /* CBLUnaryExpression.h in Headers */,
 				9343EFB0207D611600F19A89 /* CBLMutableDocument.h in Headers */,
 				40E46B1D2DD6A808007E495D /* CBLConflictResolverService.h in Headers */,
-				1AECFF8724AE98A30015C9F8 /* CBLStoppable.h in Headers */,
+				1AECFF8724AE98A30015C9F8 /* CBLDatabaseService.h in Headers */,
 				40E46AE82DD6A4E7007E495D /* CBLMultipeerReplicatorConfiguration.h in Headers */,
 				40E46AE92DD6A4E7007E495D /* CBLMultipeerCollectionConfiguration.h in Headers */,
 				40E46AEA2DD6A4E7007E495D /* CBLMultipeerEventTypes.h in Headers */,
@@ -5574,7 +5574,7 @@
 				93F5D19F1EFAE90200E2DF53 /* CBLBasicAuthenticator.h in Headers */,
 				1A3470E0266F415E0042C6BA /* CBLIndexSpec.h in Headers */,
 				934F4CAD1E241FB500F90659 /* CBLJSON.h in Headers */,
-				1AECFF7B24AE988F0015C9F8 /* CBLStoppable.h in Headers */,
+				1AECFF7B24AE988F0015C9F8 /* CBLDatabaseService.h in Headers */,
 				93E17EF81ED3ABE200671CA1 /* CBLDocumentChange.h in Headers */,
 				9383A5841F1EE7C00083053D /* CBLQueryResultSet.h in Headers */,
 				9384D8271FC405BF00FE89D8 /* CBLQueryFullTextExpression.h in Headers */,

--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -87,7 +87,7 @@ typedef enum {
     BOOL _shellMode;
     dispatch_source_t _docExpiryTimer;
     
-    NSMutableSet<id<CBLStoppable>>* _activeStoppables;
+    NSMutableSet<id<CBLDatabaseService>>* _activeServices;
     
     NSCondition* _closeCondition;
     
@@ -397,7 +397,7 @@ static const C4DatabaseConfig2 kDBConfig = {
 #pragma mark - DATABASE MAINTENANCE
 
 - (BOOL) close: (NSError**)outError {
-    NSArray *activeStoppables = nil;
+    NSArray *activeServices = nil;
     
     CBL_LOCK(_mutex) {
         if ([self isClosed])
@@ -411,13 +411,13 @@ static const C4DatabaseConfig2 kDBConfig = {
             if (!_closeCondition)
                 _closeCondition = [[NSCondition alloc] init];
             
-            activeStoppables = [_activeStoppables allObjects];
+            activeServices = [_activeServices allObjects];
         }
     }
     
-    // Stop all active stoppable connections:
-    for (id<CBLStoppable> instance in activeStoppables) {
-        [instance stop];
+    // Stop all active services:
+    for (id<CBLDatabaseService> service in activeServices) {
+        [service stop];
     }
     
     // Wait for all active replicators and live queries to stop:
@@ -450,7 +450,7 @@ static const C4DatabaseConfig2 kDBConfig = {
 
 - (BOOL) isReadyToClose {
     CBL_LOCK(_mutex) {
-        return _activeStoppables.count == 0;
+        return _activeServices.count == 0;
     }
 }
 
@@ -1154,23 +1154,23 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
     }
 }
 
-#pragma mark - Stoppable
+#pragma mark - Database Services
 
-- (void) addActiveStoppable: (id<CBLStoppable>)stoppable {
+- (void) registerActiveService: (id<CBLDatabaseService>)service {
     CBL_LOCK(_mutex) {
         [self mustBeOpenAndNotClosing];
         
-        if (!_activeStoppables)
-            _activeStoppables = [NSMutableSet new];
+        if (!_activeServices)
+            _activeServices = [NSMutableSet new];
         
-        [_activeStoppables addObject: stoppable];
+        [_activeServices addObject: service];
     }
 }
 
-- (void) removeActiveStoppable: (id<CBLStoppable>)stoppable {
+- (void) unregisterActiveService: (id<CBLDatabaseService>)service {
     CBL_LOCK(_mutex) {
-        [_activeStoppables removeObject: stoppable];
-        if (_activeStoppables.count == 0) {
+        [_activeServices removeObject: service];
+        if (_activeServices.count == 0) {
             [_closeCondition lock];
             [_closeCondition broadcast];
             [_closeCondition unlock];
@@ -1178,9 +1178,9 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
     }
 }
 
-- (uint64_t) activeStoppableCount {
+- (uint64_t) activeServiceCount {
     CBL_LOCK(_mutex) {
-        return _activeStoppables.count;
+        return _activeServices.count;
     }
 }
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -187,7 +187,7 @@ typedef enum {
             [self setConflictResolutionSuspended: NO];
             c4repl_start(_repl, reset);
             status = c4repl_getStatus(_repl);
-            [_config.database addActiveStoppable: self];
+            [_config.database registerActiveService: self];
             
 #if TARGET_OS_IPHONE
             if (!_config.allowReplicatingInBackground)
@@ -381,7 +381,7 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
     
     // Prevent self to get released when removing from the active replications:
     CBLReplicator* repl = self;
-    [_config.database removeActiveStoppable: repl];
+    [_config.database unregisterActiveService: repl];
     
 #if TARGET_OS_IPHONE
     [self endBackgroundingMonitor];

--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -30,7 +30,7 @@
 #import "CBLDocumentChange.h"
 #import "CBLReplicator.h"
 #import "CBLConflictResolver.h"
-#import "CBLStoppable.h"
+#import "CBLDatabaseService.h"
 #import "CBLLockable.h"
 
 #ifdef COUCHBASE_ENTERPRISE
@@ -61,9 +61,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable C4BlobStore*) getBlobStore: (NSError**)outError;
 
-- (void) addActiveStoppable: (id<CBLStoppable>)stoppable;
-- (void) removeActiveStoppable: (id<CBLStoppable>)stoppable;
-- (uint64_t) activeStoppableCount; // For testing only
+- (void) registerActiveService: (id<CBLDatabaseService>)service;
+- (void) unregisterActiveService: (id<CBLDatabaseService>)service;
+- (uint64_t) activeServiceCount; // For testing only
 
 // Initialize the CBLDatabase with a give C4Database object in the shell mode.
 // This is currently used for creating a CBLDictionary as an input of the predict()

--- a/Objective-C/Internal/CBLDatabaseService.h
+++ b/Objective-C/Internal/CBLDatabaseService.h
@@ -1,8 +1,8 @@
 //
-//  CBLStoppable.h
+//  CBLDatabaseService.h
 //  CouchbaseLite
 //
-//  Copyright (c) 2020 Couchbase, Inc All rights reserved.
+//  Copyright (c) 2025 Couchbase, Inc All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol CBLStoppable <NSObject>
+@protocol CBLDatabaseService <NSObject>
 
 - (void) stop;
 

--- a/Objective-C/Internal/CBLQueryObserver.m
+++ b/Objective-C/Internal/CBLQueryObserver.m
@@ -25,7 +25,7 @@
 #import "CBLQuery+Internal.h"
 #import "CBLQueryResultSet+Internal.h"
 
-@interface CBLQueryObserver () <CBLStoppable>
+@interface CBLQueryObserver () <CBLDatabaseService>
 
 /** The query object will be set to nil when the replicator is stopped to break the circular retain references.  */
 @property (nonatomic, readonly, nullable) CBLQuery* query;
@@ -58,7 +58,7 @@
         _context = [[CBLContextManager shared] registerObject: self];
         _c4obs = c4queryobs_create(query.c4query, liveQueryCallback, _context); // c4queryobs_create is thread-safe.
         
-        [query.database addActiveStoppable: self];
+        [query.database registerActiveService: self];
     }
     return self;
 }
@@ -91,7 +91,7 @@
         [_query.database safeBlock: ^{
             c4queryobs_setEnabled(self->_c4obs, false);
             c4queryobs_free(self->_c4obs);
-            [self->_query.database removeActiveStoppable: self];
+            [self->_query.database unregisterActiveService: self];
         }];
         
         [[CBLContextManager shared] unregisterObjectForPointer: _context];

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -20,7 +20,7 @@
 #import "CBLReplicator.h"
 #import "CBLReplicatorConfiguration.h"
 #import "c4.h"
-#import "CBLStoppable.h"
+#import "CBLDatabaseService.h"
 
 #ifdef COUCHBASE_ENTERPRISE
 #import "CBLReplicatorConfiguration+ServerCert.h"
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface CBLReplicator () <CBLStoppable> {
+@interface CBLReplicator () <CBLDatabaseService> {
     // For CBLReplicator+Backgrounding:
     BOOL _deepBackground;
     BOOL _filesystemUnavailable;

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -1505,11 +1505,11 @@
     
     [self waitForExpectations: @[change1, change2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)2);
+    AssertEqual([self.db activeServiceCount], (unsigned long)2);
     
     [self closeDatabase: self.db];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
     Assert([self.db isClosedLocked]);
 }
 
@@ -1537,13 +1537,13 @@
     
     [self waitForExpectations: @[idle1, idle2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)2);
+    AssertEqual([self.db activeServiceCount], (unsigned long)2);
     
     [self closeDatabase: self.db];
     
     [self waitForExpectations: @[stopped1, stopped2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
     Assert([self.db isClosedLocked]);
 }
 
@@ -1563,7 +1563,7 @@
     
     [self waitForExpectations: @[change1, change2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)2);
+    AssertEqual([self.db activeServiceCount], (unsigned long)2);
     
     // Replicators:
     
@@ -1588,15 +1588,15 @@
     
     [self waitForExpectations: @[idle1, idle2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)4); // total stoppables
+    AssertEqual([self.db activeServiceCount], (unsigned long)4); // total services
     
     // Close database:
     [self closeDatabase: self.db];
     
     [self waitForExpectations: @[stopped1, stopped2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
     Assert([self.db isClosedLocked]);
 }
 
@@ -1727,11 +1727,11 @@
     
     [self waitForExpectations: @[change1, change2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)2);
+    AssertEqual([self.db activeServiceCount], (unsigned long)2);
     
     [self deleteDatabase: self.db];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
     Assert([self.db isClosedLocked]);
 }
 
@@ -1759,13 +1759,13 @@
     
     [self waitForExpectations: @[idle1, idle2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)2);
+    AssertEqual([self.db activeServiceCount], (unsigned long)2);
     
     [self deleteDatabase: self.db];
     
     [self waitForExpectations: @[stopped1, stopped2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
     Assert([self.db isClosedLocked]);
 }
 
@@ -1785,7 +1785,7 @@
     
     [self waitForExpectations: @[change1, change2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)2);
+    AssertEqual([self.db activeServiceCount], (unsigned long)2);
     
     CBLDatabaseEndpoint* target = [[CBLDatabaseEndpoint alloc] initWithDatabase: self.otherDB];
     CBLReplicatorConfiguration* config =
@@ -1806,14 +1806,14 @@
     
     [self waitForExpectations: @[idle1, idle2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)4); // total stoppables
+    AssertEqual([self.db activeServiceCount], (unsigned long)4); // total services
     
     [self deleteDatabase: self.db];
     
     [self waitForExpectations: @[stopped1, stopped2] timeout: 5.0];
     
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
-    AssertEqual([self.db activeStoppableCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
+    AssertEqual([self.db activeServiceCount], (unsigned long)0);
     Assert([self.db isClosedLocked]);
 }
 


### PR DESCRIPTION
* Stop Multipeer Replicator when its database is closed.

* Renamed CBLStoppable protocol to CBLDatabaseService as a better name.

* Renamed CBLDatabase’s addActiveStoppable to registerActiveService and unregisterActiveService which are more correct in term of naming.

* Added tests.