### PR TITLE
CBL-8727 : Fix use after free in the lazy vector index tests

### DIFF
--- a/Objective-C/Tests/VectorSearchTest+Lazy.m
+++ b/Objective-C/Tests/VectorSearchTest+Lazy.m
@@ -69,9 +69,11 @@
     NSArray<NSNumber*>* vector;
     CBLQueryResult *result = [rs nextObject];
     if (result) {
-        id value = [result arrayAtIndex: 0];
+        CBLArray* value = [result arrayAtIndex: 0];
         if (value) {
-            vector = (NSArray<NSNumber*>*)value;
+            // Copy the values out of the fleece-backed CBLArray, which is only
+            // valid while the result set is alive:
+            vector = (NSArray<NSNumber*>*)[value toArray];
         }
     }
     return vector;


### PR DESCRIPTION
Cherry-Picked directly from master branch (db1abd2b6fbae85c8fc75eacb589ac3a60f5f150)

vectorForWord: returned the CBLArray from a query result, cast to NSArray. That array is only valid while the result set is alive, so callers read freed memory once the enumeration ended. The result was an EXC_BAD_ACCESS crash inside -[CBLIndexUpdater setVector:atIndex:error:] and wrong vectors in the assertions. It only showed up when running against release builds. Copy the values out with -[CBLArray toArray] instead.