### PR TITLE
CBL-8192 : Update to fix build errors when using Xcode 26.4

### DIFF
--- a/Objective-C/CBLCollection.mm
+++ b/Objective-C/CBLCollection.mm
@@ -455,7 +455,7 @@ NSString* const kCBLDefaultCollectionName = @"_default";
         if (timestamp == 0) {
             return nil;
         }
-        return [NSDate dateWithTimeIntervalSince1970: (timestamp/msec)];
+        return [NSDate dateWithTimeIntervalSince1970: ((double)timestamp/msec)];
     }
 }
 

--- a/Objective-C/CBLEncoder.mm
+++ b/Objective-C/CBLEncoder.mm
@@ -126,7 +126,11 @@ using namespace fleece;
         _database = db;
         _error = nil;
         _hasAttachment = false;
-        _context = { .database = _database, .encodingError = &_error, .outHasAttachment = &_hasAttachment };
+        _context = {
+            .database = _database,
+            .outHasAttachment = &_hasAttachment,
+            .encodingError = &_error
+        };
     }
     return self;
 }

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -285,10 +285,10 @@ typedef enum {
             .collection = col.c4spec,
             .push = mkmode(isPush(_config.replicatorType), _config.continuous),
             .pull = mkmode(isPull(_config.replicatorType), _config.continuous),
+            .optionsDictFleece  = dict,
             .pushFilter = filter(colConfig.pushFilter, true),
             .pullFilter = filter(colConfig.pullFilter, false),
-            .callbackContext    = (__bridge void*)self,
-            .optionsDictFleece  = dict,
+            .callbackContext    = (__bridge void*)self
         };
         
         cols.push_back(c);

--- a/Objective-C/Internal/CBLJSON.mm
+++ b/Objective-C/Internal/CBLJSON.mm
@@ -96,7 +96,7 @@ static NSDateFormatter* getISO8601Formatter() {
     int64_t time = fleece::ParseISO8601Date(string.UTF8String);
     if (time == fleece::kInvalidDate)
         return NAN;
-    return time / 1000.0 + k1970ToReferenceDate;
+    return (double)time / 1000.0 + k1970ToReferenceDate;
 }
 
 + (NSDate*) dateWithJSONObject: (id)jsonObject {

--- a/Objective-C/Internal/CBLParseDate.c
+++ b/Objective-C/Internal/CBLParseDate.c
@@ -333,5 +333,5 @@ double CBLParseISO8601Date(const char* zDate) {
     if (parseYyyyMmDd(zDate,&x))
         return NAN;
     computeJD(&x);
-    return x.iJD/1000.0 - 210866760000.0;
+    return (double)x.iJD/1000.0 - 210866760000.0;
 }

--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -122,9 +122,9 @@ NSString * const kCBLWebSocketUseTLSServerAuthCallback = @"serverAuthCallback";
     return {
         .framing = kC4WebSocketClientFraming,
         .open = &doOpen,
-        .close = &doClose,
         .write = &doWrite,
         .completedReceive = &doCompletedReceive,
+        .close = &doClose,
         .dispose = &doDispose,
     };
 }

--- a/Objective-C/LogSink/CBLFileLogSink.mm
+++ b/Objective-C/LogSink/CBLFileLogSink.mm
@@ -75,10 +75,10 @@
         header = CBLStringBytes([CBLVersion userAgent], false);
         
         options = {
-            .base_path = directory,
             .log_level = (C4LogLevel)logSink.level,
-            .max_rotate_count = static_cast<int32_t>(logSink.maxKeptFiles - 1),
+            .base_path = directory,
             .max_size_bytes = static_cast<int64_t>(logSink.maxFileSize),
+            .max_rotate_count = static_cast<int32_t>(logSink.maxKeptFiles - 1),
             .use_plaintext = static_cast<bool>(logSink.usePlaintext),
             .header = header
         };


### PR DESCRIPTION
Fix build errors for the followings:

- Implicit conversion from string to ‘double' may lose precision

- ISO C++ requires field designators to be specified in declaration order

- Related PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/330