### PR TITLE
CBL-7428 : Swift Codable decoding fails for some ISO8601 formats (Port)

### DIFF
--- a/Swift/FleeceEncoder.swift
+++ b/Swift/FleeceEncoder.swift
@@ -90,8 +90,7 @@ internal class FleeceEncoder : Encoder {
         case is Blob:
             try _writeNSObject((value as! Blob).impl)
         case is Date:
-            let formatter = ISO8601DateFormatter()
-            let string = formatter.string(from: value as! Date)
+            let string = ISO8601DateFormatter.couchbase.string(from: value as! Date)
             try _writeNSObject(string as NSString)
         case is NSObject:
             try _writeNSObject(value as! NSObject)

--- a/Swift/Tests/CodableTest.swift
+++ b/Swift/Tests/CodableTest.swift
@@ -766,6 +766,51 @@ class CodableTest: CBLTestCase {
         XCTAssertEqual(loadedReportFile.report.body, body)
     }
     
+    // CBL-7061
+    // Test that Codable can decode Date when it was encoded using Document methods.
+    func testCollectionDecodeISO8601Date() throws {
+        // Create a ReportFile document
+        let body = Blob(contentType: "text/plain", data: Data("Hello, World!".utf8))
+        let report = MutableDictionaryObject()
+        report.setValue(NSNull(), forKey: "id")
+        report.setString("My Report", forKey: "title")
+        report.setBoolean(false, forKey: "filed")
+        report.setBlob(body, forKey: "body")
+        let document = MutableDocument()
+        let now = Date()
+        document.setDate(now, forKey: "dateFiled")
+        document.setDictionary(report, forKey: "report")
+        // Save to the default collection
+        try defaultCollection!.save(document: document)
+        //  Load the object from the collection
+        let reportFile = try defaultCollection!.document(id: document.id, as: ReportFile.self)!
+        // Assert the loaded object Date is identical to the source (to accuracy of 1 millisecond)
+        XCTAssertEqual(reportFile.dateFiled.timeIntervalSince1970, now.timeIntervalSince1970, accuracy: 0.001)
+    }
+    
+    // CBL-7061
+    // Test that Codable can decode Date when it was encoded using Swift's default ISO8601 formatter.
+    func testCollectionDecodeISO8601DateWithDefaultFormatter() throws {
+        // Create a ReportFile document
+        let body = Blob(contentType: "text/plain", data: Data("Hello, World!".utf8))
+        let report = MutableDictionaryObject()
+        report.setValue(NSNull(), forKey: "id")
+        report.setString("My Report", forKey: "title")
+        report.setBoolean(false, forKey: "filed")
+        report.setBlob(body, forKey: "body")
+        let document = MutableDocument()
+        let now = Date()
+        let nowString = ISO8601DateFormatter().string(from: now)
+        document.setString(nowString, forKey: "dateFiled")
+        document.setDictionary(report, forKey: "report")
+        // Save to the default collection
+        try defaultCollection!.save(document: document)
+        //  Load the object from the collection
+        let reportFile = try defaultCollection!.document(id: document.id, as: ReportFile.self)!
+        // Assert the loaded object Date is identical to the source (to accuracy of 1 second)
+        XCTAssertEqual(reportFile.dateFiled.timeIntervalSince1970, now.timeIntervalSince1970, accuracy: 1)
+    }
+    
     // 23. TestCollectionEncodeAndDecodeArrayNestedBlob
     func testCollectionEncodeAndDecodeArrayNestedBlob() throws {
         // 1. Create a Note object with array of 3 blobs


### PR DESCRIPTION
* Port the fix from release/3.2 branch for CBL-7061.

* Fix Codable ISO8601 format

* Add test to decode Swift ISO8601 default format