### PR TITLE
CBL-7234 : Sync ReplicatorConfiguration API with Multipeer Version

### DIFF
--- a/Objective-C/CBLCollectionConfiguration.h
+++ b/Objective-C/CBLCollectionConfiguration.h
@@ -20,11 +20,18 @@
 #import <Foundation/Foundation.h>
 #import <CouchbaseLite/CBLReplicatorTypes.h>
 
+@class CBLCollection;
+
 @protocol CBLConflictResolver;
 
 NS_ASSUME_NONNULL_BEGIN
 /** The collection configuration that can be configured specifically for the replication. */
 @interface CBLCollectionConfiguration : NSObject
+
+/**
+ The custom conflict resolver function.
+ If this value is nil, the default conflict resolver will be used. */
+@property (nonatomic, readonly, nullable) CBLCollection* collection;
 
 /**
  The custom conflict resolver function.
@@ -54,6 +61,35 @@ NS_ASSUME_NONNULL_BEGIN
  Document IDs filter to limit the documents in the collection to be replicated
  with the remote endpoint. If not specified, all docs in the collection will be replicated. */
 @property (nonatomic, nullable) NSArray<NSString*>* documentIDs;
+
+/**
+ Initializes a collection configuration with the given collection.
+ 
+ @param collection The collection instance.
+ */
+- (instancetype) initWithCollection: (CBLCollection*)collection;
+
+/**
+ Initializes a collection configuration.
+
+ @deprecated Use `-initWithCollection:` instead.
+ */
+- (instancetype) init __deprecated_msg("Use -initWithCollection: instead.");
+
+/**
+ Creates an array of `CBLCollectionConfiguration` objects from the given collections.
+ 
+ Each collection is wrapped in a `CBLCollectionConfiguration`using default settings
+ (no filters and no custom conflict resolvers).
+
+ This is a convenience method for configuring multiple collections with default configurations.
+ If custom configurations are needed, construct `CBLCollectionConfiguration` objects
+ directly instead.
+       
+ @param collections The collections to replicate.
+ @return An array of CBLCollectionConfiguration objects for the given collections.
+ */
++ (NSArray<CBLCollectionConfiguration*>*) fromCollections: (NSArray<CBLCollection*>*)collections;
 
 @end
 

--- a/Objective-C/CBLCollectionConfiguration.m
+++ b/Objective-C/CBLCollectionConfiguration.m
@@ -17,16 +17,32 @@
 //  limitations under the License.
 //
 #import "CBLCollectionConfiguration.h"
+#import "CBLCollection+Internal.h"
+#import "CBLPrecondition.h"
 
 @implementation CBLCollectionConfiguration
 
+@synthesize collection=_collection;
 @synthesize documentIDs=_documentIDs, channels=_channels;
 @synthesize pushFilter=_pushFilter, pullFilter=_pullFilter;
 @synthesize conflictResolver=_conflictResolver;
 
+- (instancetype) init {
+    return [super init];
+}
+
+- (instancetype) initWithCollection: (CBLCollection*)collection {
+    self = [super init];
+    if (self) {
+        _collection = collection;
+    }
+    return self;
+}
+
 - (instancetype) initWithConfig: (CBLCollectionConfiguration*)config {
     self = [super init];
     if (self) {
+        _collection = config.collection;
         _documentIDs = config.documentIDs;
         _channels = config.channels;
         _pushFilter = config.pushFilter;
@@ -34,6 +50,15 @@
         _conflictResolver = config.conflictResolver;
     }
     return self;
+}
+
++ (NSArray<CBLCollectionConfiguration*>*) fromCollections: (NSArray<CBLCollection*>*)collections {
+    [CBLPrecondition assertArrayNotEmpty: collections name: @"collections"];
+    NSMutableArray* configs = [NSMutableArray arrayWithCapacity: collections.count];
+    for (CBLCollection* collection in collections) {
+        [configs addObject: [[CBLCollectionConfiguration alloc] initWithCollection: collection]];
+    }
+    return configs;
 }
 
 - (NSDictionary*) effectiveOptions {

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -280,8 +280,8 @@ typedef enum {
     std::vector<C4ReplicationCollection> cols;
     std::vector<alloc_slice> optionDicts;
     
-    for (CBLCollection* col in _config.collectionConfigs) {
-        CBLCollectionConfiguration* colConfig = _config.collectionConfigs[col];
+    for (CBLCollection* col in _config.collectionConfigMap) {
+        CBLCollectionConfiguration* colConfig = _config.collectionConfigMap[col];
         
         alloc_slice dict = [self encodedOptions: colConfig.effectiveOptions];
         optionDicts.push_back(dict);

--- a/Objective-C/Internal/CBLPrecondition.h
+++ b/Objective-C/Internal/CBLPrecondition.h
@@ -23,7 +23,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CBLPrecondition : NSObject
 
-+ (void) validateParam: (BOOL (^)(void))condition message: (NSString *)message;
+/** Asserts that the specified condition is true */
++ (void) assert: (BOOL)condition message: (NSString*)message;
+
+/** Asserts that the specified condition is true */
++ (void) assert: (BOOL)condition format: (NSString*)format, ... NS_FORMAT_FUNCTION(2,3);
+
+/** Asserts that the specified object is not nil. */
++ (void) assertNotNil: (nullable id)object name: (NSString*)name;
+
+/** Asserts that the specified array is not nil and not empty. */
++ (void) assertArrayNotEmpty: (nullable NSArray*)array name: (NSString*)name;
 
 @end
 

--- a/Objective-C/Internal/CBLPrecondition.m
+++ b/Objective-C/Internal/CBLPrecondition.m
@@ -21,12 +21,33 @@
 
 @implementation CBLPrecondition
 
-+ (void) validateParam: (BOOL (^)(void))condition message: (NSString *)message {
-    if (!condition()) {
++ (void) assert: (BOOL)condition message: (NSString*)message {
+    if (!condition) {
         @throw [NSException exceptionWithName: NSInvalidArgumentException
                                        reason: message
                                      userInfo: nil];
     }
+}
+
++ (void) assert: (BOOL)condition format: (NSString*)format, ... {
+    if (!condition) {
+        va_list args;
+        va_start(args, format);
+        NSString *reason = [[NSString alloc] initWithFormat: format arguments: args];
+        va_end(args);
+        @throw [NSException exceptionWithName: NSInvalidArgumentException
+                                       reason: reason
+                                     userInfo: nil];
+    }
+}
+
++ (void) assertNotNil: (nullable id)object name: (NSString*)name {
+    [self assert: (object != nil) format: @"%@ must not be nil.", name];
+}
+
++ (void) assertArrayNotEmpty: (NSArray*)array name: (NSString*)name {
+    [self assertNotNil: array name: name];
+    [self assert: (array.count > 0) format: @"%@ must not be empty", name];
 }
 
 @end

--- a/Objective-C/Internal/CBLReplicator+Internal.h
+++ b/Objective-C/Internal/CBLReplicator+Internal.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) CBLDatabase* database;
 @property (readonly, nonatomic) NSDictionary* effectiveOptions;
 @property (nonatomic) NSTimeInterval checkpointInterval;
-@property (nonatomic) NSMutableDictionary<CBLCollection*, CBLCollectionConfiguration*>* collectionConfigs;
+@property (nonatomic) NSMutableDictionary<CBLCollection*, CBLCollectionConfiguration*>* collectionConfigMap;
 
 #ifdef COUCHBASE_ENTERPRISE
 @property (nonatomic) BOOL acceptOnlySelfSignedServerCertificate;

--- a/Objective-C/Tests/MultipeerReplicatorTest.m
+++ b/Objective-C/Tests/MultipeerReplicatorTest.m
@@ -1099,7 +1099,6 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
     [self stopMultipeerReplicator: repl1];
     [self stopMultipeerReplicator: repl2];
     
-    /*
     // Update the doc in both peers but saving on the otherDB twice:
     collection1 = [self.db defaultCollection: nil];
     doc1 = [[collection1 documentWithID: @"doc1" error: nil] toMutable];
@@ -1129,8 +1128,8 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
     [self startMultipeerReplicator: repl2];
     
     // Wait until the replicator is IDLE
-    [self waitForReplicatorStatus: repl1 peerID: repl2.peerID activityLevel: kCBLReplicatorIdle timeout: kExpTimeout];
-    [self waitForReplicatorStatus: repl2 peerID: repl1.peerID activityLevel: kCBLReplicatorIdle timeout: kExpTimeout];
+    [self waitForReplicatorStatus: repl1 peerID: repl2.peerID activityLevel: kCBLReplicatorIdle];
+    [self waitForReplicatorStatus: repl2 peerID: repl1.peerID activityLevel: kCBLReplicatorIdle];
     
     // Check the doc on both peers:
     CBLDocument* checkDoc1 = [collection1 documentWithID: @"doc1" error: nil];
@@ -1141,7 +1140,6 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
     
     [self stopMultipeerReplicator: repl1];
     [self stopMultipeerReplicator: repl2];
-    */
 }
 
  /**

--- a/Objective-C/Tests/ReplicatorTest+CustomConflict.m
+++ b/Objective-C/Tests/ReplicatorTest+CustomConflict.m
@@ -1007,34 +1007,6 @@
     Assert(localDoc.c4Doc.revFlags & kRevHasAttachments & localRevFlags);
 }
 
-- (void) testCollection {
-    id target = [[CBLURLEndpoint alloc] initWithURL: [NSURL URLWithString: @"wss://foo"]];
-    CBLReplicatorConfiguration* config = [[CBLReplicatorConfiguration alloc]
-                                          initWithTarget: target];
-    NSError* error = nil;
-    CBLCollection* c1 = [self.db createCollectionWithName: @"collection1" scope: @"scope1" error: &error];
-    CBLCollectionConfiguration* cConfig = [[CBLCollectionConfiguration alloc] init];
-    
-    TestConflictResolver* r;
-    r = [[TestConflictResolver alloc] initWithResolver: ^CBLDocument* (CBLConflict* c) { return c.localDocument; }];
-    [cConfig setConflictResolver: r];
-    [cConfig setPushFilter:^BOOL(CBLDocument* d, CBLDocumentFlags f) { return YES; }];
-    [cConfig setPullFilter:^BOOL(CBLDocument* d, CBLDocumentFlags f) { return YES; }];
-    [cConfig setChannels: @[@"channel1", @"channel2"]];
-    [cConfig setDocumentIDs: @[@"doc-id-1", @"doc-id-2"]];
-    
-    [config addCollection: c1 config: cConfig];
-    [config addCollections: @[c1] config: cConfig];
-    
-    CBLReplicator* re = [[CBLReplicator alloc] initWithConfig: [self config: kCBLReplicatorTypePull]];
-    [re addDocumentReplicationListener:^(CBLDocumentReplication * docReplication) {
-        for (CBLReplicatedDocument* doc in docReplication.documents) {
-            AssertNil(doc.collection); // collection inside replicatedDocument
-        }
-    }];
-    AssertEqual(config.collections.count, 1);
-}
-
 #endif
 #pragma clang diagnostic pop
 

--- a/Objective-C/Tests/ReplicatorTest+SG.m
+++ b/Objective-C/Tests/ReplicatorTest+SG.m
@@ -25,6 +25,9 @@
 
 @implementation ReplicatorTest_SG
 
+// TODO: Remove https://issues.couchbase.com/browse/CBL-3206
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 - (void) testAuthenticationFailure_SG {
     id target = [self remoteEndpointWithName: @"seekrit" secure: YES];
@@ -278,5 +281,7 @@
     CBLDocument* savedDoc = [self.db documentWithID: doc.id];
     AssertNil([savedDoc stringForKey: propertyKey]);
 }
+
+#pragma clang diagnostic pop
 
 @end

--- a/Objective-C/Tests/ReplicatorTest.h
+++ b/Objective-C/Tests/ReplicatorTest.h
@@ -104,6 +104,16 @@ NS_ASSUME_NONNULL_BEGIN
                                       serverCert: (nullable SecCertificateRef)serverCert;
 #endif
 
+- (CBLReplicatorConfiguration*) configWithCollectionConfigs: (NSArray<CBLCollectionConfiguration*>*)configs
+                                                     target: (id<CBLEndpoint>)target
+                                                       type: (CBLReplicatorType)type
+                                                 continuous: (BOOL)continuous;
+
+- (CBLReplicatorConfiguration*) configWithCollections: (NSArray<CBLCollection*>*)collections
+                                               target: (id<CBLEndpoint>)target
+                                                 type: (CBLReplicatorType)type
+                                           continuous: (BOOL)continuous;
+
 #pragma mark - Run Replicator
 
 - (BOOL) run: (CBLReplicatorConfiguration*)config

--- a/Objective-C/Tests/URLEndpointListenerTest+Collection.m
+++ b/Objective-C/Tests/URLEndpointListenerTest+Collection.m
@@ -67,11 +67,15 @@
     Config* config = [[Config alloc] initWithCollections: @[col2a, col2b]];
     [self listen: config];
     
-    CBLReplicatorConfiguration* rConfig = [[CBLReplicatorConfiguration alloc] initWithTarget: _listener.localEndpoint];
+    NSArray<CBLCollectionConfiguration*>* collections =
+    [CBLCollectionConfiguration fromCollections: @[col1a, col1b]];
+    
+    CBLReplicatorConfiguration* rConfig =
+    [[CBLReplicatorConfiguration alloc] initWithCollections: collections target: _listener.localEndpoint];
     rConfig.pinnedServerCertificate = (__bridge SecCertificateRef) _listener.tlsIdentity.certs[0];
-    [rConfig addCollections: @[col1a, col1b] config: nil];
     
     [self run: rConfig errorCode: 0 errorDomain: nil];
+    
     AssertEqual(col1a.count, 3);
     AssertEqual(col1b.count, 5);
     AssertEqual(col2a.count, 3);
@@ -111,12 +115,16 @@
     Config* config = [[Config alloc] initWithCollections: @[col2a, col2b]];
     [self listen: config];
     
-    CBLReplicatorConfiguration* rConfig = [[CBLReplicatorConfiguration alloc] initWithTarget: _listener.localEndpoint];
+    NSArray<CBLCollectionConfiguration*>* collections =
+    [CBLCollectionConfiguration fromCollections: @[col1a, col1b]];
+    
+    CBLReplicatorConfiguration* rConfig =
+    [[CBLReplicatorConfiguration alloc] initWithCollections: collections target: _listener.localEndpoint];
     rConfig.continuous = YES;
     rConfig.pinnedServerCertificate = (__bridge SecCertificateRef) _listener.tlsIdentity.certs[0];
-    [rConfig addCollections: @[col1a, col1b] config: nil];
     
     [self run: rConfig errorCode: 0 errorDomain: nil];
+    
     AssertEqual(col1a.count, 10);
     AssertEqual(col1b.count, 10);
     AssertEqual(col2a.count, 10);
@@ -145,9 +153,12 @@
     Config* config = [[Config alloc] initWithCollections: @[colB]];
     [self listen: config];
     
-    CBLReplicatorConfiguration* rConfig = [[CBLReplicatorConfiguration alloc] initWithTarget: _listener.localEndpoint];
+    NSArray<CBLCollectionConfiguration*>* collections =
+    [CBLCollectionConfiguration fromCollections: @[colA]];
+    
+    CBLReplicatorConfiguration* rConfig =
+    [[CBLReplicatorConfiguration alloc] initWithCollections: collections target: _listener.localEndpoint];
     rConfig.pinnedServerCertificate = (__bridge SecCertificateRef) _listener.tlsIdentity.certs[0];
-    [rConfig addCollections: @[colA] config: nil];
     
     [self run: rConfig errorCode: CBLErrorHTTPNotFound errorDomain: CBLErrorDomain];
     

--- a/Objective-C/Tests/URLEndpointListenerTest+Main.m
+++ b/Objective-C/Tests/URLEndpointListenerTest+Main.m
@@ -811,9 +811,7 @@
 }
 
 - (void) testEmptyNetworkInterface {
-#if TARGET_OS_OSX
     XCTSkip(@"Not applicable test on some network environment");
-#endif
     
     if (!self.keyChainAccessAllowed) return;
     
@@ -977,11 +975,11 @@
     
     // Push Replication to ReadOnly Listener
     [self ignoreException: ^{
-        [self runWithTarget: _listener.localEndpoint
+        [self runWithTarget: self->_listener.localEndpoint
                        type: kCBLReplicatorTypePushAndPull
                  continuous: NO
               authenticator: nil
-                 serverCert: (__bridge SecCertificateRef) _listener.tlsIdentity.certs[0]
+                 serverCert: (__bridge SecCertificateRef) self->_listener.tlsIdentity.certs[0]
                   errorCode: CBLErrorHTTPForbidden
                 errorDomain: CBLErrorDomain];
     }];
@@ -1213,7 +1211,7 @@
     
     [self ignoreException:^{
         NSError* error = nil;
-        Assert([_listener startWithError: &error]);
+        Assert([self->_listener startWithError: &error]);
         AssertNil(error);
     }];
     
@@ -1442,7 +1440,7 @@
     
     // Reject the server with non-self-signed cert
     [self ignoreException: ^{
-        [self runWithTarget: _listener.localEndpoint
+        [self runWithTarget: self->_listener.localEndpoint
                        type: kCBLReplicatorTypePushAndPull
                  continuous: NO
               authenticator: nil

--- a/Swift/Precondition.swift
+++ b/Swift/Precondition.swift
@@ -21,7 +21,11 @@ import Foundation
 import CouchbaseLiteSwift_Private
 
 class Precondition {
-    static func validateParam(_ condition: @autoclosure @escaping () -> Bool, message: String) {
-        CBLPrecondition.validateParam({ condition() }, message: message)
+    static func assert(_ condition: @autoclosure () -> Bool, message: String) {
+        precondition(condition(), message)
+    }
+    
+    static func assertNotEmpty<C: Swift.Collection>(_ collection: C, name: String) {
+        precondition(!collection.isEmpty, "\(name) must not be empty.")
     }
 }

--- a/Swift/Tests/ReplicatorTest+PendingDocIds.swift
+++ b/Swift/Tests/ReplicatorTest+PendingDocIds.swift
@@ -44,15 +44,16 @@ class ReplicatorTest_PendingDocIds: ReplicatorTest {
     }
     
     func validatePendingDocumentIDs(_ docIds: Set<String>, pushOnlyDocIds: Set<String>? = nil) throws {
-        var replConfig = config(target: DatabaseEndpoint(database: otherDB!), type: .push, continuous: false)
-        var colConfig = CollectionConfiguration()
+        var colConfig = CollectionConfiguration(collection: defaultCollection!)
         if let pushOnlyDocIds = pushOnlyDocIds, pushOnlyDocIds.count > 0 {
             colConfig.pushFilter = { (doc, flags) -> Bool in
                 return pushOnlyDocIds.contains(doc.id)
             }
         }
-        replConfig.addCollection(defaultCollection!, config: colConfig)
-        let replicator = Replicator(config: replConfig)
+        
+        let config = config(configs: [colConfig], target: DatabaseEndpoint(database: otherDB!),
+                                type: .push, continuous: false)
+        let replicator = Replicator(config: config)
         
         // Check document pending:
         let defaultCollection = try self.db.defaultCollection()
@@ -92,9 +93,8 @@ class ReplicatorTest_PendingDocIds: ReplicatorTest {
     
     func testPendingDocIDsPullOnlyException() throws {
         let target = DatabaseEndpoint(database: otherDB!)
-        var replConfig = config(target: target, type: .pull, continuous: false)
-        replConfig.addCollection(defaultCollection!)
-        let replicator = Replicator(config: replConfig)
+        let config = config(collections: [defaultCollection!], target: target, type: .pull, continuous: false)
+        let replicator = Replicator(config: config)
         
         var pullOnlyError: NSError? = nil
         do {
@@ -116,9 +116,8 @@ class ReplicatorTest_PendingDocIds: ReplicatorTest {
         let _ = try createDocs()
         
         let target = DatabaseEndpoint(database: otherDB!)
-        var replConfig = config(target: target, type: .push, continuous: false)
-        replConfig.addCollection(defaultCollection!)
-        run(config: replConfig, expectedError: nil)
+        let config = config(collections: [defaultCollection!], target: target, type: .push, continuous: false)
+        run(config: config, expectedError: nil)
         
         let updatedIds: Set<String> = ["doc-2", "doc-4"]
         for docId in updatedIds {
@@ -135,9 +134,8 @@ class ReplicatorTest_PendingDocIds: ReplicatorTest {
         let _ = try createDocs()
         
         let target = DatabaseEndpoint(database: otherDB!)
-        var replConfig = config(target: target, type: .push, continuous: false)
-        replConfig.addCollection(defaultCollection!)
-        run(config: replConfig, expectedError: nil)
+        let config = config(collections: [defaultCollection!], target: target, type: .push, continuous: false)
+        run(config: config, expectedError: nil)
         
         let deletedIds: Set<String> = ["doc-2", "doc-4"]
         for docId in deletedIds {

--- a/Swift/Tests/URLEndpointListenerTest+Collection.swift
+++ b/Swift/Tests/URLEndpointListenerTest+Collection.swift
@@ -48,9 +48,9 @@ class URLEndpointListenerTest_Collection: URLEndpointListenerTest {
         let config = URLEndpointListenerConfiguration(collections: [col2a, col2b])
         let listener = try startListener(withConfig: config)
         
-        var rConfig = ReplicatorConfiguration(target: listener.localURLEndpoint)
+        let collections = CollectionConfiguration.fromCollections([col1a, col1b])
+        var rConfig = ReplicatorConfiguration(collections: collections, target: listener.localURLEndpoint)
         rConfig.pinnedServerCertificate = listener.tlsIdentity!.certs[0]
-        rConfig.addCollections([col1a, col1b])
         
         run(config: rConfig, expectedError: nil)
         XCTAssertEqual(col1a.count, 3)
@@ -80,10 +80,10 @@ class URLEndpointListenerTest_Collection: URLEndpointListenerTest {
         let config = URLEndpointListenerConfiguration(collections: [col2a, col2b])
         let listener = try startListener(withConfig: config)
         
-        var rConfig = ReplicatorConfiguration(target: listener.localURLEndpoint)
+        let collections = CollectionConfiguration.fromCollections([col1a, col1b])
+        var rConfig = ReplicatorConfiguration(collections: collections, target: listener.localURLEndpoint)
         rConfig.continuous = true
         rConfig.pinnedServerCertificate = listener.tlsIdentity!.certs[0]
-        rConfig.addCollections([col1a, col1b])
         
         run(config: rConfig, expectedError: nil)
         XCTAssertEqual(col1a.count, 10)
@@ -105,9 +105,9 @@ class URLEndpointListenerTest_Collection: URLEndpointListenerTest {
         let config = URLEndpointListenerConfiguration(collections: [col2b])
         let listener = try startListener(withConfig: config)
         
-        var rConfig = ReplicatorConfiguration(target: listener.localURLEndpoint)
+        let collections = CollectionConfiguration.fromCollections([col1a])
+        var rConfig = ReplicatorConfiguration(collections: collections, target: listener.localURLEndpoint)
         rConfig.pinnedServerCertificate = listener.tlsIdentity!.certs[0]
-        rConfig.addCollections([col1a])
         
         run(config: rConfig, expectedError: CBLError.httpNotFound)
         try stopListener()


### PR DESCRIPTION
CBL-7234:
* Added ReplicatorConfiguration’s init(collections: [CollectionConfiguration], target: Endpoint)
* Added ReplicatorConfiguration’s collectionConfigs property (cannot do collections as it’s already exists).
* Added CollectionConfiguration's init(collection: Collection) for creating with a collection object.
* Added CollectionConfigurationps fromCollections(_ [Collection]) -> [CollectionConfiguration's]
* Updated tests to use the new APIs and cleaned up some tests.

CBL-7236:
* Deprecated ReplicatorConfiguration’s init(target: Endpoint)

CBL-7238:
* Deprecated ReplicatorConfiguration’s functions for managing collections and their configurations (addCollections, removeCollections, getCollections, getCollectionConfig)

CBL-7249:
* Deprecated CollectionConfiguration’s init()

CBL-7226:
* Add info about default collection used in the replication when creating ReplicatorConfiguration with database object