### PR TITLE
Update LiteCore submodule

### DIFF
--- a/Objective-C/CBLCollectionConfiguration.h
+++ b/Objective-C/CBLCollectionConfiguration.h
@@ -82,20 +82,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSArray<CBLCollectionConfiguration*>*) fromCollections: (NSArray<CBLCollection*>*)collections;
 
-/**
- Creates an array of `CBLCollectionConfiguration` objects from the given collections with the same configuration closure.
-
- This is a convenience method for configuring multiple collections with the same configurations.
- If custom configurations are needed, construct `CBLCollectionConfiguration` objects
- directly instead.
-       
- @param collections The collections to replicate.
- @param config A block to configure all `CBLCollectionConfiguration` object.
- @return An array of CBLCollectionConfiguration objects for the given collections.
- */
-+ (NSArray<CBLCollectionConfiguration*>*) fromCollections: (NSArray<CBLCollection*>*)collections
-                                                   config: (void (^)(CBLCollectionConfiguration* config))config;
-
 /** Not available */
 - (instancetype) init NS_UNAVAILABLE;
 

--- a/Objective-C/Internal/Replicator/CBLCollectionConfiguration+Internal.h
+++ b/Objective-C/Internal/Replicator/CBLCollectionConfiguration+Internal.h
@@ -28,6 +28,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSDictionary*) effectiveOptions;
 
+/**
+ Creates an array of `CBLCollectionConfiguration` objects from the given collections with the same configuration closure.
+
+ This is a convenience method for configuring multiple collections with the same configurations.
+ If custom configurations are needed, construct `CBLCollectionConfiguration` objects
+ directly instead.
+       
+ @param collections The collections to replicate.
+ @param config A block to configure all `CBLCollectionConfiguration` object.
+ @return An array of CBLCollectionConfiguration objects for the given collections.
+ */
++ (NSArray<CBLCollectionConfiguration*>*) fromCollections: (NSArray<CBLCollection*>*)collections
+                                                   config: (void (^)(CBLCollectionConfiguration* config))config;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/Tests/ReplicatorTest+Collection.m
+++ b/Objective-C/Tests/ReplicatorTest+Collection.m
@@ -19,6 +19,7 @@
 
 #import "ReplicatorTest.h"
 #import "CBLReplicator+Internal.h"
+#import "CBLCollectionConfiguration+Internal.h"
 
 @interface ReplicatorTest_Collection : ReplicatorTest
 

--- a/Swift/CollectionConfiguration.swift
+++ b/Swift/CollectionConfiguration.swift
@@ -68,30 +68,6 @@ public struct CollectionConfiguration {
         return collections.map { CollectionConfiguration(collection: $0) }
     }
     
-    /// Creates an array of `CollectionConfiguration` objects from the given collections with the same configuration closure.
-    ///
-    /// Each collection is wrapped in a `CollectionConfiguration`using default settings
-    /// (no filters and no custom conflict resolvers).
-    ///
-    /// This is a convenience method for configuring multiple collections with the same configuration.
-    /// If custom configurations are needed, construct `CollectionConfiguration` objects
-    /// directly instead.
-    ///
-    /// - Parameter collections: An array of `Collection` objects to configure for replication.
-    /// - Parameter config: A closure that takes a `CollectionConfiguration` object
-    /// - Returns: An array of `CollectionConfiguration` objects corresponding to the given collections.
-    /// Creates configurations from an array of collections with a configuration closure.
-    static func fromCollections(_ collections: [Collection], config: (CollectionConfiguration) -> Void) -> [CollectionConfiguration] {
-        Precondition.assertNotEmpty(collections, name: "collections")
-        return collections.map {
-            let colConfig = CollectionConfiguration(collection: $0)
-            config(colConfig)
-            return colConfig
-        }
-    }
-    
-    
-    
     // MARK: internal
     
     func toImpl() -> CBLCollectionConfiguration {

--- a/Swift/Tests/ReplicatorTest+Collection.swift
+++ b/Swift/Tests/ReplicatorTest+Collection.swift
@@ -52,20 +52,6 @@ class ReplicatorTest_Collection: ReplicatorTest {
         XCTAssertNil(colConfig!.pushFilter)
         XCTAssertNil(colConfig!.pullFilter)
     }
-    
-    func testCreateCollectionConfigsWithSameConfig() throws {
-        let url = URL(string: "wss://foo")!
-        let target = URLEndpoint(url: url)
-        
-        let col1a = try self.db.createCollection(name: "colA", scope: "scopeA")
-        let col1b = try self.db.createCollection(name: "colB", scope: "scopeA")
-        
-        var colConfigs = CollectionConfiguration.fromCollections([col1a, col1b], config: { c in
-            c.channels = ["test"]
-        })
-        
-        let config = self.config(collections: [col1a, col1b], target: target)
-    }
         
     // fatal error! can't be unit tested.
     func _testCollectionsFromDifferentDatabaseInstances() throws {

--- a/Swift/Tests/ReplicatorTest+Collection.swift
+++ b/Swift/Tests/ReplicatorTest+Collection.swift
@@ -53,6 +53,20 @@ class ReplicatorTest_Collection: ReplicatorTest {
         XCTAssertNil(colConfig!.pullFilter)
     }
     
+    func testCreateCollectionConfigsWithSameConfig() throws {
+        let url = URL(string: "wss://foo")!
+        let target = URLEndpoint(url: url)
+        
+        let col1a = try self.db.createCollection(name: "colA", scope: "scopeA")
+        let col1b = try self.db.createCollection(name: "colB", scope: "scopeA")
+        
+        var colConfigs = CollectionConfiguration.fromCollections([col1a, col1b], config: { c in
+            c.channels = ["test"]
+        })
+        
+        let config = self.config(collections: [col1a, col1b], target: target)
+    }
+        
     // fatal error! can't be unit tested.
     func _testCollectionsFromDifferentDatabaseInstances() throws {
         let col1a = try self.db.createCollection(name: "colA", scope: "scopeA")


### PR DESCRIPTION
- moved `[CBLCollectionConfig fromCollections: config:]` to internal
- removed the Swift equivalent because CollectionConfiguration is struct and the block cannot modify the config. I have not yet found a good solution without adding a Mutable option, which I don't really like.
- LiteCore 4.0.0-85