### PR TITLE
CBL-7167 : Fix getting non-existing identity throws an error

### DIFF
--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -155,7 +155,7 @@
     Assert(status == errSecSuccess);
 }
 
-#if 1
+#if 0
 
 /** For Debugging */
 - (void) dumpItemsInKeyChain {
@@ -257,7 +257,7 @@
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
     AssertNil(identity);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     // Create:
     error = nil;
@@ -286,7 +286,7 @@
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
     AssertNil(identity);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
 }
 
 - (void) testCreateDuplicateServerIdentity {
@@ -333,7 +333,7 @@
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kClientCertLabel error: &error];
     AssertNil(identity);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     // Create:
     error = nil;
@@ -362,7 +362,7 @@
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kClientCertLabel error: &error];
     AssertNil(identity);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
 }
 
 - (void) testCreateDuplicateClientIdentity {
@@ -501,8 +501,7 @@
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
     AssertNil(identity);
-    AssertEqual(error.code, CBLErrorNotFound);
-    //}
+    AssertNil(error);
 }
 
 - (void) testCreateIdentityWithNoAttributes {
@@ -514,7 +513,7 @@
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
     AssertNil(identity);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     // Create:
     error = nil; // reset the error
@@ -539,7 +538,7 @@
     // Get:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
     AssertNil(identity);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
     
     // Create:
     error = nil; // reset the error
@@ -618,8 +617,7 @@
     // Check the identity in KeyChain:
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
     AssertNil(identity);
-    AssertNotNil(error);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
 }
 
 - (void) testCreateIdentitySignedWithImportedIssuer {
@@ -674,8 +672,7 @@
     
     identity = [CBLTLSIdentity identityWithLabel: kServerCertLabel error: &error];
     AssertNil(identity);
-    AssertNotNil(error);
-    AssertEqual(error.code, CBLErrorNotFound);
+    AssertNil(error);
 }
 
 @end


### PR DESCRIPTION
* The current API for retrieving a TLSIdentity by persistent label throws or returns a NotFound error when the identity does not exist in the keychain. However, this behavior contradicts the API’s signature, which suggests it should return nil if the identity is missing.

* The actual fix is in the EE repo. This commit only updates the tests according to the fix.

* Companion PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/285