### PR TITLE
CBL-7179: Swift Codable nil values are skipped from encoding

### DIFF
--- a/Swift/DocumentEncoder.swift
+++ b/Swift/DocumentEncoder.swift
@@ -86,6 +86,14 @@ private class DocumentEncodingContainer<Key: CodingKey>: KeyedEncodingContainerP
         codingPath.append(key)
     }
     
+    func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
     // Nested containers use FleeceEncoder, because they don't need the override for DocumentId
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
         try! encoder._encoder.writeKey(key)
@@ -153,6 +161,14 @@ private struct ImpossibleKeyedContainer<Key: CodingKey>: KeyedEncodingContainerP
     
     func encodeNil(forKey key: Key) throws {
         throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
     }
     
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {

--- a/Swift/DocumentEncoder.swift
+++ b/Swift/DocumentEncoder.swift
@@ -94,6 +94,138 @@ private class DocumentEncodingContainer<Key: CodingKey>: KeyedEncodingContainerP
         }
     }
     
+    // For some reason we have to override every overload of encodeIfPresent
+    
+    func encodeIfPresent(_ value: Bool?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: String?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Double?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Float?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int8?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int16?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int32?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int64?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    @available(macOSApplicationExtension 15.0, *)
+    func encodeIfPresent(_ value: Int128?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt8?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    @available(macOSApplicationExtension 15.0, *)
+    func encodeIfPresent(_ value: UInt128?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
     // Nested containers use FleeceEncoder, because they don't need the override for DocumentId
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
         try! encoder._encoder.writeKey(key)
@@ -169,6 +301,74 @@ private struct ImpossibleKeyedContainer<Key: CodingKey>: KeyedEncodingContainerP
         } else {
             try encodeNil(forKey: key)
         }
+    }
+    
+    // For some reason we have to override every overload of encodeIfPresent
+    
+    func encodeIfPresent(_ value: Bool?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: String?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: Double?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: Float?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: Int?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: Int8?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: Int16?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: Int32?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: Int64?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    @available(macOSApplicationExtension 15.0, *)
+    func encodeIfPresent(_ value: Int128?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: UInt8?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
+    }
+    
+    @available(macOSApplicationExtension 15.0, *)
+    func encodeIfPresent(_ value: UInt128?, forKey key: Key) throws {
+        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
     }
     
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {

--- a/Swift/DocumentEncoder.swift
+++ b/Swift/DocumentEncoder.swift
@@ -168,15 +168,6 @@ private class DocumentEncodingContainer<Key: CodingKey>: KeyedEncodingContainerP
         }
     }
     
-    @available(macOSApplicationExtension 15.0, *)
-    func encodeIfPresent(_ value: Int128?, forKey key: Key) throws {
-        if value != nil {
-            try encode(value, forKey: key)
-        } else {
-            try encodeNil(forKey: key)
-        }
-    }
-    
     func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
         if value != nil {
             try encode(value, forKey: key)
@@ -210,15 +201,6 @@ private class DocumentEncodingContainer<Key: CodingKey>: KeyedEncodingContainerP
     }
     
     func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
-        if value != nil {
-            try encode(value, forKey: key)
-        } else {
-            try encodeNil(forKey: key)
-        }
-    }
-    
-    @available(macOSApplicationExtension 15.0, *)
-    func encodeIfPresent(_ value: UInt128?, forKey key: Key) throws {
         if value != nil {
             try encode(value, forKey: key)
         } else {
@@ -341,11 +323,6 @@ private struct ImpossibleKeyedContainer<Key: CodingKey>: KeyedEncodingContainerP
         throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
     }
     
-    @available(macOSApplicationExtension 15.0, *)
-    func encodeIfPresent(_ value: Int128?, forKey key: Key) throws {
-        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
-    }
-    
     func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
         throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
     }
@@ -363,11 +340,6 @@ private struct ImpossibleKeyedContainer<Key: CodingKey>: KeyedEncodingContainerP
     }
     
     func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
-        throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
-    }
-    
-    @available(macOSApplicationExtension 15.0, *)
-    func encodeIfPresent(_ value: UInt128?, forKey key: Key) throws {
         throw CBLError.create(CBLError.encodingError, description: "Document encoding requires a keyed container")
     }
     

--- a/Swift/FleeceEncoder.swift
+++ b/Swift/FleeceEncoder.swift
@@ -203,6 +203,14 @@ internal class DictEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProt
         try encoder.writeValue(value)
     }
     
+    func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
         try! encoder.writeKey(key)
         let container = try! DictEncodingContainer<NestedKey>(encoder: encoder)

--- a/Swift/FleeceEncoder.swift
+++ b/Swift/FleeceEncoder.swift
@@ -285,15 +285,6 @@ internal class DictEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProt
         }
     }
     
-    @available(macOSApplicationExtension 15.0, *)
-    func encodeIfPresent(_ value: Int128?, forKey key: Key) throws {
-        if value != nil {
-            try encode(value, forKey: key)
-        } else {
-            try encodeNil(forKey: key)
-        }
-    }
-    
     func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
         if value != nil {
             try encode(value, forKey: key)
@@ -327,15 +318,6 @@ internal class DictEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProt
     }
     
     func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
-        if value != nil {
-            try encode(value, forKey: key)
-        } else {
-            try encodeNil(forKey: key)
-        }
-    }
-    
-    @available(macOSApplicationExtension 15.0, *)
-    func encodeIfPresent(_ value: UInt128?, forKey key: Key) throws {
         if value != nil {
             try encode(value, forKey: key)
         } else {

--- a/Swift/FleeceEncoder.swift
+++ b/Swift/FleeceEncoder.swift
@@ -211,6 +211,138 @@ internal class DictEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProt
         }
     }
     
+    // For some reason we have to override every overload of encodeIfPresent
+    
+    func encodeIfPresent(_ value: Bool?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: String?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Double?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Float?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int8?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int16?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int32?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: Int64?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    @available(macOSApplicationExtension 15.0, *)
+    func encodeIfPresent(_ value: Int128?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt8?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
+    @available(macOSApplicationExtension 15.0, *)
+    func encodeIfPresent(_ value: UInt128?, forKey key: Key) throws {
+        if value != nil {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+    
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
         try! encoder.writeKey(key)
         let container = try! DictEncodingContainer<NestedKey>(encoder: encoder)

--- a/Swift/Tests/CodableTest.swift
+++ b/Swift/Tests/CodableTest.swift
@@ -251,6 +251,12 @@ class Favourites : Codable, Equatable {
     var colour: String?
     var animal: Animal?
     
+    init(id: String? = nil, colour: String? = nil, animal: Animal? = nil) {
+        self.id = id
+        self.colour = colour
+        self.animal = animal
+    }
+    
     static func == (lhs: Favourites, rhs: DictionaryProtocol) -> Bool {
         // use DictionaryEquatable protocol to test equality
         return lhs.eq(dict: rhs)
@@ -787,6 +793,15 @@ class CodableTest: CBLTestCase {
         expectError(domain: CBLError.domain, code: CBLError.decodingError) {
             let _ = try self.defaultCollection!.document(id: largeCalc.id!, as: Calculation.self)
         }
+    }
+    
+    func testCollectionEncodeAndDecodeNil() throws {
+        let favourites = Favourites(colour: nil, animal: Animal(name: "Whale", legs: nil))
+        try defaultCollection!.save(from: favourites)
+        let favouritesLoaded = try defaultCollection!.document(id: favourites.id!, as: Favourites.self)
+        XCTAssertEqual(favourites, favouritesLoaded)
+        let favouritesDoc = try defaultCollection!.document(id: favourites.id!)!
+        XCTAssert(favourites == favouritesDoc)
     }
 }
 


### PR DESCRIPTION
Override encodeIfPresent to encode if not present.