### PR TITLE
CBL-8740 : Remove CoreBluetooth.framework link

### DIFF
--- a/CouchbaseLite.xcodeproj/project.pbxproj
+++ b/CouchbaseLite.xcodeproj/project.pbxproj
@@ -385,8 +385,6 @@
 		406F8E002C27F0AB000223FC /* VectorSearchTest+Lazy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406F8DFC2C27F097000223FC /* VectorSearchTest+Lazy.swift */; };
 		40815F9A2F0F2279004D8590 /* CBLMultipeerTransportTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 40815F992F0F2279004D8590 /* CBLMultipeerTransportTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		40815F9B2F0F2279004D8590 /* CBLMultipeerTransportTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 40815F992F0F2279004D8590 /* CBLMultipeerTransportTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		40815FB42F1058C3004D8590 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40815FB32F1058C3004D8590 /* CoreBluetooth.framework */; };
-		40815FB52F1058CB004D8590 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40815FB32F1058C3004D8590 /* CoreBluetooth.framework */; };
 		409389E92D4AB81700691393 /* LogSinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409389E82D4AB81700691393 /* LogSinks.swift */; };
 		409389EA2D4AB81700691393 /* LogSinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409389E82D4AB81700691393 /* LogSinks.swift */; };
 		409389EC2D4AB8B500691393 /* ConsoleLogSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409389EB2D4AB8B500691393 /* ConsoleLogSink.swift */; };
@@ -2711,10 +2709,10 @@
 		40E46B122DD6A7B5007E495D /* CBLReplicatorStatus+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CBLReplicatorStatus+Internal.h"; sourceTree = "<group>"; };
 		40E46B172DD6A808007E495D /* CBLConflictResolverService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLConflictResolverService.h; sourceTree = "<group>"; };
 		40E46B182DD6A808007E495D /* CBLConflictResolverService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBLConflictResolverService.m; sourceTree = "<group>"; };
-		40E92C4C303E4282005C088C /* CBL_EE_Swift_Binary_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CouchbaseLiteSwiftBinaryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		40E92C4C303E4282005C088C /* CouchbaseLiteSwiftBinaryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CouchbaseLiteSwiftBinaryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		40E92C4D303E42FA005C088C /* CBL_EE_Swift_Binary_Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CBL_EE_Swift_Binary_Tests.xcconfig; sourceTree = "<group>"; };
 		40E92C70303E44E5005C088C /* CouchbaseLiteSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CouchbaseLiteSwift.xcframework; path = BinaryTests/Frameworks/CouchbaseLiteSwift.xcframework; sourceTree = "<group>"; };
-		40E92CA6303E45A3005C088C /* CBL_Swift_Binary_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CouchbaseLiteSwiftBinaryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		40E92CA6303E45A3005C088C /* CouchbaseLiteSwiftBinaryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CouchbaseLiteSwiftBinaryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		40E92CA7303E4635005C088C /* CBL_Swift_Binary_Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CBL_Swift_Binary_Tests.xcconfig; sourceTree = "<group>"; };
 		40ECAE852E0E08CC00C109A6 /* Precondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Precondition.swift; sourceTree = "<group>"; };
 		40ECAE882E0E0B0F00C109A6 /* CBLPrecondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBLPrecondition.h; sourceTree = "<group>"; };
@@ -3327,7 +3325,6 @@
 				9343EF8E207D611600F19A89 /* libz.tbd in Frameworks */,
 				9343EF8F207D611600F19A89 /* libLiteCore-static.a in Frameworks */,
 				939C5E68244FC7DE007CEBAC /* libLiteCoreWebSocket.a in Frameworks */,
-				40815FB42F1058C3004D8590 /* CoreBluetooth.framework in Frameworks */,
 				93A4F2452221058500257423 /* CoreImage.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3340,7 +3337,6 @@
 				9343F0B3207D61AB00F19A89 /* libLiteCore-static.a in Frameworks */,
 				93249D7B246B6EB0000A8A6E /* libLiteCoreWebSocket.a in Frameworks */,
 				9343F0B2207D61AB00F19A89 /* libz.tbd in Frameworks */,
-				40815FB52F1058CB004D8590 /* CoreBluetooth.framework in Frameworks */,
 				93A4F2462221059500257423 /* CoreImage.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4590,8 +4586,8 @@
 				40CC4B80302C2FF90002386D /* CouchbaseLiteBinaryTests.xctest */,
 				40CC4C4E3033CE540002386D /* CBL_Binary_Tests.app */,
 				40CC4D38303403F30002386D /* CouchbaseLiteBinaryTests.xctest */,
-				40E92C4C303E4282005C088C /* CBL_EE_Swift_Binary_Tests.xctest */,
-				40E92CA6303E45A3005C088C /* CBL_Swift_Binary_Tests.xctest */,
+				40E92C4C303E4282005C088C /* CouchbaseLiteSwiftBinaryTests.xctest */,
+				40E92CA6303E45A3005C088C /* CouchbaseLiteSwiftBinaryTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -5924,7 +5920,7 @@
 			packageProductDependencies = (
 			);
 			productName = CouchbaseLiteSwiftBinaryTests;
-			productReference = 40E92C4C303E4282005C088C /* CBL_EE_Swift_Binary_Tests.xctest */;
+			productReference = 40E92C4C303E4282005C088C /* CouchbaseLiteSwiftBinaryTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		40E92C76303E45A3005C088C /* CBL_Swift_Binary_Tests */ = {
@@ -5945,7 +5941,7 @@
 			packageProductDependencies = (
 			);
 			productName = CouchbaseLiteSwiftBinaryTests;
-			productReference = 40E92CA6303E45A3005C088C /* CBL_Swift_Binary_Tests.xctest */;
+			productReference = 40E92CA6303E45A3005C088C /* CouchbaseLiteSwiftBinaryTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		930B63CF246B9CD1006D94FF /* CBL_EE_Swift_Tests_iOS_App */ = {


### PR DESCRIPTION
- Remove CoreBluetooth.framework link as the apps will need to link the the frameworks by themselves when using the MultipeerReplicator with the Bluetooth LE transport.

- Plus: XCode auto corrected a mismatched filename comments in the project file so that should be committed as well.

- Bump LiteCore to latest master.