### PR TITLE
Update LiteCore to 3.3.0-112

### DIFF
--- a/Objective-C/Tests/CBLTestCase.h
+++ b/Objective-C/Tests/CBLTestCase.h
@@ -204,10 +204,13 @@ extern const NSTimeInterval kExpTimeout;
             randomAccess: (BOOL)randomAccess
                     test: (void (^)(uint64_t n, CBLQueryResult *result))block;
 
+/** Checks whether the explain plan contains either USING INDEX or USING COVERING INDEX for the given index name. */
+- (BOOL) isUsingIndexNamed: (NSString*)indexName forQuery: (CBLQuery*)query;
+
 - (NSString*) getRickAndMortyJSON;
 
 /**
- /// This expectation will allow overfill expectation.
+ This expectation will allow overfill expectation.
  CBL-2363: Replicator might send extra idle status when its being stopped, which is not a bug
  */
 - (XCTestExpectation*) allowOverfillExpectationWithDescription:(NSString *)description;

--- a/Objective-C/Tests/CBLTestCase.m
+++ b/Objective-C/Tests/CBLTestCase.m
@@ -453,6 +453,19 @@ const NSTimeInterval kExpTimeout = 20.0;
     return n;
 }
 
+- (BOOL) isUsingIndexNamed: (NSString*)indexName forQuery: (CBLQuery*)query {
+    NSError* error;
+    NSString* plan = [query explain: &error];
+    AssertNil(error);
+    AssertNotNil(plan);
+    
+    NSString *usingIndex = [NSString stringWithFormat:@"USING INDEX %@", indexName];
+    NSString *usingCoveringIndex = [NSString stringWithFormat:@"USING COVERING INDEX %@", indexName];
+    
+    return ([plan rangeOfString:usingIndex].location != NSNotFound ||
+            [plan rangeOfString:usingCoveringIndex].location != NSNotFound);
+}
+
 - (BOOL) isProfiling {
     return NSProcessInfo.processInfo.environment[@"PROFILING"] != nil;
 }

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -2038,8 +2038,8 @@
     CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult expression: key]]
                                      from: [CBLQueryDataSource database: self.db]
                                     where: [key greaterThan: [CBLQueryExpression integer: 9]]];
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"USING INDEX KeyIndex"].location != NSNotFound);
+    
+    Assert([self isUsingIndexNamed: @"KeyIndex" forQuery: q]);
     
     // Reindex:
     Assert([_db performMaintenance: kCBLMaintenanceTypeReindex error: &error],
@@ -2047,8 +2047,7 @@
     
     // Check if the index is still there and used:
     AssertEqual(self.db.indexes.count, 1u);
-    explain = [q explain: &error];
-    Assert([explain rangeOfString: @"USING INDEX KeyIndex"].location != NSNotFound);
+    Assert([self isUsingIndexNamed: @"KeyIndex" forQuery: q]);
 }
 
 - (void) testPerformMaintenanceIntegrityCheck {

--- a/Objective-C/Tests/PartialIndexTest.m
+++ b/Objective-C/Tests/PartialIndexTest.m
@@ -61,13 +61,11 @@
     NSString* sql = @"SELECT * FROM _ WHERE type = 'number' AND num > 1000";
     CBLQuery* q = [_db createQuery: sql error: &error];
     AssertNotNil(q);
-    NSString* explain = [q explain: &error];
-    Assert([explain rangeOfString: @"USING INDEX numIndex"].location != NSNotFound);
+    Assert([self isUsingIndexNamed: @"numIndex" forQuery: q]);
     
     sql = @"SELECT * FROM _ WHERE type = 'foo' AND num > 1000";
     q = [_db createQuery: sql error: &error];
-    explain = [q explain: &error];
-    AssertFalse([explain rangeOfString: @"USING INDEX numIndex"].location != NSNotFound);
+    AssertFalse([self isUsingIndexNamed: @"numIndex" forQuery: q]);
 }
 
 /**

--- a/Objective-C/Tests/PredictiveQueryTest.m
+++ b/Objective-C/Tests/PredictiveQueryTest.m
@@ -538,7 +538,7 @@
                                      from: kDATA_SRC_DB
                                     where: [sumPrediction equalTo: EXPR_VAL(@15)]];
     
-    Assert([[q explain: nil] rangeOfString: @"USING INDEX SumIndex"].location != NSNotFound);
+    Assert([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
     
     uint64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -577,9 +577,9 @@
                                      from: kDATA_SRC_DB
                                     where: [[sumPrediction lessThanOrEqualTo: EXPR_VAL(@15)] orExpression:
                                             [avgPrediction equalTo: EXPR_VAL(@8)]]];
-    NSString* explain = [q explain: nil];
-    Assert([explain rangeOfString: @"USING INDEX SumIndex"].location != NSNotFound);
-    Assert([explain rangeOfString: @"USING INDEX AvgIndex"].location != NSNotFound);
+    
+    Assert([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
+    Assert([self isUsingIndexNamed: @"AvgIndex" forQuery: q]);
     
     int64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         Assert([r integerAtIndex: 0] == 15 || [r integerAtIndex: 1] == 8);
@@ -611,7 +611,7 @@
                                     where: [[sumPrediction equalTo: EXPR_VAL(@15)] andExpression:
                                             [avgPrediction equalTo: EXPR_VAL(@3)]]];
     
-    Assert([[q explain: nil] rangeOfString: @"USING INDEX SumAvgIndex"].location != NSNotFound);
+    Assert([self isUsingIndexNamed: @"SumAvgIndex" forQuery: q]);
     
     uint64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         AssertEqual([r integerAtIndex: 0], 15);
@@ -644,7 +644,7 @@
                                      from: kDATA_SRC_DB
                                     where: [sumPrediction equalTo: EXPR_VAL(@15)]];
     
-    Assert([[q explain: nil] rangeOfString: @"USING INDEX AggCache"].location == NSNotFound);
+    AssertFalse([self isUsingIndexNamed: @"AggCache" forQuery: q]);
     
     uint64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -677,12 +677,12 @@
                                                                 properties: @[@"sum"]];
     Assert([self.db createIndex: index withName: @"SumIndex" error: &error]);
     
-    CBLQuery *q = [CBLQueryBuilder select: @[SEL_PROP(@"numbers"),
+    CBLQuery* q = [CBLQueryBuilder select: @[SEL_PROP(@"numbers"),
                                              SEL_EXPR(sumPrediction)]
                                      from: kDATA_SRC_DB
                                     where: [sumPrediction equalTo: EXPR_VAL(@15)]];
     
-    Assert([[q explain: nil] rangeOfString: @"USING INDEX SumIndex"].location != NSNotFound);
+    Assert([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
     
     uint64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -725,9 +725,9 @@
                                      from: kDATA_SRC_DB
                                     where: [[sumPrediction lessThanOrEqualTo: EXPR_VAL(@15)] orExpression:
                                             [avgPrediction equalTo: EXPR_VAL(@8)]]];
-    NSString* explain = [q explain: nil];
-    Assert([explain rangeOfString: @"USING INDEX SumIndex"].location != NSNotFound);
-    Assert([explain rangeOfString: @"USING INDEX AvgIndex"].location != NSNotFound);
+    
+    Assert([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
+    Assert([self isUsingIndexNamed: @"AvgIndex" forQuery: q]);
     
     int64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         Assert([r integerAtIndex: 0] == 15 || [r integerAtIndex: 1] == 8);
@@ -762,7 +762,7 @@
                                     where: [[sumPrediction equalTo: EXPR_VAL(@15)] andExpression:
                                             [avgPrediction equalTo: EXPR_VAL(@3)]]];
     
-    Assert([[q explain: nil] rangeOfString: @"USING INDEX SumAvgIndex"].location != NSNotFound);
+    Assert([self isUsingIndexNamed: @"SumAvgIndex" forQuery: q]);
     
     uint64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         AssertEqual([r integerAtIndex: 0], 15);
@@ -795,7 +795,8 @@
     CBLQuery *q = [CBLQueryBuilder select: @[SEL_PROP(@"numbers")]
                                      from: kDATA_SRC_DB
                                     where: [sumPrediction equalTo: EXPR_VAL(@15)]];
-    Assert([[q explain: nil] rangeOfString: @"USING INDEX SumIndex"].location != NSNotFound);
+    
+    Assert([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
     
     // Query with index:
     uint64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
@@ -813,7 +814,8 @@
     q = [CBLQueryBuilder select: @[SEL_PROP(@"numbers")]
                            from: kDATA_SRC_DB
                           where: [sumPrediction equalTo: EXPR_VAL(@15)]];
-    Assert([[q explain: nil] rangeOfString: @"USING INDEX SumIndex"].location == NSNotFound);
+    
+    AssertFalse([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
     
     numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -861,9 +863,9 @@
                                      from: kDATA_SRC_DB
                                     where: [[sumPrediction lessThanOrEqualTo: EXPR_VAL(@15)] orExpression:
                                             [avgPrediction equalTo: EXPR_VAL(@8)]]];
-    NSString* explain = [q explain: nil];
-    Assert([explain rangeOfString: @"USING INDEX SumIndex"].location != NSNotFound);
-    Assert([explain rangeOfString: @"USING INDEX AvgIndex"].location != NSNotFound);
+    
+    Assert([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
+    Assert([self isUsingIndexNamed: @"AvgIndex" forQuery: q]);
     
     uint64_t numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -881,8 +883,8 @@
     q = [CBLQueryBuilder select: @[SEL_PROP(@"numbers")]
                            from: kDATA_SRC_DB
                           where: [sumPrediction equalTo: EXPR_VAL(@15)]];
-    explain = [q explain: nil];
-    Assert([explain rangeOfString: @"USING INDEX SumIndex"].location == NSNotFound);
+    
+    AssertFalse([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
     
     numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -894,8 +896,8 @@
     q = [CBLQueryBuilder select: @[SEL_PROP(@"numbers")]
                            from: kDATA_SRC_DB
                           where: [avgPrediction equalTo: EXPR_VAL(@8)]];
-    explain = [q explain: nil];
-    Assert([explain rangeOfString: @"USING INDEX AvgIndex"].location != NSNotFound);
+    
+    Assert([self isUsingIndexNamed: @"AvgIndex" forQuery: q]);
     
     numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -911,8 +913,8 @@
     q = [CBLQueryBuilder select: @[SEL_PROP(@"numbers")]
                            from: kDATA_SRC_DB
                           where: [avgPrediction equalTo: EXPR_VAL(@8)]];
-    explain = [q explain: nil];
-    Assert([explain rangeOfString: @"USING INDEX AvgIndex"].location == NSNotFound);
+    
+    AssertFalse([self isUsingIndexNamed: @"AvgIndex" forQuery: q]);
     
     numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
@@ -929,9 +931,10 @@
                            from: kDATA_SRC_DB
                           where: [[sumPrediction lessThanOrEqualTo: EXPR_VAL(@15)] orExpression:
                                   [avgPrediction equalTo: EXPR_VAL(@8)]]];
-    explain = [q explain: nil];
-    Assert([explain rangeOfString: @"USING INDEX SumIndex"].location == NSNotFound);
-    Assert([explain rangeOfString: @"USING INDEX AvgIndex"].location == NSNotFound);
+    
+    AssertFalse([self isUsingIndexNamed: @"SumIndex" forQuery: q]);
+    AssertFalse([self isUsingIndexNamed: @"AvgIndex" forQuery: q]);
+    
     numRows = [self verifyQuery: q randomAccess: NO  test: ^(uint64_t n, CBLQueryResult *r) {
         NSArray* numbers = [[r arrayAtIndex:0] toArray];
         Assert(numbers.count > 0);

--- a/Swift/Tests/CBLTestCase.swift
+++ b/Swift/Tests/CBLTestCase.swift
@@ -334,6 +334,13 @@ class CBLTestCase: XCTestCase {
         return n
     }
     
+    func isUsingIndex(named indexName: String, for query: Query) throws -> Bool {
+        let plan = try query.explain()
+        let usingIndex = "USING INDEX \(indexName)"
+        let usingCoveringIndex = "USING COVERING INDEX \(indexName)"
+        return plan.contains(usingIndex) || plan.contains(usingCoveringIndex)
+    }
+    
     func getRickAndMortyJSON() throws -> String {
         var content = "Earth(C-137)".data(using: .utf8)!
         var blob = Blob(contentType: "text/plain", data: content)

--- a/Swift/Tests/DatabaseTest.swift
+++ b/Swift/Tests/DatabaseTest.swift
@@ -177,16 +177,14 @@ class DatabaseTest: CBLTestCase {
             .from(DataSource.collection(defaultCollection!))
             .where(key.greaterThan(Expression.int(9)))
         
-        var explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX KeyIndex").location, NSNotFound)
+        XCTAssert(try isUsingIndex(named: "KeyIndex", for: q))
         
         // Reindex:
         try db.performMaintenance(type: .reindex)
         
         // Check if the index is still there and used:
         XCTAssertEqual(try defaultCollection!.indexes().count, 1)
-        explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX KeyIndex").location, NSNotFound)
+        XCTAssert(try isUsingIndex(named: "KeyIndex", for: q))
     }
     
     func testPerformMaintenanceIntegrityCheck() throws {

--- a/Swift/Tests/PartialIndexTest.swift
+++ b/Swift/Tests/PartialIndexTest.swift
@@ -50,13 +50,11 @@ class PartialIndexTest: CBLTestCase {
 
         var sql = "SELECT * FROM _ WHERE type = 'number' AND num > 1000"
         var q = try db.createQuery(sql)
-        var explain = try q.explain()
-        XCTAssert(explain.contains("USING INDEX numIndex"))
+        XCTAssert(try isUsingIndex(named: "numIndex", for: q))
         
         sql = "SELECT * FROM _ WHERE type = 'foo' AND num > 1000"
         q = try db.createQuery(sql)
-        explain = try q.explain()
-        XCTAssertFalse(explain.contains("USING INDEX numIndex"))
+        XCTAssertFalse(try isUsingIndex(named: "numIndex", for: q))
     }
     
     /// 2. TestCreatePartialFullTextIndex

--- a/Swift/Tests/PredictiveQueryTest.swift
+++ b/Swift/Tests/PredictiveQueryTest.swift
@@ -491,9 +491,8 @@ class PredictiveQueryTest: CBLTestCase {
             .select(SelectResult.property("numbers"), SelectResult.expression(prediction.property("sum")).as("sum"))
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("sum").equalTo(Expression.value(15)))
-        
-        let explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
+
+        XCTAssert(try isUsingIndex(named: "SumIndex", for: q))
         
         let rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -530,9 +529,8 @@ class PredictiveQueryTest: CBLTestCase {
             .where(prediction.property("sum").lessThanOrEqualTo(Expression.value(15)).or(
                    prediction.property("avg").equalTo(Expression.value(8))))
         
-        let explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
-        XCTAssertNotEqual(explain.range(of: "USING INDEX AvgIndex").location, NSNotFound)
+        XCTAssert(try isUsingIndex(named: "SumIndex", for: q))
+        XCTAssert(try isUsingIndex(named: "AvgIndex", for: q))
         
         let rows = try verifyQuery(q) { (n, r) in
             XCTAssert(r.int(at: 0) == 15 || r.int(at: 1) == 8)
@@ -562,8 +560,7 @@ class PredictiveQueryTest: CBLTestCase {
             .where(prediction.property("sum").equalTo(Expression.value(15)).and(
                    prediction.property("avg").equalTo(Expression.value(3))))
         
-        let explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumAvgIndex").location, NSNotFound)
+        XCTAssert(try isUsingIndex(named: "SumAvgIndex", for: q))
         
         let rows = try verifyQuery(q) { (n, r) in
             XCTAssertEqual(r.int(at: 0), 15)
@@ -593,8 +590,7 @@ class PredictiveQueryTest: CBLTestCase {
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("sum").equalTo(Expression.value(15)))
         
-        let explain = try q.explain() as NSString
-        XCTAssertEqual(explain.range(of: "USING INDEX AggIndex").location, NSNotFound)
+        XCTAssertFalse(try isUsingIndex(named: "AggIndex", for: q))
         
         let rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -629,8 +625,7 @@ class PredictiveQueryTest: CBLTestCase {
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("sum").equalTo(Expression.value(15)))
         
-        let explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
+        XCTAssert(try isUsingIndex(named: "SumIndex", for: q))
         
         let rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -669,9 +664,8 @@ class PredictiveQueryTest: CBLTestCase {
             .where(prediction.property("sum").lessThanOrEqualTo(Expression.value(15)).or(
                 prediction.property("avg").equalTo(Expression.value(8))))
         
-        let explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
-        XCTAssertNotEqual(explain.range(of: "USING INDEX AvgIndex").location, NSNotFound)
+        XCTAssert(try isUsingIndex(named: "SumIndex", for: q))
+        XCTAssert(try isUsingIndex(named: "AvgIndex", for: q))
         
         let rows = try verifyQuery(q) { (n, r) in
             XCTAssert(r.int(at: 0) == 15 || r.int(at: 1) == 8)
@@ -703,8 +697,7 @@ class PredictiveQueryTest: CBLTestCase {
             .where(prediction.property("sum").equalTo(Expression.value(15)).and(
                 prediction.property("avg").equalTo(Expression.value(3))))
         
-        let explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumAvgIndex").location, NSNotFound)
+        XCTAssert(try isUsingIndex(named: "SumAvgIndex", for: q))
         
         let rows = try verifyQuery(q) { (n, r) in
             XCTAssertEqual(r.int(at: 0), 15)
@@ -737,7 +730,7 @@ class PredictiveQueryTest: CBLTestCase {
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("sum").equalTo(Expression.value(15)))
         var explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
+        XCTAssertNotEqual(explain.range(of: "USING COVERING INDEX SumIndex").location, NSNotFound)
         
         var rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -756,7 +749,7 @@ class PredictiveQueryTest: CBLTestCase {
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("sum").equalTo(Expression.value(15)))
         explain = try q.explain() as NSString
-        XCTAssertEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
+        XCTAssertEqual(explain.range(of: "USING COVERING INDEX SumIndex").location, NSNotFound)
         
         rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -797,9 +790,9 @@ class PredictiveQueryTest: CBLTestCase {
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("sum").lessThanOrEqualTo(Expression.value(15)).or(
                    prediction.property("avg").equalTo(Expression.value(8))))
-        var explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
-        XCTAssertNotEqual(explain.range(of: "USING INDEX AvgIndex").location, NSNotFound)
+        
+        XCTAssert(try isUsingIndex(named: "SumIndex", for: q))
+        XCTAssert(try isUsingIndex(named: "AvgIndex", for: q))
         
         var rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -819,8 +812,7 @@ class PredictiveQueryTest: CBLTestCase {
         .from(DataSource.collection(defaultCollection!))
         .where(prediction.property("sum").equalTo(Expression.value(15)))
         
-        explain = try q.explain() as NSString
-        XCTAssertEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
+        XCTAssertFalse(try isUsingIndex(named: "SumIndex", for: q))
         
         rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -834,8 +826,8 @@ class PredictiveQueryTest: CBLTestCase {
             .select(SelectResult.property("numbers"))
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("avg").equalTo(Expression.value(8)))
-        explain = try q.explain() as NSString
-        XCTAssertNotEqual(explain.range(of: "USING INDEX AvgIndex").location, NSNotFound)
+        
+        XCTAssert(try isUsingIndex(named: "AvgIndex", for: q))
         
         rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -852,8 +844,8 @@ class PredictiveQueryTest: CBLTestCase {
             .select(SelectResult.property("numbers"))
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("avg").equalTo(Expression.value(8)))
-        explain = try q.explain() as NSString
-        XCTAssertEqual(explain.range(of: "USING INDEX AvgIndex").location, NSNotFound)
+        
+        XCTAssertFalse(try isUsingIndex(named: "AvgIndex", for: q))
         
         rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray
@@ -871,9 +863,9 @@ class PredictiveQueryTest: CBLTestCase {
             .from(DataSource.collection(defaultCollection!))
             .where(prediction.property("sum").lessThanOrEqualTo(Expression.value(15)).or(
                 prediction.property("avg").equalTo(Expression.value(8))))
-        explain = try q.explain() as NSString
-        XCTAssertEqual(explain.range(of: "USING INDEX SumIndex").location, NSNotFound)
-        XCTAssertEqual(explain.range(of: "USING INDEX AvgIndex").location, NSNotFound)
+        
+        XCTAssertFalse(try isUsingIndex(named: "SumIndex", for: q))
+        XCTAssertFalse(try isUsingIndex(named: "AvgIndex", for: q))
         
         rows = try verifyQuery(q) { (n, r) in
             let numbers = r.array(at: 0)!.toArray() as NSArray


### PR DESCRIPTION
* CBL-7196: Predictive Queries test failing when running with CBL 3.3.0
* CBL-7200: LITECORE_VERSION_STRING should be set to 0.0.0 in Project.xcconfig
* CBL-7195: Upgrade SQLite to the latest release, 3.50.3
* Per changes in SQLite's explain plan (since v3.48.0), update USING INDEX assertions to include COVERING INDEX in Query and Predictive tests.