### PR TITLE
CBL-7979 : Add correlationID property to Replicator

### DIFF
--- a/Objective-C/CBLReplicator.h
+++ b/Objective-C/CBLReplicator.h
@@ -51,6 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
     for releasing the certificate object when the application code finishes using the certificate. */
 @property (readonly, copy, atomic, nullable) __attribute__((NSObject)) SecCertificateRef serverCertificate;
 
+/** The ID used to correlate the replication session with the remote endpoint.
+    This value is intended for logging and diagnostics, and is `nil` until
+    the replicator receives a correlation ID from the remote endpoint. */
+@property (readonly, copy, atomic, nullable) NSString* correlationID;
+
 /** Initializes a replicator with the given configuration. */
 - (instancetype) initWithConfig: (CBLReplicatorConfiguration*)config;
 

--- a/Objective-C/CBLReplicator.mm
+++ b/Objective-C/CBLReplicator.mm
@@ -450,6 +450,17 @@ static C4ReplicatorValidationFunction filter(CBLReplicationFilter filter, bool i
     }
 }
 
+#pragma mark - Correlation ID
+
+- (NSString*) correlationID {
+    CBL_LOCK(self) {
+        if (!_repl)
+            return nil;
+        NSString* result = sliceResult2string(c4repl_getCorrelationID(_repl));
+        return result.length > 0 ? result : nil;
+    }
+}
+
 #pragma mark - CHANGE NOTIFIERS:
 
 - (id<CBLListenerToken>) addChangeListener: (void (^)(CBLReplicatorChange*))listener {

--- a/Objective-C/Tests/ReplicatorTest+Main.m
+++ b/Objective-C/Tests/ReplicatorTest+Main.m
@@ -1580,4 +1580,35 @@
     [token1 remove];
 }
 
+#pragma mark - Correlation ID
+
+// Spec: https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0013-CorrelationID.md
+//
+// 1. TestGetCorrelationID
+//
+// Description:
+//   Test get the correlation id from the replicator.
+//   Note: Alternatively this test can be tested DatabaseEndpoint.
+//
+// Steps:
+//   1. Start a URLEndpointListener.
+//   2. Creates a replicator with an endpoint connecting the URLEndpointListener.
+//        - Continuous: No
+//        - Type: Push-and-Pull
+//   3. Gets the correlationID and checks that the value is null.
+//   4. Starts the replicator and wait until the replicator stopped.
+//   5. Gets the correlationID and checks that the value is not null or empty.
+- (void) testGetCorrelationID {
+    CBLReplicatorConfiguration* config = [self configWithTarget: _target
+                                                           type: kCBLReplicatorTypePushAndPull
+                                                     continuous: NO];
+
+    __block CBLReplicator* replicator;
+    [self run: config reset: NO errorCode: 0 errorDomain: nil onReplicatorReady: ^(CBLReplicator* r) {
+        replicator = r;
+        AssertNil(r.correlationID);
+    }];
+    Assert(replicator.correlationID.length > 0);
+}
+
 @end

--- a/Swift/Replicator.swift
+++ b/Swift/Replicator.swift
@@ -96,6 +96,14 @@ public final class Replicator {
     public var serverCertificate: SecCertificate? {
         return impl.serverCertificate
     }
+
+    /// The ID used to correlate the replication session with the remote endpoint.
+    ///
+    /// This value is intended for logging and diagnostics, and is `nil` until the
+    /// replicator receives a correlation ID from the remote endpoint.
+    public var correlationID: String? {
+        return impl.correlationID
+    }
     
     /// Starts the replicator. This method returns immediately; the replicator runs asynchronously
     /// and will report its progress through the replicator change notification.

--- a/Swift/Tests/ReplicatorTest.swift
+++ b/Swift/Tests/ReplicatorTest.swift
@@ -1333,6 +1333,45 @@ class ReplicatorTest_Main: ReplicatorTest {
         XCTAssertNil(config.collections.first?.pullFilter)
         XCTAssertNil(config.collections.first?.pushFilter)
     }
+    
+#if COUCHBASE_ENTERPRISE
+    
+    // MARK: Correlation ID
+
+    // Spec: https://github.com/couchbaselabs/couchbase-lite-api/blob/master/spec/tests/T0013-CorrelationID.md
+    //
+    // 1. TestGetCorrelationID
+    //
+    // Description:
+    //   Test get the correlation id from the replicator.
+    //   Note: Alternatively this test can be tested DatabaseEndpoint.
+    //
+    // Steps:
+    //   1. Start a URLEndpointListener.
+    //   2. Creates a replicator with an endpoint connecting the URLEndpointListener.
+    //        - Continuous: No
+    //        - Type: Push-and-Pull
+    //   3. Gets the correlationID and checks that the value is null.
+    //   4. Starts the replicator and wait until the replicator stopped.
+    //   5. Gets the correlationID and checks that the value is not null or empty.
+    func testGetCorrelationID() throws {
+        let target = DatabaseEndpoint(database: otherDB!)
+        let config = self.config(collections: [defaultCollection!],
+                                 target: target,
+                                 type: .pushAndPull,
+                                 continuous: false)
+
+        run(config: config, reset: false, expectedError: nil) { r in
+            XCTAssertNil(r.correlationID)
+        }
+
+        let corrID = repl.correlationID
+        XCTAssertNotNil(corrID)
+        XCTAssertFalse(corrID?.isEmpty ?? true)
+    }
+    
+#endif
+    
 }
 
 class TestConflictResolver: ConflictResolverProtocol {


### PR DESCRIPTION
- Added correlationID property in Replicator for both Objective-C and Swift. The correlation ID is used for correlating the replication session with the remote endpoint’s session, such as Sync Gateway.

- Added a test using DatabaseEndpoint, which is sufficient to test the API from the binding perspective.

- Updated LiteCore to pick up the API for getting the correlation ID. 

- Updated LiteCore to the latest on master branch (4ae661)