### PR TITLE
CBL-7117: Fix MultipeerReplicator not suspending in background

### DIFF
--- a/Objective-C/Internal/Replicator/CBLAppBackgroundingMonitor.h
+++ b/Objective-C/Internal/Replicator/CBLAppBackgroundingMonitor.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL) appWillBackgroundAndShouldExtend: (CBLAppBackgroundingMonitor*)monitor;
 
+- (void) appDidExtendBackgroundTask: (CBLAppBackgroundingMonitor*)monitor;
+
 - (void) appDidBackground: (CBLAppBackgroundingMonitor*)monitor;
 
 - (void) appDidForeground: (CBLAppBackgroundingMonitor*)monitor;

--- a/Objective-C/Internal/Replicator/CBLAppBackgroundingMonitor.m
+++ b/Objective-C/Internal/Replicator/CBLAppBackgroundingMonitor.m
@@ -124,15 +124,16 @@
 /** All the methods below are called on the MAIN THREAD */
 
 - (void) appBackgrounding {
-    BOOL extend = [_delegate appWillBackgroundAndShouldExtend: self];
+    id<CBLAppBackgroundingMonitorDelegate> delegate = _delegate;
+    BOOL extend = [delegate appWillBackgroundAndShouldExtend: self];
     if (extend && [_bgMonitor beginBackgroundTaskNamed: self.description]) {
         CBLLogInfo(Sync, @"%@: App backgrounding, starting background task.", self);
-        return;
+        [delegate appDidExtendBackgroundTask: self];
+    } else {
+        CBLLogInfo(Sync, @"%@: App backgrounding without starting background task.", self);
+        _deepBackground = YES;
+        [self updateState];
     }
-    
-    CBLLogInfo(Sync, @"%@: App backgrounding without starting background task.", self);
-    _deepBackground = YES;
-    [self updateState];
 }
 
 - (void) appForegrounding {


### PR DESCRIPTION
* Issue : CBLAppBackgroundingMonitor was adapted from the regular replicator’s backgrounding logic, but it’s not fully compatible with MultipeerReplicator. The current logic depends on the replicator to tell the monitor that it is IDLE so that the monitor can be in the deep background mode and to tell the replicator to actually suspend. Unlike the regular replicator, MultipeerReplicator doesn’t track any internal replicators’ status so it will need to be suspended immediately regardless of the status of the replicator.

* Fix : Introduced a new delegate method in CBLAppBackgroundingMonitor to notify when the app enters background and the extended background task has been requested. This allows MultipeerReplicator to suspend immediately regardless.

* Note : Test has been done manually to ensure that the backgrounding support works properly.

* Companion PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/282