### PR TITLE
CBL-8333 : Fix Fleece document leak when encoding a Codable model

### DIFF
--- a/Objective-C/CBLDocument.mm
+++ b/Objective-C/CBLDocument.mm
@@ -52,8 +52,6 @@ using namespace fleece;
         _revID = nil;
         
         [self setC4Doc: c4Doc];
-        
-        CBLLogVerbose(Database, @"%@ init doc", self.fullDescription);
     }
     return self;
 }
@@ -187,11 +185,6 @@ using namespace fleece;
     return [_dict toJSON];
 }
 
-- (void)setFleece:(FLDict)data {
-    _fleeceData = data;
-    [self updateDictionary];
-}
-
 #pragma mark - Internal
 
 - (C4Database*) c4db {
@@ -208,9 +201,17 @@ using namespace fleece;
 }
 
 - (void) updateDictionary {
+    [self updateDictionaryWithFleeceDoc: nullptr];
+}
+
+// `fleeceDoc`, if non-null, owns the bytes (and shared-keys Scope) backing _fleeceData;
+// the DocContext retains it so the data stays valid for the lifetime of the dictionary.
+- (void) updateDictionaryWithFleeceDoc: (FLDoc)fleeceDoc {
     if (_fleeceData) {
         CBLDatabase* db = _collection.database;
-        _root.reset(new MRoot<id>(new cbl::DocContext(db, _c4Doc), Dict(_fleeceData), self.isMutable));
+        // The body is backed by either `fleeceDoc` (encoder output) or `_c4Doc`, never both.
+        CBLC4Document* c4Doc = fleeceDoc ? nil : _c4Doc;
+        _root.reset(new MRoot<id>(new cbl::DocContext(db, c4Doc, fleeceDoc), Dict(_fleeceData), self.isMutable));
         [db safeBlock:^{
             self->_dict = self->_root->asNative();
         }];
@@ -220,6 +221,23 @@ using namespace fleece;
         _dict = self.isMutable ? (id)[[CBLNewDictionary alloc] init]
                                : [[CBLDictionary alloc] initEmpty];
     }
+}
+
+// Sets the document body from a Fleece doc produced by CBLEncoder. Returns NO if the
+// encoded root is not a dictionary. The DocContext built in -updateDictionaryWithFleeceDoc:
+// retains `doc`, keeping its bytes AND their shared-keys Scope alive for as long as the
+// dictionary uses them.
+- (BOOL) setFleeceDoc: (FLDoc)doc {
+    FLDict root = FLValue_AsDict(FLDoc_GetRoot(doc));
+    if (!root)
+        return NO;
+    // Serialize the body mutation like -setC4Doc: does, so it is safe even if the
+    // document is shared (don't rely on the caller passing an unshared document).
+    CBL_LOCK(self) {
+        _fleeceData = root;
+        [self updateDictionaryWithFleeceDoc: doc];
+    }
+    return YES;
 }
 
 - (CBLC4Document*) c4Doc {

--- a/Objective-C/CBLEncoder.mm
+++ b/Objective-C/CBLEncoder.mm
@@ -19,15 +19,12 @@
 
 #import "fleece/Fleece.hh"
 #import "CBLFleece.hh"
-#import "MRoot.hh"
 #import "CBLEncoder.h"
 #import "CBLCoreBridge.h"
 #import "CBLStatus.h"
 #import "CBLStringBytes.h"
 #import "CBLDatabase+Internal.h"
 #import "CBLDocument+Internal.h"
-
-using namespace fleece;
 
 @implementation CBLEncoder {
     FLEncoder _encoder;
@@ -77,17 +74,14 @@ using namespace fleece;
 
 - (BOOL)finishIntoDocument:(CBLDocument*)document error:(NSError**)outError {
     FLError error {};
-    FLDoc fldoc = FLEncoder_FinishDoc(_encoder, &error);
-    if (!fldoc) {
+    FLDoc doc = FLEncoder_FinishDoc(_encoder, &error);
+    if (!doc) {
         return convertError(error, outError);
     }
-    Doc doc { fldoc };
-    Dict fleeceData = doc.asDict();
-    if (!fleeceData) {
-        return NO;
-    }
-    [document setFleece: (FLDict)fleeceData];
-    return YES;
+    // setFleeceDoc: retains the doc so the doc can be released here.
+    BOOL ok = [document setFleeceDoc: doc];
+    FLDoc_Release(doc);
+    return ok;
 }
 
 - (void)reset {

--- a/Objective-C/Internal/CBLDocument+Internal.h
+++ b/Objective-C/Internal/CBLDocument+Internal.h
@@ -66,7 +66,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) FLDict fleeceData;
 
-- (void) setFleece: (FLDict)data;
+// Sets and retains the fleece document which owns the backing data.
+// Returns NO if the document's root value is not a dictionary.
+- (BOOL) setFleeceDoc: (FLDoc)doc;
 
 - (instancetype) initWithCollection: (nullable CBLCollection*)collection
                          documentID: (NSString*)documentID

--- a/Objective-C/Internal/CBLFleece.hh
+++ b/Objective-C/Internal/CBLFleece.hh
@@ -57,17 +57,24 @@ namespace cbl {
     // Doc Context
     class DocContext : public fleece::MContext {
     public:
-        DocContext(CBLDatabase *db, CBLC4Document* __nullable doc);
-        
+        /// Holds a document's Fleece body alive. The body has at most one owner that the
+        /// context retains: `doc` (the C4Document a loaded body was read from) or `fleeceDoc`
+        /// (the in-memory Fleece doc that produced the body, e.g. via CBLEncoder).
+        /// Both are nil when the body is kept alive elsewhere, e.g. the transient FLDict
+        /// passed to a replication filter, or a subclass that owns the backing (QueryResultContext).
+        DocContext(CBLDatabase *db, CBLC4Document* __nullable doc,
+                   FLDoc __nullable fleeceDoc = nullptr);
+
         CBLDatabase* database() const   {return _db;}
         CBLC4Document* __nullable document() const {return _doc;}
         NSMapTable* fleeceToNSStrings() const {return _fleeceToNSStrings;}
-        
+
         id toObject(fleece::Value);
-        
+
         private:
         CBLDatabase *_db;
         CBLC4Document* __nullable _doc;
+        fleece::Doc _fleeceDoc;
         NSMapTable* _fleeceToNSStrings;
     };
 }

--- a/Objective-C/Internal/CBLFleece.mm
+++ b/Objective-C/Internal/CBLFleece.mm
@@ -33,12 +33,16 @@
 @end
 
 namespace cbl {
-    DocContext::DocContext(CBLDatabase *db, CBLC4Document *doc)
+    DocContext::DocContext(CBLDatabase *db, CBLC4Document *doc, FLDoc fleeceDoc)
     :fleece::MContext(fleece::alloc_slice())
     ,_db(db)
     ,_doc(doc)
+    ,_fleeceDoc(fleeceDoc)      // fleece::Doc(FLDoc) retains; ~Doc releases
     ,_fleeceToNSStrings(FLCreateSharedStringsTable())
-    { }
+    {
+        Assert(!doc || !fleeceDoc,
+               @"A document body cannot be backed by both a C4Document and a Fleece doc");
+    }
     
     
     id DocContext::toObject(fleece::Value value) {


### PR DESCRIPTION
- Issue: `CBLEncoder.finishIntoDocument:` leaked the FLDoc returned by FLEncoder_FinishDoc. Its +1 reference was never released; the FLDoc was wrapped in a `fleece::Doc` that retained it again and released only that extra reference, leaking the FLDoc and its encoded body.

- Fix: Release that +1 and let the document's DocContext own the FLDoc, so the encoded fleece data stays valid for the lifetime of the document.

- Remove unnecessary logging from one of CBLDocument's initializers (probably leftover from development)