### PR TITLE
CBL-7355 : Ensure to use different CN in MultipeerReplicatorTest

### DIFF
--- a/Objective-C/Tests/MultipeerReplicatorTest.m
+++ b/Objective-C/Tests/MultipeerReplicatorTest.m
@@ -129,15 +129,18 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
 
 - (CBLTLSIdentity*) createIdentity {
     Assert(_identityCount++ <= kTestMaxIdentity);
-    
     NSError* error;
-    NSString* name = [self identityNameForNumber: _identityCount];
-    NSDictionary* attrs = @{ kCBLCertAttrCommonName: name };
+    NSString* label = [self identityNameForNumber: _identityCount];
+    
+    uint64_t timestamp = (uint64_t)([[NSDate date] timeIntervalSince1970] * 1000);
+    NSString* cn = [NSString stringWithFormat: @"%@-%llu", label, timestamp];
+    NSDictionary* attrs = @{ kCBLCertAttrCommonName: cn };
+    
     CBLTLSIdentity* identity = [CBLTLSIdentity createIdentityForKeyUsages: kTestKeyUsages
                                                                attributes: attrs
                                                                expiration: nil
                                                                    issuer: [self issuer]
-                                                                    label: name
+                                                                    label: label
                                                                     error: &error];
     
     AssertNotNil(identity);
@@ -1185,7 +1188,6 @@ typedef void (^MultipeerCollectionConfigureBlock)(CBLMultipeerCollectionConfigur
   18. Check the doc1 in both peers and verify that the its body is {"greeting": "howdy"}.
   */
 - (void) testDefaultConflictResolver {
-    CBLLogSinks.console = [[CBLConsoleLogSink alloc] initWithLevel: kCBLLogLevelVerbose];
     [self runConflictResolverTestWithResolver: nil verifyBlock: ^BOOL (CBLDocument* resolvedDoc) {
         return [[resolvedDoc stringForKey: @"greeting"] isEqualToString: @"howdy"];
     }];

--- a/Swift/Tests/MultipeerReplicatorTest.swift
+++ b/Swift/Tests/MultipeerReplicatorTest.swift
@@ -121,14 +121,18 @@ class MultipeerReplicatorTest: CBLTestCase {
         assert(identityCount <= kTestMaxIdentity)
         identityCount += 1
         
-        let name = identityNameForNumber(identityCount)
-        let attrs = [certAttrCommonName: name]
+        let label = identityNameForNumber(identityCount)
+        
+        let timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+        let cn = "\(label)-\(timestamp)"
+        let attrs = [certAttrCommonName: cn]
+        
         return try TLSIdentity.createIdentity(
             for: kTestKeyUsages,
             attributes: attrs,
             expiration: nil,
             issuer: self.issuer,
-            label: name)
+            label: label)
     }
     
     typealias CollectionConfigBlock = (inout MultipeerCollectionConfiguration) -> Void


### PR DESCRIPTION
To avoid service name collisions in DNS-SD, ensure each peer uses a unique certificate common name (CN) when creating its TLSIdentity in tests.

Related PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/296