### PR TITLE
CBL-7394 : Add mdns logging domain

### DIFF
--- a/Objective-C/CBLLog.mm
+++ b/Objective-C/CBLLog.mm
@@ -133,6 +133,9 @@ void cblLog(C4LogDomain domain, C4LogLevel level, NSString *msg, ...) {
         case kCBLLogDomainPeerDiscovery:
             c4Domain = kCBL_LogDomainDiscovery;
             break;
+        case kCBLLogDomainMDNS:
+            c4Domain = kCBL_LogDomainMDNS;
+            break;
         case kCBLLogDomainMultipeer:
             c4Domain = kCBL_LogDomainP2P;
             break;

--- a/Objective-C/Internal/CBLLog+Logging.h
+++ b/Objective-C/Internal/CBLLog+Logging.h
@@ -40,6 +40,7 @@ extern C4LogDomain kCBL_LogDomainSync;
 extern C4LogDomain kCBL_LogDomainWebSocket;
 extern C4LogDomain kCBL_LogDomainListener;
 extern C4LogDomain kCBL_LogDomainDiscovery;
+extern C4LogDomain kCBL_LogDomainMDNS;
 extern C4LogDomain kCBL_LogDomainP2P;
     
 // Logging functions. For the domain, just use the part of the name between kCBL… and …LogDomain.

--- a/Objective-C/LogSink/CBLConsoleLogSink.mm
+++ b/Objective-C/LogSink/CBLConsoleLogSink.mm
@@ -70,6 +70,9 @@ static NSArray* logLevelNames = @[@"Debug", @"Verbose", @"Info", @"WARNING", @"E
         case kCBLLogDomainPeerDiscovery:
             return @"PeerDiscovery";
             break;
+        case kCBLLogDomainMDNS:
+            return @"mDNS";
+            break;
         case kCBLLogDomainMultipeer:
             return @"Multipeer";
             break;

--- a/Objective-C/LogSink/CBLFileLogSink.mm
+++ b/Objective-C/LogSink/CBLFileLogSink.mm
@@ -111,11 +111,18 @@
         case kCBLLogDomainNetwork:
             c4domain = kCBL_LogDomainWebSocket;
             break;
-#ifdef COUCHBASE_ENTERPRISE
         case kCBLLogDomainListener:
             c4domain = kCBL_LogDomainListener;
             break;
-#endif
+        case kCBLLogDomainPeerDiscovery:
+            c4domain = kCBL_LogDomainDiscovery;
+            break;
+        case kCBLLogDomainMDNS:
+            c4domain = kCBL_LogDomainMDNS;
+            break;
+        case kCBLLogDomainMultipeer:
+            c4domain = kCBL_LogDomainP2P;
+            break;
         default:
             c4domain = kCBL_LogDomainDatabase;
     }

--- a/Objective-C/LogSink/CBLLogSinks.mm
+++ b/Objective-C/LogSink/CBLLogSinks.mm
@@ -27,9 +27,10 @@ C4LogDomain kCBL_LogDomainSync;
 C4LogDomain kCBL_LogDomainWebSocket;
 C4LogDomain kCBL_LogDomainListener;
 C4LogDomain kCBL_LogDomainDiscovery;
+C4LogDomain kCBL_LogDomainMDNS;
 C4LogDomain kCBL_LogDomainP2P;
 
-static NSArray* c4Domains = @[@"DB", @"Query", @"Sync", @"WS", @"Listener", @"Discovery", @"P2P"];
+static NSArray* c4Domains = @[@"DB", @"Query", @"Sync", @"WS", @"Listener", @"Discovery", @"mDNS", @"P2P"];
 static NSArray* platformDomains = @[@"BLIP", @"BLIPMessages", @"SyncBusy", @"TLS", @"Changes", @"Zip"];
 
 static CBLLogLevel _domainsLevel = kCBLLogLevelNone;
@@ -62,6 +63,7 @@ NSDictionary* domainDictionary = nil;
         kCBL_LogDomainWebSocket  = c4log_getDomain("WS", true);
         kCBL_LogDomainListener  = c4log_getDomain("Listener", true);
         kCBL_LogDomainDiscovery = c4log_getDomain("Discovery", true);
+        kCBL_LogDomainMDNS = c4log_getDomain("mDNS", true);
         kCBL_LogDomainP2P = c4log_getDomain("P2P", true);
         
         // Create the default warning console log:
@@ -182,6 +184,7 @@ static CBLLogDomain toCBLLogDomain(C4LogDomain domain) {
                               @"TLS": @(kCBLLogDomainNetwork),
                               @"Listener": @(kCBLLogDomainListener),
                               @"Discovery": @(kCBLLogDomainPeerDiscovery),
+                              @"mDNS": @(kCBLLogDomainMDNS),
                               @"P2P": @(kCBLLogDomainMultipeer)
         };
     }

--- a/Objective-C/LogSink/CBLLogTypes.h
+++ b/Objective-C/LogSink/CBLLogTypes.h
@@ -27,8 +27,9 @@ typedef NS_OPTIONS(NSUInteger, CBLLogDomain) {
     kCBLLogDomainNetwork        = 1 << 3,       ///< Network domain.
     kCBLLogDomainListener       = 1 << 4,       ///< Listener domain.
     kCBLLogDomainPeerDiscovery  = 1 << 5,       ///< Peer Discovery domain.
-    kCBLLogDomainMultipeer      = 1 << 6,       ///< Multipeer Replication domain.
-    kCBLLogDomainAll            = (1 << 7) - 1  ///< All domains
+    kCBLLogDomainMDNS           = 1 << 6,       ///< mDNS specific logs used for DNS-SD peer discovery
+    kCBLLogDomainMultipeer      = 1 << 9,       ///< Multipeer Replication domain.
+    kCBLLogDomainAll            = (1 << 10) - 1 ///< All domains
 };
 
 /** Log level. */

--- a/Swift/ConsoleLogger.swift
+++ b/Swift/ConsoleLogger.swift
@@ -51,13 +51,17 @@ public struct LogDomains: OptionSet {
     /// Peer Discovery domain.
     public static let peerDiscovery = LogDomains(rawValue: Int(LogDomain.peerDiscovery.rawValue))
     
+    /// mDNS specific logs used for DNS-SD peer discovery.
+    public static let mdns = LogDomains(rawValue: Int(LogDomain.mdns.rawValue))
+    
     /// Multipeer Replication domain.
     public static let multipeer = LogDomains(rawValue: Int(LogDomain.multipeer.rawValue))
     
     /// All domains.
     public static let all: LogDomains = [
-        .database, .query, .replicator, .network, .listener, .peerDiscovery, .multipeer
+        .database, .query, .replicator, .network, .listener, .peerDiscovery, .mdns, .multipeer
     ]
+    
 }
 
 public class ConsoleLogger {

--- a/Swift/Log.swift
+++ b/Swift/Log.swift
@@ -40,7 +40,7 @@ public class Log {
                 let logLevel = CBLLogLevel(rawValue: UInt(logger.level.rawValue))!
                 CBLDatabase.log().setCustomLoggerWith(logLevel) { (level, domain, message) in
                     let l = LogLevel(rawValue: UInt8(level.rawValue))!
-                    let d = LogDomain(rawValue: UInt8(domain.rawValue))!
+                    let d = LogDomain(rawValue: domain.rawValue)!
                     logger.log(level: l, domain: d, message: message)
                 }
             } else {

--- a/Swift/LogSinks.swift
+++ b/Swift/LogSinks.swift
@@ -75,7 +75,7 @@ public class LogSinks {
         
         func writeLog(with level: CBLLogLevel, domain: CBLLogDomain, message: String) {
             let logLevel = LogLevel.init(rawValue: UInt8(level.rawValue))!
-            let logDomain = LogDomain.init(rawValue: UInt8(domain.rawValue))!
+            let logDomain = LogDomain.init(rawValue: domain.rawValue)!
             logSink.writeLog(level:logLevel, domain: logDomain, message: message)
         }
     }

--- a/Swift/Logger.swift
+++ b/Swift/Logger.swift
@@ -21,20 +21,30 @@ import Foundation
 import CouchbaseLiteSwift_Private
 
 /// Log domain.
-///
-/// database:   Database domain.
-/// query:      Query domain.
-/// replicator: Replicator domain.
-/// network:    Network domain.
-/// listener:   Listener domain.
-public enum LogDomain: UInt8 {
+public enum LogDomain: UInt {
+    /// Database domain.
     case database       = 1
+    
+    /// Query domain.
     case query          = 2
+    
+    /// Replicator domain.
     case replicator     = 4
+    
+    /// Network domain.
     case network        = 8
+    
+    /// Listener domain.
     case listener       = 16
+    
+    /// Peer Discovery domain.
     case peerDiscovery  = 32
-    case multipeer      = 64
+    
+    /// mDNS specific logs used for DNS-SD peer discovery
+    case mdns           = 64
+    
+    /// Multipeer Replication domain
+    case multipeer      = 512
 }
 
 /// Log level.

--- a/Swift/Tests/LogSinkTest.swift
+++ b/Swift/Tests/LogSinkTest.swift
@@ -399,7 +399,7 @@ class LogSinkTest: CBLTestCase {
             let logSink = TestCustomLogSink()
             LogSinks.custom = CustomLogSink(level: .debug, domains: domains[i], logSink: logSink)
             for j in 0..<domains.count {
-                Log.log(domain: LogDomain(rawValue: UInt8(domains[j].rawValue))!, level: .verbose, message: names[j])
+                Log.log(domain: LogDomain(rawValue: UInt(domains[j].rawValue))!, level: .verbose, message: names[j])
             }
             XCTAssertEqual(logSink.lines.count, 1)
             XCTAssertEqual(logSink.lines[0], names[i])
@@ -415,7 +415,7 @@ class LogSinkTest: CBLTestCase {
             let logSink = TestCustomLogSink()
             LogSinks.custom = CustomLogSink(level: .debug, domains: combined, logSink: logSink)
             for j in 0..<domains.count {
-                Log.log(domain: LogDomain(rawValue: UInt8(domains[j].rawValue))!, level: .verbose, message: names[j])
+                Log.log(domain: LogDomain(rawValue: UInt(domains[j].rawValue))!, level: .verbose, message: names[j])
             }
             
             XCTAssertEqual(logSink.lines.count, i + 1)
@@ -428,7 +428,7 @@ class LogSinkTest: CBLTestCase {
         let logSink = TestCustomLogSink()
         LogSinks.custom = CustomLogSink(level: .debug, domains: .all, logSink: logSink)
         for i in 0..<domains.count {
-            Log.log(domain: LogDomain(rawValue: UInt8(domains[i].rawValue))!, level: .verbose, message: names[i])
+            Log.log(domain: LogDomain(rawValue: UInt(domains[i].rawValue))!, level: .verbose, message: names[i])
         }
         XCTAssertEqual(logSink.lines.count, names.count)
         for i in 0..<names.count {

--- a/Swift/Tests/MultipeerReplicatorTest.swift
+++ b/Swift/Tests/MultipeerReplicatorTest.swift
@@ -346,6 +346,8 @@ class MultipeerReplicatorTest: CBLTestCase {
      4. Check that the configuration cannot be created as the collections are empty.
      */
     func testConfigurationValidation() throws {
+        throw XCTSkip("Swift's Precondition cannot be asserted. Enable manually when needed.")
+        
         // Create the collection and identity
         let collection = try db.defaultCollection()
         let identity = try createIdentity()
@@ -353,24 +355,20 @@ class MultipeerReplicatorTest: CBLTestCase {
         let collConfig = MultipeerCollectionConfiguration(collection: collection)
 
         // Create the configuration with an empty peerGroupID:
-        expectException(exception: .invalidArgumentException) {
-            _ = MultipeerReplicatorConfiguration(
-                peerGroupID: "",
-                identity: identity,
-                authenticator: auth,
-                collections: [collConfig]
-            )
-        }
+        _ = MultipeerReplicatorConfiguration(
+            peerGroupID: "",
+            identity: identity,
+            authenticator: auth,
+            collections: [collConfig]
+        )
         
         // Create the configuration with an empty collections:
-        expectException(exception: .invalidArgumentException) {
-            _ = MultipeerReplicatorConfiguration(
-                peerGroupID: self.kTestPeerGroupID,
-                identity: identity,
-                authenticator: auth,
-                collections: []
-            )
-        }
+        _ = MultipeerReplicatorConfiguration(
+            peerGroupID: self.kTestPeerGroupID,
+            identity: identity,
+            authenticator: auth,
+            collections: []
+        )
     }
     
     // MARK: - Stop and Restart
@@ -646,8 +644,6 @@ class MultipeerReplicatorTest: CBLTestCase {
         that one of the replicators is STOPPED with the error.
      */
     func testAuthenticateWithRootCertsFailed() throws {
-        LogSinks.console = ConsoleLogSink(level: .verbose)
-        
         let rootCertPEM = """
         -----BEGIN CERTIFICATE-----
         MIIE/DCCAuSgAwIBAgIUHKj9KlERcqJF62FpOzQn7rC9PPgwDQYJKoZIhvcNAQEL
@@ -749,8 +745,6 @@ class MultipeerReplicatorTest: CBLTestCase {
         that one of the replicators is STOPPED with the error.
      */
     func testAuthenticateWithCallbackFailed() throws {
-        LogSinks.console = ConsoleLogSink(level: .verbose)
-        
         let auth = MultipeerCertificateAuthenticator { peerID, certs in
             XCTAssertNotNil(peerID)
             XCTAssertFalse(certs.isEmpty)
@@ -1376,8 +1370,6 @@ class MultipeerReplicatorTest: CBLTestCase {
      13. Verify that MultipeerReplicator#2's neighborPeers is empty.
      */
     func testNeighborPeers() throws {
-        LogSinks.console = ConsoleLogSink(level: .verbose)
-        
         let repl1 = try multipeerReplicator(for: db)
         XCTAssertEqual(repl1.neighborPeers.count, 0)
 


### PR DESCRIPTION
* Added mdns logging domain to both objective-c and swift.

* Reserved 128 and 256 value for bluetooth and wifi-aware that we may have in the future for multipeer replicator.

* Changed Swift LogDomain type from UInt8 to UInt for enum values > 256 (Need a release note for this)

* Fixed missing switch cases in CBLFileLogSink.mm.

* Skip testConfigurationValidation as precondition cannot be asserted. We use Swift’s precondition() for parameter validation in Precondition.swift. Since it traps like fatalError, it cannot be asserted in tests, so the test is left disabled for manual runs.

* Will need to be ported to 4.0 after this is merged.

* Note: Adding a logging domain needs to touch multiple places and is easily to be missed - we should think about improving this.