### PR TITLE
CBL-7151 : Adjust progress level in MultipeerReplicator

### DIFF
--- a/Objective-C/Internal/CBLChangeNotifier.h
+++ b/Objective-C/Internal/CBLChangeNotifier.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSUInteger) removeChangeListenerWithToken: (id<CBLListenerToken>)token;
 
+/** Check whether this notifier has the token or not. */
+- (BOOL) containsToken: (id<CBLListenerToken>)token;
 
 /** Posts a change notification object to all listeners, asynchronously. */
 - (void) postChange: (ChangeType)change;

--- a/Objective-C/Internal/CBLChangeNotifier.m
+++ b/Objective-C/Internal/CBLChangeNotifier.m
@@ -51,6 +51,12 @@
     }
 }
 
+- (BOOL) containsToken: (id<CBLListenerToken>)token {
+    CBL_LOCK(self) {
+        return [_listenerTokens containsObject: token];
+    }
+}
+
 - (void) postChange: (id)change {
     CBLAssertNotNil(change);
 


### PR DESCRIPTION
* Like the regular replicator, set the progress level to overall by default and bump it to per-doc when there is a document replication listener added.

* Add a method in CBLChangeNotifier to check whether it contains the token or not.

* Companion PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/283