### PR TITLE
CBL-7103 : Fix default conflict resolver not being used in MultipeerReplicator

### DIFF
--- a/Objective-C/Internal/Replicator/CBLConflictResolverService.h
+++ b/Objective-C/Internal/Replicator/CBLConflictResolverService.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) addConflict: (CBLReplicatedDocument*)doc
           collection: (CBLCollection*)collection
-            resolver: (id<CBLConflictResolver>)resolver
+            resolver: (nullable id<CBLConflictResolver>)resolver
           completion: (void (^)(BOOL cancelled, NSError* _Nullable error))completion;
 
 - (instancetype) init NS_UNAVAILABLE;

--- a/Objective-C/Internal/Replicator/CBLConflictResolverService.m
+++ b/Objective-C/Internal/Replicator/CBLConflictResolverService.m
@@ -89,14 +89,8 @@ typedef NS_ENUM(NSInteger, CBLConflictResolverState) {
             return;
         }
         
-        __block dispatch_block_t block;
-        block = dispatch_block_create(0, ^{
-            if (dispatch_block_testcancel(block)) {
-                completion(YES, nil);
-                return;
-            }
-            
-            NSError* error;
+        dispatch_block_t block = dispatch_block_create(0, ^{
+            NSError* error = nil;
             if (![collection resolveConflictInDocument: doc.id
                                   withConflictResolver: resolver
                                                  error: &error]) {
@@ -116,8 +110,7 @@ typedef NS_ENUM(NSInteger, CBLConflictResolverState) {
 
 - (void) removePendingBlock :(dispatch_block_t)block {
     CBL_LOCK(_mutex) {
-        [_pendingBlocks removeObject:block];
-        
+        [_pendingBlocks removeObject: block];
         if (_state == CBLConflictResolverStopping && _pendingBlocks.count == 0) {
             _state = CBLConflictResolverStopped;
             void (^completion)(void) = _pendingShutdownCompletion;


### PR DESCRIPTION
* Allowed resolver to be nil to use default conflict resolver.

* Simplified and fixed circular retain cycle in the dispatch block.

* No conflict resolution tests included as it's currently flaky with some workaround implemented due to CBL - 7099 and CBL - 7100.

* Companion PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/276

* Note: testSanityReplication is very flaky. I will look into this more once all of the current LiteCore's issues have been resolved.