### PR TITLE
CBL-7240 : Add mdns logging domain (Port)

### DIFF
--- a/Objective-C/Internal/CBLLog+Internal.h
+++ b/Objective-C/Internal/CBLLog+Internal.h
@@ -40,6 +40,7 @@ extern C4LogDomain kCBL_LogDomainSync;
 extern C4LogDomain kCBL_LogDomainWebSocket;
 extern C4LogDomain kCBL_LogDomainListener;
 extern C4LogDomain kCBL_LogDomainDiscovery;
+extern C4LogDomain kCBL_LogDomainMDNS;
 extern C4LogDomain kCBL_LogDomainP2P;
     
 // Logging functions. For the domain, just use the part of the name between kCBL… and …LogDomain.

--- a/Objective-C/Internal/CBLLog.mm
+++ b/Objective-C/Internal/CBLLog.mm
@@ -61,6 +61,9 @@ void writeCBLLogMessage(C4LogDomain domain, C4LogLevel level, NSString *msg, ...
         case kCBLLogDomainPeerDiscovery:
             c4Domain = kCBL_LogDomainDiscovery;
             break;
+        case kCBLLogDomainMDNS:
+            c4Domain = kCBL_LogDomainMDNS;
+            break;
         case kCBLLogDomainMultipeer:
             c4Domain = kCBL_LogDomainP2P;
             break;

--- a/Objective-C/LogSink/CBLConsoleLogSink.mm
+++ b/Objective-C/LogSink/CBLConsoleLogSink.mm
@@ -69,6 +69,9 @@ static NSArray* logLevelNames = @[@"Debug", @"Verbose", @"Info", @"WARNING", @"E
         case kCBLLogDomainPeerDiscovery:
             return @"PeerDiscovery";
             break;
+        case kCBLLogDomainMDNS:
+            return @"mDNS";
+            break;
         case kCBLLogDomainMultipeer:
             return @"Multipeer";
             break;

--- a/Objective-C/LogSink/CBLFileLogSink.mm
+++ b/Objective-C/LogSink/CBLFileLogSink.mm
@@ -110,16 +110,23 @@
         case kCBLLogDomainNetwork:
             c4domain = kCBL_LogDomainWebSocket;
             break;
-#ifdef COUCHBASE_ENTERPRISE
         case kCBLLogDomainListener:
             c4domain = kCBL_LogDomainListener;
             break;
-#endif
+        case kCBLLogDomainPeerDiscovery:
+            c4domain = kCBL_LogDomainDiscovery;
+            break;
+        case kCBLLogDomainMDNS:
+            c4domain = kCBL_LogDomainMDNS;
+            break;
+        case kCBLLogDomainMultipeer:
+            c4domain = kCBL_LogDomainP2P;
+            break;
         default:
             c4domain = kCBL_LogDomainDatabase;
     }
-        CBLStringBytes c4msg(message);
-        c4slog(c4domain, c4level, c4msg);
+    CBLStringBytes c4msg(message);
+    c4slog(c4domain, c4level, c4msg);
 }
 
 + (BOOL) setupLogDirectory: (NSString*)directory error: (NSError**)outError {

--- a/Objective-C/LogSink/CBLLogTypes.h
+++ b/Objective-C/LogSink/CBLLogTypes.h
@@ -27,8 +27,9 @@ typedef NS_OPTIONS(NSUInteger, CBLLogDomain) {
     kCBLLogDomainNetwork        = 1 << 3,       ///< Network domain.
     kCBLLogDomainListener       = 1 << 4,       ///< Listener domain.
     kCBLLogDomainPeerDiscovery  = 1 << 5,       ///< Peer Discovery domain.
-    kCBLLogDomainMultipeer      = 1 << 6,       ///< Multipeer Replication domain.
-    kCBLLogDomainAll            = (1 << 7) - 1  ///< All domains
+    kCBLLogDomainMDNS           = 1 << 6,       ///< mDNS specific logs used for DNS-SD peer discovery
+    kCBLLogDomainMultipeer      = 1 << 9,       ///< Multipeer Replication domain.
+    kCBLLogDomainAll            = (1 << 10) - 1 ///< All domains
 };
 
 /** Log level. */

--- a/Swift/ConsoleLogSink.swift
+++ b/Swift/ConsoleLogSink.swift
@@ -21,39 +21,42 @@ import Foundation
 
 /// Log domain options that can be enabled in the console logger.
 public struct LogDomains: OptionSet {
-    
     /// Raw value.
-    public let rawValue: Int
+    public let rawValue: UInt
     
     /// Constructor with the raw value.
-    public init(rawValue: Int) {
+    public init(rawValue: UInt) {
         self.rawValue = rawValue
     }
     
     /// Database domain.
-    public static let database = LogDomains(rawValue: Int(LogDomain.database.rawValue))
+    public static let database = LogDomains(rawValue: LogDomain.database.rawValue)
     
     /// Query domain.
-    public static let query = LogDomains(rawValue: Int(LogDomain.query.rawValue))
+    public static let query = LogDomains(rawValue: LogDomain.query.rawValue)
     
     /// Replicator domain.
-    public static let replicator = LogDomains(rawValue: Int(LogDomain.replicator.rawValue))
+    public static let replicator = LogDomains(rawValue: LogDomain.replicator.rawValue)
     
     /// Network domain.
-    public static let network = LogDomains(rawValue: Int(LogDomain.network.rawValue))
+    public static let network = LogDomains(rawValue: LogDomain.network.rawValue)
     
     /// Listener domain.
-    public static let listener = LogDomains(rawValue: Int(LogDomain.listener.rawValue))
+    public static let listener = LogDomains(rawValue: LogDomain.listener.rawValue)
     
     /// Peer Discovery domain.
-    public static let peerDiscovery = LogDomains(rawValue: Int(LogDomain.peerDiscovery.rawValue))
+    public static let peerDiscovery = LogDomains(rawValue: LogDomain.peerDiscovery.rawValue)
+    
+    /// mDNS specific logs used for DNS-SD peer discovery.
+    public static let mdns = LogDomains(rawValue: LogDomain.mdns.rawValue)
+
     
     /// Multipeer Replication domain.
-    public static let multipeer = LogDomains(rawValue: Int(LogDomain.multipeer.rawValue))
+    public static let multipeer = LogDomains(rawValue: LogDomain.multipeer.rawValue)
     
     /// All domains.
     public static let all: LogDomains = [
-        .database, .query, .replicator, .network, .listener, .peerDiscovery, .multipeer
+        .database, .query, .replicator, .network, .listener, .peerDiscovery, .mdns, .multipeer
     ]
 }
 

--- a/Swift/Log.swift
+++ b/Swift/Log.swift
@@ -23,7 +23,7 @@ import CouchbaseLiteSwift_Private
 internal class Log {
     /// Writes a log message to all the enabled log sinks.
     internal static func log(domain: LogDomain, level: LogLevel, message: String) {
-        let cDomain = CBLLogDomain.init(rawValue: UInt(domain.rawValue))
+        let cDomain = CBLLogDomain.init(rawValue: domain.rawValue)
         let cLevel = CBLLogLevel(rawValue: UInt(level.rawValue))!
         CBLLog.writeSwiftLog(cDomain, level: cLevel, message: message)
     }

--- a/Swift/LogSinks.swift
+++ b/Swift/LogSinks.swift
@@ -21,20 +21,30 @@ import Foundation
 import CouchbaseLiteSwift_Private
 
 /// Log domain.
-///
-/// database:   Database domain.
-/// query:      Query domain.
-/// replicator: Replicator domain.
-/// network:    Network domain.
-/// listener:   Listener domain.
-public enum LogDomain: UInt8 {
+public enum LogDomain: UInt {
+    /// Database domain.
     case database       = 1
+    
+    /// Query domain.
     case query          = 2
+    
+    /// Replicator domain.
     case replicator     = 4
+    
+    /// Network domain.
     case network        = 8
+    
+    /// Listener domain.
     case listener       = 16
+    
+    /// Peer Discovery domain.
     case peerDiscovery  = 32
-    case multipeer      = 64
+    
+    /// mDNS specific logs used for DNS-SD peer discovery
+    case mdns           = 64
+    
+    /// Multipeer Replication domain
+    case multipeer      = 512
 }
 
 /// Log level.
@@ -109,7 +119,7 @@ public class LogSinks {
         
         func writeLog(with level: CBLLogLevel, domain: CBLLogDomain, message: String) {
             let logLevel = LogLevel.init(rawValue: UInt8(level.rawValue))!
-            let logDomain = LogDomain.init(rawValue: UInt8(domain.rawValue))!
+            let logDomain = LogDomain.init(rawValue: domain.rawValue)!
             logSink.writeLog(level:logLevel, domain: logDomain, message: message)
         }
     }

--- a/Swift/Tests/LogSinkTest.swift
+++ b/Swift/Tests/LogSinkTest.swift
@@ -376,7 +376,7 @@ class LogSinkTest: CBLTestCase {
             let logSink = TestCustomLogSink()
             LogSinks.custom = CustomLogSink(level: .debug, domains: domains[i], logSink: logSink)
             for j in 0..<domains.count {
-                Log.log(domain: LogDomain(rawValue: UInt8(domains[j].rawValue))!, level: .verbose, message: names[j])
+                Log.log(domain: LogDomain(rawValue: domains[j].rawValue)!, level: .verbose, message: names[j])
             }
             XCTAssertEqual(logSink.lines.count, 1)
             XCTAssertEqual(logSink.lines[0], names[i])
@@ -392,7 +392,7 @@ class LogSinkTest: CBLTestCase {
             let logSink = TestCustomLogSink()
             LogSinks.custom = CustomLogSink(level: .debug, domains: combined, logSink: logSink)
             for j in 0..<domains.count {
-                Log.log(domain: LogDomain(rawValue: UInt8(domains[j].rawValue))!, level: .verbose, message: names[j])
+                Log.log(domain: LogDomain(rawValue: domains[j].rawValue)!, level: .verbose, message: names[j])
             }
             
             XCTAssertEqual(logSink.lines.count, i + 1)
@@ -405,7 +405,7 @@ class LogSinkTest: CBLTestCase {
         let logSink = TestCustomLogSink()
         LogSinks.custom = CustomLogSink(level: .debug, domains: .all, logSink: logSink)
         for i in 0..<domains.count {
-            Log.log(domain: LogDomain(rawValue: UInt8(domains[i].rawValue))!, level: .verbose, message: names[i])
+            Log.log(domain: LogDomain(rawValue: domains[i].rawValue)!, level: .verbose, message: names[i])
         }
         XCTAssertEqual(logSink.lines.count, names.count)
         for i in 0..<names.count {

--- a/Swift/Tests/MultipeerReplicatorTest.swift
+++ b/Swift/Tests/MultipeerReplicatorTest.swift
@@ -342,6 +342,8 @@ class MultipeerReplicatorTest: CBLTestCase {
      4. Check that the configuration cannot be created as the collections are empty.
      */
     func testConfigurationValidation() throws {
+        throw XCTSkip("Swift's Precondition cannot be asserted. Enable manually when needed.")
+        
         // Create the collection and identity
         let collection = try db.defaultCollection()
         let identity = try createIdentity()
@@ -349,24 +351,20 @@ class MultipeerReplicatorTest: CBLTestCase {
         let collConfig = MultipeerCollectionConfiguration(collection: collection)
 
         // Create the configuration with an empty peerGroupID:
-        expectException(exception: .invalidArgumentException) {
-            _ = MultipeerReplicatorConfiguration(
-                peerGroupID: "",
-                identity: identity,
-                authenticator: auth,
-                collections: [collConfig]
-            )
-        }
+        _ = MultipeerReplicatorConfiguration(
+            peerGroupID: "",
+            identity: identity,
+            authenticator: auth,
+            collections: [collConfig]
+        )
         
         // Create the configuration with an empty collections:
-        expectException(exception: .invalidArgumentException) {
-            _ = MultipeerReplicatorConfiguration(
-                peerGroupID: self.kTestPeerGroupID,
-                identity: identity,
-                authenticator: auth,
-                collections: []
-            )
-        }
+        _ = MultipeerReplicatorConfiguration(
+            peerGroupID: self.kTestPeerGroupID,
+            identity: identity,
+            authenticator: auth,
+            collections: []
+        )
     }
     
     // MARK: - Stop and Restart
@@ -642,8 +640,6 @@ class MultipeerReplicatorTest: CBLTestCase {
         that one of the replicators is STOPPED with the error.
      */
     func testAuthenticateWithRootCertsFailed() throws {
-        LogSinks.console = ConsoleLogSink(level: .verbose)
-        
         let rootCertPEM = """
         -----BEGIN CERTIFICATE-----
         MIIE/DCCAuSgAwIBAgIUHKj9KlERcqJF62FpOzQn7rC9PPgwDQYJKoZIhvcNAQEL
@@ -745,8 +741,6 @@ class MultipeerReplicatorTest: CBLTestCase {
         that one of the replicators is STOPPED with the error.
      */
     func testAuthenticateWithCallbackFailed() throws {
-        LogSinks.console = ConsoleLogSink(level: .verbose)
-        
         let auth = MultipeerCertificateAuthenticator { peerID, certs in
             XCTAssertNotNil(peerID)
             XCTAssertFalse(certs.isEmpty)
@@ -1372,8 +1366,6 @@ class MultipeerReplicatorTest: CBLTestCase {
      13. Verify that MultipeerReplicator#2's neighborPeers is empty.
      */
     func testNeighborPeers() throws {
-        LogSinks.console = ConsoleLogSink(level: .verbose)
-        
         let repl1 = try multipeerReplicator(for: db)
         XCTAssertEqual(repl1.neighborPeers.count, 0)
 


### PR DESCRIPTION
* Ported changes from release/3.3 branch for CBL-7394.

* Added mdns logging domain to both objective-c and swift

* Reserved 128 and 256 value for bluetooth and wifi-aware that we may have in the future for multipeer replicator.

* Changed Swift LogDomain type from UInt8 to UInt.

* (New) Update LogDomains’s rawValue types to UInt to match LogDomain’s rawValue type (So no type conversion will be needed).

* Fixed missing switch cases in CBLFileLogSink.mm.

* Skip testConfigurationValidation as precondition cannot be asserted

* We use Swift’s precondition() for parameter validation in Precondition.swift. Since it traps like fatalError, it cannot be asserted in tests, so the test is left disabled for manual runs.

* Removed leftover debug logging

