### PR TITLE
CBL-7229 : Document default collection used when creating ReplicatorConfiguration with a database

### DIFF
--- a/Objective-C/CBLReplicatorConfiguration.h
+++ b/Objective-C/CBLReplicatorConfiguration.h
@@ -210,6 +210,13 @@ __deprecated_msg(" Use [... initWithTarget:] and [config addCollection: config:]
  Initializes a CBLReplicatorConfiguration with the local database and
  the target endpoint.
  
+ When using this initializer, the default collection of the provided
+ database is automatically included in the configuration.
+
+ If you do not intend to replicate the default collection, use
+ initWithTarget: instead, and explicitly add the intended collections
+ to avoid unintended behavior.
+ 
  @param database The database.
  @param target The target endpoint.
  @return The CBLReplicatorConfiguration object.

--- a/Swift/ReplicatorConfiguration.swift
+++ b/Swift/ReplicatorConfiguration.swift
@@ -286,6 +286,13 @@ public struct ReplicatorConfiguration {
     /// Initializes a ReplicatorConfiguration's builder with the given
     /// local database and the replication target.
     ///
+    /// When using this initializer, the default collection of the provided
+    /// database is automatically included in the configuration.
+    ///
+    /// If you do not intend to replicate the default collection, use
+    /// `init(target:)` instead and explicitly add the intended collections
+    /// to avoid unintended behavior.
+    ///
     /// - Parameters:
     ///   - database: The local database.
     ///   - target: The replication target.
@@ -312,7 +319,7 @@ public struct ReplicatorConfiguration {
     /// configuration is specified, a default empty configuration will be applied.
     @discardableResult
     public mutating func addCollection(_ collection: Collection,
-                              config: CollectionConfiguration? = nil) -> ReplicatorConfiguration {
+                                       config: CollectionConfiguration? = nil) -> ReplicatorConfiguration {
         
         if !collection.impl.isValid {
             fatalError("Attempt to add an invalid collection.")


### PR DESCRIPTION
Add documentation to the database+target initializers in both Obj-C and Swift clarifying that the default collection is automatically included, and recommending `initWithTarget:`/`init(target:)` when replicating specific collections only.