### PR TITLE
CBL-7351: Return error for AnchorTrusted in CBLCheckTrust

### DIFF
--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -965,7 +965,10 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
                                                   kCFStreamPropertySSLPeerTrust);
 }
 
-// Notify the received cert and verify the cert if using custom verification logic
+// Handles SSL certificate validation for the peer.
+// Performs custom trust evaluation if enabled, notifies certificate to
+// CBLWebSocketContext's callback and C4Socket and closes the connection on failure.
+// Returns YES if the certificate is accepted.
 - (BOOL) checkSSLCert {
     _shouldCheckSSLCert = NO;
     
@@ -974,10 +977,16 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
     
     SecCertificateRef cert = [self certificateFromTrust: trust];
     [self notifyServerCertificateReceived: cert];
-
+    
     NSError* error = nil;
+    
+    // Validate trust only when using custom certificate validation
+    // (kCFStreamSSLValidatesCertificateChain is disabled).
+    // If system validation is enabled, the certificates have already been verified,
+    // and any validation failure will trigger NSStreamEventErrorOccurred without
+    // calling this method.
     if ([self usesCustomTLSCertValidation]) {
-        if (![self validateTrust:trust error:&error]) {
+        if (![self validateTrust: trust error: &error]) {
             [self closeWithError: error];
             return NO;
         }
@@ -1010,18 +1019,17 @@ static BOOL checkHeader(NSDictionary* headers, NSString* header, NSString* expec
     NSURL* url = _logic.URL;
     CBLTrustCheck* check = [[CBLTrustCheck alloc] initWithTrust: trust host: url.host port: url.port.shortValue];
     
-    NSURLCredential* credentials = nil;
     Value pinnedCert = _options[kC4ReplicatorOptionPinnedServerCert];
     if (pinnedCert) {
         check.pinnedCertData = slice(pinnedCert.asData()).copiedNSData();
-        credentials = [check checkTrust: error];
     }
 #ifdef COUCHBASE_ENTERPRISE
     else if (_options[kC4ReplicatorOptionOnlySelfSignedServerCert].asBool()) {
         check.acceptOnlySelfSignedCert = YES;
-        credentials = [check checkTrust: error];
     }
 #endif
+    
+    NSURLCredential* credentials = [check checkTrust: error];
     if (!credentials) {
         CBLWarn(WebSocket, @"%@: TLS handshake failed: certificate verification error: %@", self, (*error).localizedDescription);
         return false;

--- a/Objective-C/Tests/MultipeerReplicatorTest.m
+++ b/Objective-C/Tests/MultipeerReplicatorTest.m
@@ -85,13 +85,13 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
 
 // TODO: Too flaky, enable after all LiteCore issues have been handled.
 - (BOOL) isExecutionAllowed {
-#if TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST || TARGET_OS_OSX
     // Cannot be tested on the simulator as local network access permission is required.
     // See FAQ-12 : https://developer.apple.com/forums/thread/663858)
     return NO;
 #else
     // Disable as cannot be run on the build VM (Got POSIX Error 50, Network is down)
-    return self.keyChainAccessAllowed && false;
+    return self.keyChainAccessAllowed;
 #endif
 }
 
@@ -408,6 +408,7 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
  4. Check that the configuration cannot be created as the collections are empty.
  */
 - (void) testConfigurationValidation {
+    // When exception is thrown, the object will not get released:
     self.disableObjectLeakCheck = YES;
     
     CBLCollection* collection = [self.db defaultCollection: nil];
@@ -1092,8 +1093,6 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
     // Wait until the replicator is IDLE
     [self waitForReplicatorStatus: repl1 peerID: repl2.peerID activityLevel: kCBLReplicatorIdle];
     [self waitForReplicatorStatus: repl2 peerID: repl1.peerID activityLevel: kCBLReplicatorIdle];
-    
-    NSLog(@"-----------------------------------------");
     
     // Stops:
     [self stopMultipeerReplicator: repl1];

--- a/Objective-C/Tests/TrustCheckTest.m
+++ b/Objective-C/Tests/TrustCheckTest.m
@@ -228,7 +228,7 @@
     SecCertificateRef secCert3 = [self createSecCertFromPEM: cert3];
     
     SecTrustRef trust;
-    SecPolicyRef policy = SecPolicyCreateSSL(true, (__bridge CFStringRef)_host);
+    SecPolicyRef policy = SecPolicyCreateBasicX509();
     
     // Validate leaf cert:
     
@@ -239,8 +239,7 @@
     NSError* error;
     NSURLCredential* credential;
     
-    
-    CBLTrustCheck* trustCheck = [[CBLTrustCheck alloc] initWithTrust: trust host: _host port: 443];
+    CBLTrustCheck* trustCheck = [[CBLTrustCheck alloc] initWithTrust: trust];
     credential = [trustCheck checkTrust: &error];
     AssertNil(credential);
     
@@ -261,7 +260,7 @@
     status = SecTrustCreateWithCertificates((__bridge CFTypeRef)certs, policy, &trust);
     AssertEqual(status, errSecSuccess);
     
-    trustCheck = [[CBLTrustCheck alloc] initWithTrust: trust host: _host port: 443];
+    trustCheck = [[CBLTrustCheck alloc] initWithTrust: trust];
     credential = [trustCheck checkTrust: &error];
     AssertNil(credential);
     


### PR DESCRIPTION
* MultipeerReplicatorTest.testAuthenticateWithRootCertsFailed failed on iOS devices but passed on macOS.

* The issue was that CBLTrustCheck didn’t return an error for AnchorTrusted problems — it didn’t return NO. On macOS the trust validation failed outright, but on iOS it was a recoverable error and required additional checks.

* Refactor CBLTrustCheck to skip host check only when the host is not specified.

* Add comments in CBLWebSocket and simplify the trust check calls.

* Update TrustCheckTest and clean up MultipeerReplicatorTest.

* Manual replication test performed to verify CBLTrustCheck and CBLWebSocket still work with standard wss:// servers.