### PR TITLE
CBL-8156 : QueryResultDecoder failing to decode optional properties when using dataKey

### DIFF
--- a/Swift/QueryResultDecoder.swift
+++ b/Swift/QueryResultDecoder.swift
@@ -52,7 +52,11 @@ private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingConta
     init(queryResult: Result, dataKey: String? = nil) {
         self.queryResult = queryResult
         // The actual document may be in a nested dictionary, if `SELECT id, *` was used
-        self.nestedDict = dataKey != nil ? queryResult.dictionary(forKey: dataKey!) : nil
+        if let dataKey {
+            self.nestedDict = queryResult.dictionary(forKey: dataKey)
+        } else {
+            self.nestedDict = nil
+        }
     }
 
     var codingPath: [any CodingKey] = []
@@ -69,7 +73,7 @@ private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingConta
     
     func contains(_ key: Key) -> Bool {
         queryResult.contains(key: key.stringValue) ||
-            nestedDict?.value(forKey: key.stringValue) != nil
+            nestedDict?.contains(key: key.stringValue) == true
     }
     
     func decodeNil(forKey key: Key) throws -> Bool {

--- a/Swift/QueryResultDecoder.swift
+++ b/Swift/QueryResultDecoder.swift
@@ -47,24 +47,33 @@ internal struct QueryResultDecoder: Decoder {
 
 private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingContainerProtocol {
     let queryResult: Result
-    let nestedDocument: DictionaryObject?
+    let nestedDict: DictionaryObject?
     
     init(queryResult: Result, dataKey: String? = nil) {
         self.queryResult = queryResult
         // The actual document may be in a nested dictionary, if `SELECT id, *` was used
-        self.nestedDocument = dataKey != nil ? queryResult.dictionary(forKey: dataKey!) : nil
+        self.nestedDict = dataKey != nil ? queryResult.dictionary(forKey: dataKey!) : nil
     }
 
     var codingPath: [any CodingKey] = []
     
-    var allKeys: [Key] { queryResult.keys.compactMap { Key(stringValue: $0) } }
+    var allKeys: [Key] {
+        var keys = queryResult.keys
+        if let nested = nestedDict {
+            for key in nested.keys where !keys.contains(key) {
+                keys.append(key)
+            }
+        }
+        return keys.compactMap { Key(stringValue: $0) }
+    }
     
     func contains(_ key: Key) -> Bool {
-        queryResult.contains(key: key.stringValue)
+        queryResult.contains(key: key.stringValue) ||
+            nestedDict?.value(forKey: key.stringValue) != nil
     }
     
     func decodeNil(forKey key: Key) throws -> Bool {
-        if let value = queryResult.value(forKey: key.stringValue) ?? nestedDocument?.value(forKey: key.stringValue) {
+        if let value = queryResult.value(forKey: key.stringValue) ?? nestedDict?.value(forKey: key.stringValue) {
             if value is NSNull {
                 return true
             } else {
@@ -76,7 +85,7 @@ private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingConta
     
     func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
         guard let value = queryResult.value(forKey: key.stringValue)
-                ?? nestedDocument?.value(forKey: key.stringValue) else {
+                ?? nestedDict?.value(forKey: key.stringValue) else {
             throw CBLError.create(CBLErrorInvalidQuery, description: "Query is missing field '\(key.stringValue)'")
         }
         guard let fleeceValue = FleeceValue(value, as: T.self) else {
@@ -93,7 +102,7 @@ private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingConta
     
     func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
         guard let nestedValue = queryResult.value(forKey: key.stringValue)
-                ?? nestedDocument?.value(forKey: key.stringValue) else {
+                ?? nestedDict?.value(forKey: key.stringValue) else {
             throw CBLError.create(CBLErrorInvalidQuery, description: "Query is missing field '\(key.stringValue)'")
         }
         guard let nested = nestedValue as? DictionaryObject else {
@@ -105,7 +114,7 @@ private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingConta
     
     func nestedUnkeyedContainer(forKey key: Key) throws -> any UnkeyedDecodingContainer {
         guard let nestedValue = queryResult.value(forKey: key.stringValue)
-                ?? nestedDocument?.value(forKey: key.stringValue) else {
+                ?? nestedDict?.value(forKey: key.stringValue) else {
             throw CBLError.create(CBLErrorInvalidQuery, description: "Query is missing field '\(key.stringValue)'")
         }
         guard let nested = nestedValue as? ArrayObject else {
@@ -117,7 +126,7 @@ private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingConta
     
     func superDecoder() throws -> any Decoder {
         guard let nestedValue = queryResult.value(forKey: "super")
-                ?? nestedDocument?.value(forKey: "super") else {
+                ?? nestedDict?.value(forKey: "super") else {
             throw CBLError.create(CBLErrorInvalidQuery, description: "Query is missing field 'super'")
         }
         guard let nested = nestedValue as? DictionaryObject else {
@@ -129,7 +138,7 @@ private struct QueryResultDecodingContainer<Key: CodingKey> : KeyedDecodingConta
     
     func superDecoder(forKey key: Key) throws -> any Decoder {
         guard let nestedValue = queryResult.value(forKey: key.stringValue)
-                ?? nestedDocument?.value(forKey: key.stringValue) else {
+                ?? nestedDict?.value(forKey: key.stringValue) else {
             throw CBLError.create(CBLErrorInvalidQuery, description: "Query is missing field '\(key.stringValue)'")
         }
         guard let nested = nestedValue as? DictionaryObject else {

--- a/Swift/Tests/CodableTest.swift
+++ b/Swift/Tests/CodableTest.swift
@@ -547,6 +547,28 @@ class CodableTest: CBLTestCase {
         XCTAssert(profile == document)
     }
     
+    // (CBL-8156) Test that optional properties are correctly decoded when using dataKey
+    func testQueryResultDecodeWithDataKeyOptionalProperties() throws {
+        // 1. Save a Favourites object with some optional fields set and some nil
+        let favourites = Favourites(colour: "blue", animal: Animal(name: "Whale", legs: nil))
+        try defaultCollection!.save(from: favourites)
+        
+        // 2. Query with SELECT meta().id AS id, * (the dataKey pattern)
+        let query = try db.createQuery("SELECT meta().id AS id, * FROM _ LIMIT 1")
+        
+        // 3. Execute the query and decode with dataKey
+        let result = try query.execute().next()!
+        let decoded = try result.data(as: Favourites.self, dataKey: "_")
+        
+        // 4. Assert the decoded object matches the original
+        XCTAssertEqual(decoded.id, favourites.id)
+        XCTAssertEqual(decoded.colour, "blue")
+        XCTAssertNotNil(decoded.animal)
+        XCTAssertEqual(decoded.animal?.name, "Whale")
+        XCTAssertNil(decoded.animal?.legs)
+        XCTAssertEqual(decoded, favourites)
+    }
+    
     // 10. TestQueryResultSetDecode
     func testQueryResultSetDecode() throws {
         // 1. Save 'p-0001', 'p-0002', 'p-0003' from the dataset


### PR DESCRIPTION
* When using dataKey (e.g., SELECT meta().id, *), allKeys and contains() only checked the top-level query result, missing properties from the nested document dictionary. This caused optional properties to decode as nil instead of their actual values.

* Fix contains() to check both sources.

* Fix allKeys to merge keys from both the query result and nested dictionary.

* Rename nestedDocument variable to nestedDict for correctness.

* Add a test for decoding optional properties with dataKey.