### PR TITLE
Update LiteCore to 4.1.0-84

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     options {
         disableConcurrentBuilds() 
     }
-    agent { label 'sonoma'  }
+    agent { label 'tahoe'  }
     stages {
         stage('Cleanup'){
             steps {

--- a/Objective-C/Internal/main.m
+++ b/Objective-C/Internal/main.m
@@ -28,8 +28,6 @@ static void initialize(void)
     {
         initialized = 1;
         
-        c4log_enableFatalExceptionBacktrace();
-        
 #ifdef DEBUG
         c4log_warnOnErrors(true);
 #endif

--- a/Objective-C/Tests/LogTest.m
+++ b/Objective-C/Tests/LogTest.m
@@ -282,9 +282,12 @@
     // Disable file logging
     CBLLogSinks.file = nil;
     [self writeAllLogs: inputString];
-    
+
+    // LiteCore log filenames are millisecond-resolution; sleep so re-enabled files get new
+    // names instead of truncating the first batch (otherwise < 8 files hold the message).
+    [NSThread sleepForTimeInterval: 0.1];
+
     // Re-enable file logging
-    
     CBLLogSinks.file = [[CBLFileLogSink alloc] initWithLevel: kCBLLogLevelVerbose
                                                    directory: logFileDirectory
                                                 usePlaintext: YES

--- a/Scripts/pull_request_build_test.sh
+++ b/Scripts/pull_request_build_test.sh
@@ -1,15 +1,100 @@
 #!/bin/bash -xe
-if [ "$1" = "-enterprise" ]
-  then
-    cd couchbase-lite-ios-ee/couchbase-lite-ios
-  else 
-    cd couchbase-lite-ios
+
+print_result_summary() {
+  local title="$1"
+  local result_bundle="$2"
+
+  set +x
+  echo ""
+  echo "===== ${title} result summary ====="
+
+  if [ ! -d "$result_bundle" ]; then
+    echo "Result bundle was not created: $result_bundle"
+    echo "===== End ${title} result summary ====="
+    echo ""
+    set -x
+    return
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    xcrun xcresulttool get test-results summary \
+      --path "$result_bundle" \
+      --compact |
+    jq -r '
+      def test_failures:
+        (.testFailures // [])
+        | if type == "array" then .[]
+          elif type == "object" and has("testName") then .
+          else empty
+          end;
+
+      "Result: \(.result // "unknown")",
+      "Tests: \(.totalTestCount // 0), failed: \(.failedTests // 0), skipped: \(.skippedTests // 0)",
+      "",
+      (
+        if ((.failedTests // 0) == 0) then
+          "No XCTest failures recorded."
+        else
+          "XCTest failures:",
+          (
+            test_failures
+            | "- \(.targetName // "UnknownTarget").\(.testName // "UnknownTest")\n  \(.failureText // "No failure text recorded.")"
+          )
+        end
+      )
+    ' || true
+
+  else
+    echo "jq is not available; printing raw xcresult summaries."
+    xcrun xcresulttool get test-results summary --path "$result_bundle" --compact || true
+  fi
+
+  echo "===== End ${title} result summary ====="
+  echo ""
+  set -x
+}
+
+run_xcodebuild_test() {
+  local title="$1"
+  local result_bundle="$2"
+  shift 2
+
+  rm -rf "$result_bundle"
+
+  set +e
+  xcodebuild test \
+    -project CouchbaseLite.xcodeproj \
+    -resultBundlePath "$result_bundle" \
+    "$@"
+  local status=$?
+  set -e
+
+  if [ "$status" -ne 0 ]; then
+    print_result_summary "$title" "$result_bundle"
+    exit "$status"
+  fi
+}
+
+if [ "$1" = "-enterprise" ]; then
+  cd couchbase-lite-ios-ee/couchbase-lite-ios
+else
+  cd couchbase-lite-ios
 fi
 
-# Minimum Matrix: 
-# - Run objective-C tests on macOS platform
+# Minimum Matrix:
 # - Run swift tests on iOS platform
-xcodebuild test -project CouchbaseLite.xcodeproj -scheme "CBL_EE_ObjC_Tests" -destination "platform=macOS"
-
+# - Run objective-C tests on macOS platform
 TEST_SIMULATOR=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | sed 's/Simulator//g' | awk '{$1=$1;print}')
-xcodebuild test -project CouchbaseLite.xcodeproj -scheme "CBL_EE_Swift_Tests_iOS_App" -sdk iphonesimulator -destination "platform=iOS Simulator,name=${TEST_SIMULATOR}"
+
+run_xcodebuild_test \
+  "Swift iOS XCTest" \
+  "$PWD/CBL_EE_Swift_Tests_iOS_App.xcresult" \
+  -scheme "CBL_EE_Swift_Tests_iOS_App" \
+  -sdk iphonesimulator \
+  -destination "platform=iOS Simulator,name=${TEST_SIMULATOR}"
+
+run_xcodebuild_test \
+  "ObjC macOS XCTest" \
+  "$PWD/CBL_EE_ObjC_Tests.xcresult" \
+  -scheme "CBL_EE_ObjC_Tests" \
+  -destination "platform=macOS"

--- a/Swift/Tests/LogSinkTest.swift
+++ b/Swift/Tests/LogSinkTest.swift
@@ -273,7 +273,11 @@ class LogSinkTest: CBLTestCase {
         // Disable file logging
         LogSinks.file = nil
         writeAllLogs(message)
-        
+
+        // LiteCore log filenames are millisecond-resolution; sleep so re-enabled files get new
+        // names instead of truncating the first batch (otherwise < 8 files hold the message).
+        Thread.sleep(forTimeInterval: 0.1)
+
         // Re-enable file logging
         LogSinks.file = FileLogSink(level: .verbose,
                                     directory: logFileDirectory,


### PR DESCRIPTION
* Update LiteCore to 4.1.0-84.
* Update agent to Jenkins to use Tahoe agents.
* Remove c4log_enableFatalExceptionBacktrace as it's no-ops now.
* Add delay in testReEnableFileLogSink to prevent rotated file name collision.
* Update pull request script to parse and show xcresult when swift test fails and re-order tests.
* Companion PR : https://github.com/couchbaselabs/couchbase-lite-ios-ee/pull/339