### PR TITLE
CBL-7469 Set kCFStreamSSLPeerName when using a network interface

### DIFF
--- a/Objective-C/Internal/Replicator/CBLWebSocket.mm
+++ b/Objective-C/Internal/Replicator/CBLWebSocket.mm
@@ -113,9 +113,9 @@ struct PendingWrite {
     return {
         .framing = kC4WebSocketClientFraming,
         .open = &doOpen,
-        .close = &doClose,
         .write = &doWrite,
         .completedReceive = &doCompletedReceive,
+        .close = &doClose,
         .dispose = &doDispose,
     };
 }
@@ -207,8 +207,10 @@ static void doDispose(C4Socket* s) {
         _queue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
         
         _sockfd = -1;
-        _networkInterface = _replicator.config.networkInterface;
-        if (_networkInterface) {
+        
+        NSString* inf = _replicator.config.networkInterface;
+        if (inf.length > 0) {
+            _networkInterface = inf;
             queueName = [NSString stringWithFormat: @"%@-SocketConnect", queueName];
             _socketConnectQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
         }
@@ -612,9 +614,15 @@ static inline NSError* posixError(int errNo, NSString* msg) {
     if (_logic.useTLS) {
         CBLLogVerbose(WebSocket, @"%@: Enabling TLS...", self);
         NSMutableDictionary* settings = [NSMutableDictionary dictionary];
-        if (_connectedThruProxy)
-            [settings setObject: _logic.directHost
-                         forKey: (__bridge id)kCFStreamSSLPeerName];
+        
+        // Set the actual hostname used for certificate verification during the TLS handshake
+        // when connecting through a proxy or a specified network interface. The hostname will
+        // appear in the Server Name Indication (SNI) field of the TLS ClientHello message.
+        if (_connectedThruProxy || _networkInterface) {
+            NSString* hostName = _logic.directHost;
+            CBLLogVerbose(WebSocket, @"%@: Setting TLS peer (SNI) hostname: %@", self, hostName);
+            [settings setObject: hostName forKey: (__bridge id)kCFStreamSSLPeerName];
+        }
         
         if (_options[kC4ReplicatorOptionPinnedServerCert])
             [settings setObject: @NO


### PR DESCRIPTION
* Port the fix from master branch (802d8ad7173a81d801a8b17db6cbe9a48103b990).

When a network interface is specified, CBLWebSocket resolves the hostname to an IP, creates the socket with that IP, and builds network streams from the socket. Because the original hostname isn’t set, the TLS ClientHello omits the Server Name Indication (SNI).

The fix is to set the hostname via kCFStreamSSLPeerName (the same way we did when client-side proxy is specified), ensuring SNI is included for certificate validation and compatibility with carriers/ISPs that block connections without it.

* Update order of socketFactory’s callbacks due to the warning in Xcode.