### PR TITLE
CBL-7348 : Update Database APIs to return NotOpen error for closed database cases

### DIFF
--- a/Objective-C/Internal/CBLDatabase+Internal.h
+++ b/Objective-C/Internal/CBLDatabase+Internal.h
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) dispatch_queue_t queryQueue;
 @property (readonly, nonatomic) FLSharedKeys sharedKeys;
 
+- (BOOL) mustBeOpen: (NSError**)outError;
 - (void) mustBeOpenLocked;
 - (BOOL) isClosedLocked;
 
@@ -68,11 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 // This is currently used for creating a CBLDictionary as an input of the predict()
 // method of the PredictiveModel.
 - (instancetype) initWithC4Database: (C4Database*)c4db;
-
-- (CBLCollection*) defaultCollectionOrThrow;
-- (BOOL) withDefaultCollectionAndError: (NSError**)error block: (BOOL (^)(CBLCollection*, NSError**))block;
-- (nullable id) withDefaultCollectionForObjectAndError: (NSError**)error
-                                                 block: (id _Nullable (^)(CBLCollection*, NSError**))block;
 
 - (id) mutex;
 

--- a/Objective-C/Internal/CBLQuery+JSON.h
+++ b/Objective-C/Internal/CBLQuery+JSON.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  Encoded representation of the query. Can be used to re-create the query by calling
  -initWithDatabase:JSONRepresentation:.
  */
-@property (nonatomic, readonly) NSData* JSONRepresentation;
+@property (nonatomic, readonly) NSData* json;
 
 
 /**
@@ -35,8 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param database  The database to query.
  @param json  JSON data representing an encoded query description.
  */
-- (instancetype) initWithDatabase: (CBLDatabase*)database
-               JSONRepresentation: (NSData*)json NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithDatabase: (CBLDatabase*)database json: (NSData*)json NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Objective-C/Tests/DatabaseTest.m
+++ b/Objective-C/Tests/DatabaseTest.m
@@ -377,8 +377,10 @@
 - (void) testDeleteTwice {
     NSError* error;
     Assert([self.db delete: &error]);
-    [self expectException: @"NSInternalInconsistencyException" in: ^{
-        [self.db delete: nil];
+    AssertNil(error);
+    
+    [self expectError: CBLErrorDomain code: CBLErrorNotOpen in: ^BOOL(NSError** err) {
+        return [self.db delete: err];
     }];
 }
 

--- a/Objective-C/Tests/QueryTest+Main.m
+++ b/Objective-C/Tests/QueryTest+Main.m
@@ -1648,17 +1648,19 @@
     
     NSData* json;
     {
+        CBLQueryExpression* expr = [[CBLQueryExpression property: @"string"] is:
+                                    [CBLQueryExpression string: @"string"]];
         CBLQuery* q = [CBLQueryBuilder select: @[kDOCID]
                                          from: [CBLQueryDataSource database: self.db]
-                                        where: [[CBLQueryExpression property: @"string"] is: [CBLQueryExpression string: @"string"]]];
-        json = q.JSONRepresentation;
+                                        where: expr];
+        json = q.json;
         Assert(json);
     }
     
     // Reconstitute query from JSON data:
-    CBLQuery* q = [[CBLQuery alloc] initWithDatabase: _db JSONRepresentation: json];
+    CBLQuery* q = [[CBLQuery alloc] initWithDatabase: _db json: json];
     Assert(q);
-    AssertEqualObjects(q.JSONRepresentation, json);
+    AssertEqualObjects(q.json, json);
     
     // Now test the reconstituted query:
     uint64_t numRows = [self verifyQuery: q
@@ -1811,13 +1813,12 @@
     NSError* error = nil;
     [self.db close: &error];
     
-    [self expectException: NSInternalInconsistencyException in: ^{
+    [self expectException: NSInvalidArgumentException in: ^{
         CBLQuery* q = [CBLQueryBuilder select: @[[CBLQuerySelectResult all]]
                                          from: [CBLQueryDataSource database: self.db]
                                         where: [[CBLQueryExpression property: @"string"]
                                                 isNot: [CBLQueryExpression string: @"string1"]]];
-        
-        NSLog(@" %@", q);
+        (void)q; // Suppress unused variable warning
     }];
 }
 

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -51,15 +51,10 @@
     [super tearDown];
 }
 
-- (void) testCreateReplicatorWithNilConfig {
-    [self expectException: NSInternalInconsistencyException in:^{
-        CBLReplicatorConfiguration* config = nil;
-        (void) [[CBLReplicator alloc] initWithConfig: config];
-    }];
-}
-
 - (void) testStopContinuousReplicator {
-    id config = [self configWithTarget: _target type: kCBLReplicatorTypePushAndPull continuous: YES];
+    id config = [self configWithTarget: _target
+                                  type: kCBLReplicatorTypePushAndPull
+                            continuous: YES];
     CBLReplicator* r = [[CBLReplicator alloc] initWithConfig: config];
     
     NSArray* stopWhen = @[@(kCBLReplicatorConnecting), @(kCBLReplicatorBusy),

--- a/Objective-C/Tests/ReplicatorTest+MessageEndPoint.m
+++ b/Objective-C/Tests/ReplicatorTest+MessageEndPoint.m
@@ -38,9 +38,8 @@
 - (XCTestExpectation *) waitForListenerIdle: (CBLMessageEndpointListener*)listener {
     XCTestExpectation* x = [self expectationWithDescription:@"Listener idle"];
     __block id token = nil;
-    __weak CBLMessageEndpointListener* wListener = listener;
     token = [listener addChangeListener:^(CBLMessageEndpointListenerChange* change) {
-        if(change.status.activity == kCBLReplicatorIdle) {
+        if (change.status.activity == kCBLReplicatorIdle) {
             [x fulfill];
             [token remove];
         }
@@ -52,9 +51,8 @@
 - (XCTestExpectation *) waitForListenerStopped: (CBLMessageEndpointListener*)listener {
     XCTestExpectation* x = [self expectationWithDescription:@"Listener stop"];
     __block id token = nil;
-    __weak CBLMessageEndpointListener* wListener = listener;
     token = [listener addChangeListener: ^(CBLMessageEndpointListenerChange * change) {
-        if(change.status.activity == kCBLReplicatorStopped) {
+        if (change.status.activity == kCBLReplicatorStopped) {
             [x fulfill];
             [token remove];
         }

--- a/Objective-C/Tests/TLSIdentityTest.m
+++ b/Objective-C/Tests/TLSIdentityTest.m
@@ -550,6 +550,8 @@
     
 #if TARGET_OS_OSX
     SecCertificateRef cert = (__bridge SecCertificateRef)(identity.certs[0]);
+    AssertNotNil((__bridge id)cert);
+    if (!cert) { return; } // Satisfy static analysis for null value could be passed to SecCertificateCopyValues.
     NSDictionary* certAttrs = CFBridgingRelease(SecCertificateCopyValues(cert, NULL, NULL));
     NSDictionary* expInfo = certAttrs[(id)kSecOIDX509V1ValidityNotAfter];
     NSNumber* expValue = expInfo[(id)kSecPropertyKeyValue];

--- a/Swift/Database.swift
+++ b/Swift/Database.swift
@@ -317,10 +317,6 @@ public final class Database {
         lock.unlock()
     }
     
-    static func throwNotOpenError() -> Never {
-        fatalError("The database was closed or released, or the default collection was deleted.");
-    }
-    
     let impl: CBLDatabase
     
     private var lock = NSRecursiveLock()

--- a/Swift/Query.swift
+++ b/Swift/Query.swift
@@ -168,9 +168,9 @@ public class Query {
 
     /// Encoded JSON representation of the query.
     /// Can be used later to reconstruct an identical query.
-    var JSONRepresentation : Data {
+    var json : Data {
         prepareQuery()
-        return queryImpl!.jsonRepresentation
+        return queryImpl!.json
     }
 
     /// Initialize a Query given a JSON-encoded representation.
@@ -180,7 +180,7 @@ public class Query {
     ///           JSONRepresentation property.
     init(database: Database, JSONRepresentation json: Data) {
         self.database = database
-        queryImpl = CBLQuery(database: database.impl, jsonRepresentation: json)
+        queryImpl = CBLQuery(database: database.impl, json: json)
     }
     
     /// Creates a query, given the query string, as from the expression property.

--- a/Swift/Tests/QueryTest.swift
+++ b/Swift/Tests/QueryTest.swift
@@ -1525,7 +1525,7 @@ class QueryTest: CBLTestCase {
 
         let q1 = QueryBuilder.select(kDOCID).from(DataSource.collection(defaultCollection!)).where(
             Expression.property("string").is(Expression.string("string")))
-        let json = q1.JSONRepresentation
+        let json = q1.json
 
         let q = Query(database: db, JSONRepresentation: json)
 


### PR DESCRIPTION
* Updated database APIs to return NotOpen instead of throwing exception :
  - (BOOL) inBatch:(NSError**)outError usingBlockWithError:(void (NS_NOESCAPE ^)(NSError**))block
  - (BOOL) delete:(NSError**)outError
  - (BOOL) performMaintenance:(CBLMaintenanceType)type error:(NSError**)outError (nullable CBLQuery*) createQuery:(NSString*)query error:(NSError**)error

* Refactor / Clean up :
  - Used CBLPrecondition in CBLDatabase.
  - Reset closing state when closing database fails.
  - Ensured to lock when calling to free c4db to avoid crash.
  - Renamed CBLQuery’s JSONRepresentation property to just json.
  - Fixed warnings from static analysis in TLSIdentityTest and ReplicatorTest.

* Related PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/302