### PR TITLE
CBL-8188 : Fix deadlock in CBLDatabase unregisterActiveService

### DIFF
--- a/Objective-C/CBLDatabase.mm
+++ b/Objective-C/CBLDatabase.mm
@@ -900,13 +900,17 @@ static C4DatabaseConfig2 c4DatabaseConfig2 (CBLDatabaseConfiguration *config) {
 }
 
 - (void) unregisterActiveService: (id<CBLDatabaseService>)service {
+    BOOL shouldSignal = NO;
     CBL_LOCK(_mutex) {
         [_activeServices removeObject: service];
-        if (_activeServices.count == 0) {
-            [_closeCondition lock];
-            [_closeCondition broadcast];
-            [_closeCondition unlock];
-        }
+        shouldSignal = (_activeServices.count == 0);
+    }
+    // Broadcast after releasing CBL_LOCK(_mutex) to keep lock order consistent
+    // with close() and avoid deadlocking on _mutex and _closeCondition.
+    if (shouldSignal) {
+        [_closeCondition lock];
+        [_closeCondition broadcast];
+        [_closeCondition unlock];
     }
 }
 


### PR DESCRIPTION
When close() waits for active services to stop, it holds _closeCondition and rechecks _activeServices under _mutex. unregisterActiveService() used to do the opposite: hold _mutex, then lock _closeCondition to broadcast. If an async service shutdown finished during close(), the two threads could deadlock on opposite locks.

This stayed latent because it requires a narrow timing window while closing with an active service that unregisters from another thread, so most shutdown paths never overlapped that way. This was discovered while running multipeer replicator tests.

Fix by removing the service under _mutex, recording whether the active set became empty, and broadcasting on _closeCondition only after releasing _mutex.